### PR TITLE
Add context tracer and samplers

### DIFF
--- a/trace/opencensus/trace/samplers/__init__.py
+++ b/trace/opencensus/trace/samplers/__init__.py
@@ -1,0 +1,22 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from opencensus.trace.samplers.always_off import AlwaysOffSampler
+from opencensus.trace.samplers.always_on import AlwaysOnSampler
+from opencensus.trace.samplers.base import Sampler
+from opencensus.trace.samplers.fixed_rate import FixedRateSampler
+
+
+__all__ = ['Sampler', 'AlwaysOnSampler', 'AlwaysOffSampler',
+           'FixedRateSampler']

--- a/trace/opencensus/trace/samplers/always_off.py
+++ b/trace/opencensus/trace/samplers/always_off.py
@@ -1,0 +1,23 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from opencensus.trace.samplers.base import Sampler
+
+
+class AlwaysOffSampler(Sampler):
+
+    @property
+    def should_sample(self):
+        """Always return False because we don't want to sample."""
+        return False

--- a/trace/opencensus/trace/samplers/always_on.py
+++ b/trace/opencensus/trace/samplers/always_on.py
@@ -1,0 +1,23 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from opencensus.trace.samplers.base import Sampler
+
+
+class AlwaysOnSampler(Sampler):
+
+    @property
+    def should_sample(self):
+        """Always return True because we want to sampler all requests."""
+        return True

--- a/trace/opencensus/trace/samplers/base.py
+++ b/trace/opencensus/trace/samplers/base.py
@@ -1,0 +1,27 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module containing base class for samplers."""
+
+
+class Sampler(object):
+    """Base class for opencensus trace request samplers.
+
+    Subclasses of :class:`Sampler` must override :meth:`should_sample`.
+    """
+
+    @property
+    def should_sample(self):
+        """Determine whether to sample this request or not."""
+        raise NotImplementedError

--- a/trace/opencensus/trace/samplers/fixed_rate.py
+++ b/trace/opencensus/trace/samplers/fixed_rate.py
@@ -1,0 +1,39 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import random
+
+from opencensus.trace.samplers.base import Sampler
+
+
+class FixedRateSampler(Sampler):
+    """Sample a request at a fixed rate.
+
+    :type rate: float
+    :param rate: The rate of sampling.
+    """
+    def __init__(self, rate):
+        if rate > 1 or rate < 0:
+            raise ValueError('Rate must between 0 and 1.')
+
+        self.rate = rate
+
+    @property
+    def should_sample(self):
+        random_number = random.uniform(0, 1)
+
+        if random_number <= self.rate:
+            return True
+        else:
+            return False

--- a/trace/opencensus/trace/span_context.py
+++ b/trace/opencensus/trace/span_context.py
@@ -16,7 +16,6 @@
 
 import logging
 import re
-import sys
 
 from opencensus.trace import trace
 

--- a/trace/opencensus/trace/trace_span.py
+++ b/trace/opencensus/trace/trace_span.py
@@ -61,6 +61,14 @@ class TraceSpan(object):
 
     :type span_id: int
     :param span_id: Identifier for the span, unique within a trace.
+
+    :type context_tracer: :class:`~opencensus.trace.tracer.context_tracer.
+                                 ContextTracer`
+    :param context_tracer: The tracer that holds a stack of spans. If this is
+                           not None, then when exiting a span, use the end_span
+                           method in the tracer class to finish a span. If no
+                           tracer is passed in, then just finish the span using
+                           the finish method in the Span class.
     """
 
     def __init__(
@@ -71,7 +79,8 @@ class TraceSpan(object):
             labels={},
             start_time=None,
             end_time=None,
-            span_id=None):
+            span_id=None,
+            context_tracer=None):
         self.name = name
         self.kind = kind
         self.parent_span_id = parent_span_id
