### PR TITLE
Add decorator to trace a function

### DIFF
--- a/trace/opencensus/trace/tracer/context_tracer.py
+++ b/trace/opencensus/trace/tracer/context_tracer.py
@@ -78,6 +78,21 @@ class ContextTracer(object):
         else:
             return False
 
+    def trace_decorator(self):
+        """Decorator to trace a function."""
+
+        def decorator(func):
+
+            def wrapper(*args, **kwargs):
+                self.start_span(name=func.__name__)
+                return_value = func(*args, **kwargs)
+                self.end_span()
+                return return_value
+
+            return wrapper
+
+        return decorator
+
     def trace(self):
         """Create a trace using the context information.
 

--- a/trace/tests/unit/tracer/test_context_tracer.py
+++ b/trace/tests/unit/tracer/test_context_tracer.py
@@ -87,6 +87,21 @@ class TestContextTracer(unittest.TestCase):
 
         self.assertFalse(enabled)
 
+    def test_trace_decorator(self):
+        tracer = context_tracer.ContextTracer()
+
+        return_value = "test"
+
+        @tracer.trace_decorator()
+        def test_decorator():
+            return return_value
+
+        returned = test_decorator()
+
+        self.assertEqual(len(tracer.cur_trace.spans), 1)
+        self.assertEqual(tracer.cur_trace.spans[0].name, 'test_decorator')
+        self.assertEqual(returned, return_value)
+
     def test_trace_not_enabled(self):
         tracer = context_tracer.ContextTracer()
         tracer.enabled = False


### PR DESCRIPTION
Usage as below:

```
from opencensus.trace.tracer.context_tracer import ContextTracer
tracer = ContextTracer()

@tracer.trace_decorator()
def hello(a):
    print(a)

hello()

>>> tracer.cur_trace.spans
[<opencensus.trace.trace_span.TraceSpan object at 0x7fad81d42160>]
>>> tracer.cur_trace.spans[0].name
'hello'
```