@@ -84,6 +93,7 @@ class TraceSpan(object):
 
         self.span_id = span_id
         self._child_spans = []
+        self.context_tracer = context_tracer
 
     @property
     def children(self):
@@ -136,6 +146,10 @@ class TraceSpan(object):
 
     def __exit__(self, exception_type, exception_value, traceback):
         """Finish a span."""
+        if self.context_tracer is not None:
+            self.context_tracer.end_span()
+            return
+
         self.finish()
 
 

--- a/trace/opencensus/trace/tracer/__init__.py
+++ b/trace/opencensus/trace/tracer/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/trace/opencensus/trace/tracer/context_tracer.py
+++ b/trace/opencensus/trace/tracer/context_tracer.py
@@ -1,0 +1,156 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from opencensus.trace.trace import Trace
+from opencensus.trace.span_context import SpanContext
+from opencensus.trace.trace_span import TraceSpan
+from opencensus.trace.samplers.always_on import AlwaysOnSampler
+
+
+class ContextTracer(object):
+    """The interface for tracing a request context.
+
+    :type span_context: :class:`~opencensus.trace.span_context.SpanContext`
+    :param span_context: SpanContext encapsulates the current context within
+                         the request's trace.
+
+    :type sampler: :class:`type`
+    :param sampler: Class for creating new Sampler objects. It should extend
+                    from the base :class:`.Sampler` type and implement
+                    :meth:`.Sampler.should_sample`. Defaults to
+                    :class:`.AlwaysOnSampler`. The rest options are
+                    :class:`.AlwaysOffSampler`, :class:`.FixedRateSampler`.
+    """
+    def __init__(
+            self,
+            span_context=None,
+            sampler=None):
+        if span_context is None:
+            span_context = SpanContext()
+
+        if sampler is None:
+            sampler = AlwaysOnSampler()
+
+        self.span_context = span_context
+        self.sampler = sampler
+        self.trace_id = span_context.trace_id
+        self.enabled = self.set_enabled()
+        self.cur_trace = self.trace()
+        self._span_stack = []
+        self.root_span_id = span_context.span_id
+
+    def set_enabled(self):
+        """Determine whether to sample this request or not.
+        If the context forces not tracing, just set enabled to False.
+        Else follow the sampler.
+
+        :rtype: bool
+        :returns: Whether to trace the request or not.
+        """
+        if self.span_context.enabled is False:
+            return False
+        elif self.sampler.should_sample is True:
+            return True
+        else:
+            return False
+
+    def trace(self):
+        """Create a trace using the context information.
+
+        :rtype: :class:`~opencensus.trace.trace.Trace`
+        :returns: The Trace object.
+        """
+        if self.enabled is True:
+            return Trace(trace_id=self.trace_id)
+        else:
+            return NullObject()
+
+    def start_trace(self):
+        """Start a trace."""
+        if self.enabled is False:
+            return
+
+        self.cur_trace.start()
+
+    def end_trace(self):
+        """End a trace."""
+        if self.enabled is False:
+            return
+
+        # Send the traces when finish
+        self.cur_trace.finish()
+
+    def span(self, name='span'):
+        """Create a new span with the trace using the context information.
+
+        :type name: str
+        :param name: The name of the span.
+
+        :rtype: :class:`~opencensus.trace.trace_span.TraceSpan`
+        :returns: The TraceSpan object.
+        """
+        if self.enabled is True:
+            parent_span_id = self.span_context.span_id
+            span = TraceSpan(name, parent_span_id=parent_span_id)
+            self.cur_trace.spans.append(span)
+            self._span_stack.append(span)
+            self.span_context.span_id = span.span_id
+            return span
+        else:
+            return NullObject()
+
+    def start_span(self, name='span'):
+        """Start a span."""
+        if self.enabled is False:
+            return
+
+        span = self.span(name=name)
+        span.start()
+
+    def end_span(self):
+        """End a span. Remove the span from the span stack, and update the
+        span_id in TraceContext as the current span_id which is the peek
+        element in the span stack.
+        """
+        if self.enabled is False:
+            return
+
+        try:
+            cur_span = self._span_stack.pop()
+        except IndexError:
+            logging.error('No span is active, cannot end any span.')
+            raise
+
+        cur_span.finish()
+
+        if not self._span_stack:
+            self.span_context.span_id = self.root_span_id
+        else:
+            self.span_context.span_id = self._span_stack[-1].span_id
+
+    def list_collected_spans(self):
+        return self.cur_trace.spans
+
+
+class NullObject(object):
+    """Empty object as a helper for faking Trace and TraceSpan when tracing is
+    disabled.
+    """
+    def __enter__(self):
+        pass  # pragma: NO COVER
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass  # pragma: NO COVER

--- a/trace/tests/unit/samplers/test_always_off.py
+++ b/trace/tests/unit/samplers/test_always_off.py
@@ -1,0 +1,25 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+class TestAlwaysOffSampler(unittest.TestCase):
+
+    def test_should_sample(self):
+        from opencensus.trace.samplers import always_off
+
+        sampler = always_off.AlwaysOffSampler()
+        should_sample = sampler.should_sample
+
+        self.assertFalse(should_sample)

--- a/trace/tests/unit/samplers/test_always_on.py
+++ b/trace/tests/unit/samplers/test_always_on.py
@@ -1,0 +1,25 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+class TestAlwaysOnSampler(unittest.TestCase):
+
+    def test_should_sample(self):
+        from opencensus.trace.samplers import always_on
+
+        sampler = always_on.AlwaysOnSampler()
+        should_sample = sampler.should_sample
+
+        self.assertTrue(should_sample)

--- a/trace/tests/unit/samplers/test_base.py
+++ b/trace/tests/unit/samplers/test_base.py
@@ -1,0 +1,25 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+class TestBaseSampler(unittest.TestCase):
+
+    def test_should_sampler_id_abstract(self):
+        from opencensus.trace.samplers import base
+
+        sampler = base.Sampler()
+
+        with self.assertRaises(NotImplementedError):
+            sampler.should_sample()

--- a/trace/tests/unit/samplers/test_fixed_rate.py
+++ b/trace/tests/unit/samplers/test_fixed_rate.py
@@ -1,0 +1,47 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+class TestFixedRateSampler(unittest.TestCase):
+
+    def test_constructor_invalid(self):
+        from opencensus.trace.samplers import fixed_rate
+
+        with self.assertRaises(ValueError):
+            fixed_rate.FixedRateSampler(rate=2)
+
+    def test_constructor_valid(self):
+        from opencensus.trace.samplers import fixed_rate
+
+        rate = 0.5
+        sampler = fixed_rate.FixedRateSampler(rate=rate)
+
+        self.assertEqual(sampler.rate, rate)
+
+    def test_should_sample_smaller(self):
+        from opencensus.trace.samplers import fixed_rate
+
+        sampler = fixed_rate.FixedRateSampler(rate=1)
+        should_sample = sampler.should_sample
+
+        self.assertTrue(should_sample)
+
+    def test_should_sample_greater(self):
+        from opencensus.trace.samplers import fixed_rate
+
+        sampler = fixed_rate.FixedRateSampler(rate=0)
+        should_sample = sampler.should_sample
+
+        self.assertFalse(should_sample)

--- a/trace/tests/unit/samplers/test_fixed_rate.py
+++ b/trace/tests/unit/samplers/test_fixed_rate.py
@@ -14,33 +14,28 @@
 
 import unittest
 
+from opencensus.trace.samplers import fixed_rate
+
+
 class TestFixedRateSampler(unittest.TestCase):
 
     def test_constructor_invalid(self):
-        from opencensus.trace.samplers import fixed_rate
-
         with self.assertRaises(ValueError):
             fixed_rate.FixedRateSampler(rate=2)
 
     def test_constructor_valid(self):
-        from opencensus.trace.samplers import fixed_rate
-
         rate = 0.5
         sampler = fixed_rate.FixedRateSampler(rate=rate)
 
         self.assertEqual(sampler.rate, rate)
 
     def test_should_sample_smaller(self):
-        from opencensus.trace.samplers import fixed_rate
-
         sampler = fixed_rate.FixedRateSampler(rate=1)
         should_sample = sampler.should_sample
 
         self.assertTrue(should_sample)
 
     def test_should_sample_greater(self):
-        from opencensus.trace.samplers import fixed_rate
-
         sampler = fixed_rate.FixedRateSampler(rate=0)
         should_sample = sampler.should_sample
 

--- a/trace/tests/unit/tracer/test_context_tracer.py
+++ b/trace/tests/unit/tracer/test_context_tracer.py
@@ -16,6 +16,8 @@ import unittest
 
 import mock
 
+from opencensus.trace.tracer import context_tracer
+
 
 class TestContextTracer(unittest.TestCase):
 
@@ -24,7 +26,6 @@ class TestContextTracer(unittest.TestCase):
         from opencensus.trace import trace
         from opencensus.trace.reporters import print_reporter
         from opencensus.trace.samplers import always_on
-        from opencensus.trace.tracer import context_tracer
 
         tracer = context_tracer.ContextTracer()
 
@@ -40,7 +41,6 @@ class TestContextTracer(unittest.TestCase):
         from opencensus.trace import span_context
         from opencensus.trace.reporters import print_reporter
         from opencensus.trace.samplers import fixed_rate
-        from opencensus.trace.tracer import context_tracer
 
         reporter = print_reporter.PrintReporter()
         span_context = span_context.SpanContext()
@@ -60,39 +60,34 @@ class TestContextTracer(unittest.TestCase):
         assert isinstance(tracer.cur_trace, context_tracer.NullObject)
 
     def test_set_enabled_force_not_trace(self):
-        from opencensus.trace.tracer import context_tracer
         from opencensus.trace import span_context
 
         span_context = span_context.SpanContext(enabled=False)
-        context_tracer = context_tracer.ContextTracer(
+        tracer = context_tracer.ContextTracer(
             span_context=span_context)
-        enabled = context_tracer.set_enabled()
+        enabled = tracer.set_enabled()
 
         self.assertFalse(enabled)
 
     def test_set_enabled_should_sample(self):
-        from opencensus.trace.tracer import context_tracer
         from opencensus.trace.samplers import always_on
 
         sampler = always_on.AlwaysOnSampler()
-        context_tracer = context_tracer.ContextTracer(sampler=sampler)
-        enabled = context_tracer.set_enabled()
+        tracer = context_tracer.ContextTracer(sampler=sampler)
+        enabled = tracer.set_enabled()
 
         self.assertTrue(enabled)
 
     def test_set_enabled_should_not_sample(self):
-        from opencensus.trace.tracer import context_tracer
         from opencensus.trace.samplers import always_off
 
         sampler = always_off.AlwaysOffSampler()
-        context_tracer = context_tracer.ContextTracer(sampler=sampler)
-        enabled = context_tracer.set_enabled()
+        tracer = context_tracer.ContextTracer(sampler=sampler)
+        enabled = tracer.set_enabled()
 
         self.assertFalse(enabled)
 
     def test_trace_not_enabled(self):
-        from opencensus.trace.tracer import context_tracer
-
         tracer = context_tracer.ContextTracer()
         tracer.enabled = False
         cur_trace = tracer.trace()
@@ -101,7 +96,6 @@ class TestContextTracer(unittest.TestCase):
 
     def test_trace_enabled(self):
         from opencensus.trace import trace
-        from opencensus.trace.tracer import context_tracer
 
         tracer = context_tracer.ContextTracer()
         cur_trace = tracer.trace()
@@ -110,8 +104,6 @@ class TestContextTracer(unittest.TestCase):
         assert isinstance(cur_trace, trace.Trace)
 
     def test_start_trace_not_enabled(self):
-        from opencensus.trace.tracer import context_tracer
-
         tracer = context_tracer.ContextTracer()
         cur_trace = mock.Mock()
         tracer.enabled = False
@@ -121,8 +113,6 @@ class TestContextTracer(unittest.TestCase):
         self.assertFalse(cur_trace.start.called)
 
     def test_start_trace_enabled(self):
-        from opencensus.trace.tracer import context_tracer
-
         tracer = context_tracer.ContextTracer()
         cur_trace = mock.Mock()
         tracer.cur_trace = cur_trace
@@ -131,8 +121,6 @@ class TestContextTracer(unittest.TestCase):
         self.assertTrue(cur_trace.start.called)
 
     def test_end_trace_not_enabled(self):
-        from opencensus.trace.tracer import context_tracer
-
         tracer = context_tracer.ContextTracer()
         cur_trace = mock.Mock()
         tracer.enabled = False
@@ -142,8 +130,6 @@ class TestContextTracer(unittest.TestCase):
         self.assertFalse(cur_trace.finish.called)
 
     def test_end_trace_enabled(self):
-        from opencensus.trace.tracer import context_tracer
-
         tracer = context_tracer.ContextTracer()
         cur_trace = mock.Mock()
         tracer.cur_trace = cur_trace
@@ -152,8 +138,6 @@ class TestContextTracer(unittest.TestCase):
         self.assertTrue(cur_trace.finish.called)
 
     def test_span_not_enabled(self):
-        from opencensus.trace.tracer import context_tracer
-
         tracer = context_tracer.ContextTracer()
         tracer.enabled = False
 
@@ -162,7 +146,6 @@ class TestContextTracer(unittest.TestCase):
 
     def test_span_enabled(self):
         from opencensus.trace import span_context
-        from opencensus.trace.tracer import context_tracer
 
         span_id = 1234
         span_name = 'test_span'
@@ -178,8 +161,6 @@ class TestContextTracer(unittest.TestCase):
         self.assertEqual(span_context.span_id, span.span_id)
 
     def test_start_span_not_enabled(self):
-        from opencensus.trace.tracer import context_tracer
-
         tracer = context_tracer.ContextTracer()
         tracer.enabled = False
 
@@ -189,8 +170,6 @@ class TestContextTracer(unittest.TestCase):
         self.assertEqual(len(tracer.cur_trace.spans), 0)
 
     def test_start_span_enabled(self):
-        from opencensus.trace.tracer import context_tracer
-
         tracer = context_tracer.ContextTracer()
         tracer.start_span()
 
@@ -198,8 +177,6 @@ class TestContextTracer(unittest.TestCase):
         self.assertEqual(len(tracer.cur_trace.spans), 1)
 
     def test_end_span_not_enabled(self):
-        from opencensus.trace.tracer import context_tracer
-
         tracer = context_tracer.ContextTracer()
         tracer.enabled = False
         span = mock.Mock()
@@ -209,16 +186,12 @@ class TestContextTracer(unittest.TestCase):
         self.assertFalse(span.finish.called)
 
     def test_end_span_enabled_index_error(self):
-        from opencensus.trace.tracer import context_tracer
-
         tracer = context_tracer.ContextTracer()
 
         with self.assertRaises(IndexError):
             tracer.end_span()
 
     def test_end_span_enabled_empty_span_stack(self):
-        from opencensus.trace.tracer import context_tracer
-
         tracer = context_tracer.ContextTracer()
         span = mock.Mock()
         tracer._span_stack.append(span)
@@ -228,8 +201,6 @@ class TestContextTracer(unittest.TestCase):
         self.assertTrue(span.finish.called)
 
     def test_end_span_enabled_span_stack_not_empty(self):
-        from opencensus.trace.tracer import context_tracer
-
         tracer = context_tracer.ContextTracer()
         span1 = mock.Mock()
         span2 = mock.Mock()
@@ -244,8 +215,6 @@ class TestContextTracer(unittest.TestCase):
         self.assertTrue(span2.finish.called)
 
     def test_list_collected_spans(self):
-        from opencensus.trace.tracer import context_tracer
-
         tracer = context_tracer.ContextTracer()
         span1 = mock.Mock()
         span2 = mock.Mock()

--- a/trace/tests/unit/tracer/test_context_tracer.py
+++ b/trace/tests/unit/tracer/test_context_tracer.py
@@ -1,0 +1,251 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import mock
+
+
+class TestContextTracer(unittest.TestCase):
+
+    def test_constructor_defaults(self):
+        from opencensus.trace import span_context
+        from opencensus.trace import trace
+        from opencensus.trace.samplers import always_on
+        from opencensus.trace.tracer import context_tracer
+
+        tracer = context_tracer.ContextTracer()
+
+        assert isinstance(tracer.span_context, span_context.SpanContext)
+        assert isinstance(tracer.sampler, always_on.AlwaysOnSampler)
+        assert isinstance(tracer.cur_trace, trace.Trace)
+        self.assertTrue(tracer.enabled)
+        self.assertEqual(tracer._span_stack, [])
+        self.assertEqual(tracer.root_span_id, tracer.span_context.span_id)
+
+    def test_constructor_explicit(self):
+        from opencensus.trace import span_context
+        from opencensus.trace.samplers import fixed_rate
+        from opencensus.trace.tracer import context_tracer
+
+        span_context = span_context.SpanContext()
+        sampler = fixed_rate.FixedRateSampler(rate=0)
+        tracer = context_tracer.ContextTracer(
+            span_context=span_context,
+            sampler=sampler)
+
+        self.assertIs(tracer.span_context, span_context)
+        self.assertIs(tracer.sampler, sampler)
+        self.assertEqual(tracer.trace_id, span_context.trace_id)
+        self.assertFalse(tracer.enabled)
+        self.assertEqual(tracer._span_stack, [])
+        self.assertEqual(tracer.root_span_id, span_context.span_id)
+        assert isinstance(tracer.cur_trace, context_tracer.NullObject)
+
+    def test_set_enabled_force_not_trace(self):
+        from opencensus.trace.tracer import context_tracer
+        from opencensus.trace import span_context
+
+        span_context = span_context.SpanContext(enabled=False)
+        context_tracer = context_tracer.ContextTracer(
+            span_context=span_context)
+        enabled = context_tracer.set_enabled()
+
+        self.assertFalse(enabled)
+
+    def test_set_enabled_should_sample(self):
+        from opencensus.trace.tracer import context_tracer
+        from opencensus.trace.samplers import always_on
+
+        sampler = always_on.AlwaysOnSampler()
+        context_tracer = context_tracer.ContextTracer(sampler=sampler)
+        enabled = context_tracer.set_enabled()
+
+        self.assertTrue(enabled)
+
+    def test_set_enabled_should_not_sample(self):
+        from opencensus.trace.tracer import context_tracer
+        from opencensus.trace.samplers import always_off
+
+        sampler = always_off.AlwaysOffSampler()
+        context_tracer = context_tracer.ContextTracer(sampler=sampler)
+        enabled = context_tracer.set_enabled()
+
+        self.assertFalse(enabled)
+
+    def test_trace_not_enabled(self):
+        from opencensus.trace.tracer import context_tracer
+
+        tracer = context_tracer.ContextTracer()
+        tracer.enabled = False
+        cur_trace = tracer.trace()
+
+        assert isinstance(cur_trace, context_tracer.NullObject)
+
+    def test_trace_enabled(self):
+        from opencensus.trace import trace
+        from opencensus.trace.tracer import context_tracer
+
+        tracer = context_tracer.ContextTracer()
+        cur_trace = tracer.trace()
+
+        self.assertEqual(cur_trace.trace_id, tracer.trace_id)
+        assert isinstance(cur_trace, trace.Trace)
+
+    def test_start_trace_not_enabled(self):
+        from opencensus.trace.tracer import context_tracer
+
+        tracer = context_tracer.ContextTracer()
+        cur_trace = mock.Mock()
+        tracer.enabled = False
+        tracer.cur_trace = cur_trace
+
+        tracer.start_trace()
+        self.assertFalse(cur_trace.start.called)
+
+    def test_start_trace_enabled(self):
+        from opencensus.trace.tracer import context_tracer
+
+        tracer = context_tracer.ContextTracer()
+        cur_trace = mock.Mock()
+        tracer.cur_trace = cur_trace
+
+        tracer.start_trace()
+        self.assertTrue(cur_trace.start.called)
+
+    def test_end_trace_not_enabled(self):
+        from opencensus.trace.tracer import context_tracer
+
+        tracer = context_tracer.ContextTracer()
+        cur_trace = mock.Mock()
+        tracer.enabled = False
+        tracer.cur_trace = cur_trace
+
+        tracer.end_trace()
+        self.assertFalse(cur_trace.finish.called)
+
+    def test_end_trace_enabled(self):
+        from opencensus.trace.tracer import context_tracer
+
+        tracer = context_tracer.ContextTracer()
+        cur_trace = mock.Mock()
+        tracer.cur_trace = cur_trace
+
+        tracer.end_trace()
+        self.assertTrue(cur_trace.finish.called)
+
+    def test_span_not_enabled(self):
+        from opencensus.trace.tracer import context_tracer
+
+        tracer = context_tracer.ContextTracer()
+        tracer.enabled = False
+
+        span = tracer.span()
+        assert isinstance(span, context_tracer.NullObject)
+
+    def test_span_enabled(self):
+        from opencensus.trace import span_context
+        from opencensus.trace.tracer import context_tracer
+
+        span_id = 1234
+        span_name = 'test_span'
+        span_context = span_context.SpanContext(span_id=span_id)
+        tracer = context_tracer.ContextTracer(span_context=span_context)
+
+        span = tracer.span(name=span_name)
+
+        self.assertEqual(span.parent_span_id, span_id)
+        self.assertEqual(span.name, span_name)
+        self.assertEqual(len(tracer.cur_trace.spans), 1)
+        self.assertEqual(len(tracer._span_stack), 1)
+        self.assertEqual(span_context.span_id, span.span_id)
+
+    def test_start_span_not_enabled(self):
+        from opencensus.trace.tracer import context_tracer
+
+        tracer = context_tracer.ContextTracer()
+        tracer.enabled = False
+
+        tracer.start_span()
+
+        self.assertEqual(len(tracer._span_stack), 0)
+        self.assertEqual(len(tracer.cur_trace.spans), 0)
+
+    def test_start_span_enabled(self):
+        from opencensus.trace.tracer import context_tracer
+
+        tracer = context_tracer.ContextTracer()
+        tracer.start_span()
+
+        self.assertEqual(len(tracer._span_stack), 1)
+        self.assertEqual(len(tracer.cur_trace.spans), 1)
+
+    def test_end_span_not_enabled(self):
+        from opencensus.trace.tracer import context_tracer
+
+        tracer = context_tracer.ContextTracer()
+        tracer.enabled = False
+        span = mock.Mock()
+        tracer._span_stack.append(span)
+        tracer.end_span()
+
+        self.assertFalse(span.finish.called)
+
+    def test_end_span_enabled_index_error(self):
+        from opencensus.trace.tracer import context_tracer
+
+        tracer = context_tracer.ContextTracer()
+
+        with self.assertRaises(IndexError):
+            tracer.end_span()
+
+    def test_end_span_enabled_empty_span_stack(self):
+        from opencensus.trace.tracer import context_tracer
+
+        tracer = context_tracer.ContextTracer()
+        span = mock.Mock()
+        tracer._span_stack.append(span)
+        tracer.end_span()
+
+        self.assertEqual(tracer.span_context.span_id, tracer.root_span_id)
+        self.assertTrue(span.finish.called)
+
+    def test_end_span_enabled_span_stack_not_empty(self):
+        from opencensus.trace.tracer import context_tracer
+
+        tracer = context_tracer.ContextTracer()
+        span1 = mock.Mock()
+        span2 = mock.Mock()
+        tracer._span_stack.append(span1)
+        tracer._span_stack.append(span2)
+        tracer.end_span()
+
+        self.assertEqual(
+            tracer.span_context.span_id,
+            tracer._span_stack[-1].span_id)
+        self.assertEqual(tracer.span_context.span_id, span1.span_id)
+        self.assertTrue(span2.finish.called)
+
+    def test_list_collected_spans(self):
+        from opencensus.trace.tracer import context_tracer
+
+        tracer = context_tracer.ContextTracer()
+        span1 = mock.Mock()
+        span2 = mock.Mock()
+        tracer.cur_trace.spans.append(span1)
+        tracer.cur_trace.spans.append(span2)
+
+        spans = tracer.list_collected_spans()
+
+        self.assertEqual(spans, [span1, span2])

--- a/trace/tests/unit/tracer/test_context_tracer.py
+++ b/trace/tests/unit/tracer/test_context_tracer.py
@@ -22,11 +22,13 @@ class TestContextTracer(unittest.TestCase):
     def test_constructor_defaults(self):
         from opencensus.trace import span_context
         from opencensus.trace import trace
+        from opencensus.trace.reporters import print_reporter
         from opencensus.trace.samplers import always_on
         from opencensus.trace.tracer import context_tracer
 
         tracer = context_tracer.ContextTracer()
 
+        assert isinstance(tracer.reporter, print_reporter.PrintReporter)
         assert isinstance(tracer.span_context, span_context.SpanContext)
         assert isinstance(tracer.sampler, always_on.AlwaysOnSampler)
         assert isinstance(tracer.cur_trace, trace.Trace)
@@ -36,15 +38,19 @@ class TestContextTracer(unittest.TestCase):
 
     def test_constructor_explicit(self):
         from opencensus.trace import span_context
+        from opencensus.trace.reporters import print_reporter
         from opencensus.trace.samplers import fixed_rate
         from opencensus.trace.tracer import context_tracer
 
+        reporter = print_reporter.PrintReporter()
         span_context = span_context.SpanContext()
         sampler = fixed_rate.FixedRateSampler(rate=0)
         tracer = context_tracer.ContextTracer(
+            reporter=reporter,
             span_context=span_context,
             sampler=sampler)
 
+        self.assertIs(tracer.reporter, reporter)
         self.assertIs(tracer.span_context, span_context)
         self.assertIs(tracer.sampler, sampler)
         self.assertEqual(tracer.trace_id, span_context.trace_id)


### PR DESCRIPTION
This part is also mostly reviewed in google-cloud-python repository. Usage as below:

```
import time
from opencensus.trace.tracer import context_tracer
from opencensus.trace.samplers import always_on
from opencensus.trace.reporters import print_reporter

sampler = always_on.AlwaysOnSampler()
reporter = print_reporter.PrintReporter()
tracer = context_tracer.ContextTracer(sampler=sampler, reporter=reporter)
tracer.start_trace()

with tracer.span('span1') as span1:
    time.sleep(1)
    print(span1.name)
    with tracer.span('span1_child') as span1_child:
        time.sleep(1)
        print(span1_child.name)

tracer.end_trace()
```