### PR TITLE
Move the send traces method to ContextTracer

### DIFF
--- a/trace/opencensus/trace/reporters/file_reporter.py
+++ b/trace/opencensus/trace/reporters/file_reporter.py
@@ -27,8 +27,7 @@ class FileReporter(object):
         self.file_name = file_name
 
     def report(self, traces):
-        """Report the traces by printing it out.
-
+        """
         :type traces: dict
         :param traces: Traces collected.
         """

--- a/trace/opencensus/trace/reporters/logging_reporter.py
+++ b/trace/opencensus/trace/reporters/logging_reporter.py
@@ -53,4 +53,8 @@ class LoggingReporter(object):
         self.logger.setLevel(logging.INFO)
 
     def report(self, traces):
+        """
+        :type traces: dict
+        :param traces: Traces collected.
+        """
         self.logger.info(traces)

--- a/trace/opencensus/trace/trace.py
+++ b/trace/opencensus/trace/trace.py
@@ -16,7 +16,6 @@
 
 import uuid
 
-from opencensus.trace.reporters import file_reporter
 from opencensus.trace import trace_span
 
 
@@ -37,17 +36,12 @@ class Trace(object):
     :param trace_id: (Optional) Trace_id is a 32 hex-digits uuid for the trace.
                      If not given, will generate one automatically.
     """
-    def __init__(self, project_id=None, trace_id=None, reporter=None):
+    def __init__(self, project_id=None, trace_id=None):
         if trace_id is None:
             trace_id = generate_trace_id()
 
-        if reporter is None:
-            file_name = '{}_{}'.format(project_id, trace_id)
-            reporter = file_reporter.FileReporter(file_name=file_name)
-
         self.project_id = project_id
         self.trace_id = trace_id
-        self.reporter = reporter
         self.spans = []
 
     def __enter__(self):
@@ -62,8 +56,7 @@ class Trace(object):
         self.spans = []
 
     def finish(self):
-        """Send the trace to Stackdriver Trace API and clear the spans."""
-        self.send()
+        """Clear the spans."""
         self.spans = []
 
     def span(self, name='span'):
@@ -78,35 +71,6 @@ class Trace(object):
         span = trace_span.TraceSpan(name)
         self.spans.append(span)
         return span
-
-    def send(self):
-        """API call: Patch trace to Stackdriver Trace.
-
-        See
-        https://cloud.google.com/trace/docs/reference/v1/rpc/google.devtools.
-        cloudtrace.v1#google.devtools.cloudtrace.v1.TraceService.PatchTraces
-        """
-        spans_list = []
-        for root_span in self.spans:
-            span_tree = list(iter(root_span))
-            span_tree_json = [trace_span.format_span_json(span)
-                              for span in span_tree]
-            spans_list.extend(span_tree_json)
-
-        if len(spans_list) == 0:
-            return
-
-        trace = {
-            'projectId': self.project_id,
-            'traceId': self.trace_id,
-            'spans': spans_list,
-        }
-
-        traces = {
-            'traces': [trace],
-        }
-
-        self.reporter.report(traces)
 
 
 def generate_trace_id():

--- a/trace/opencensus/trace/tracer/context_tracer.py
+++ b/trace/opencensus/trace/tracer/context_tracer.py
@@ -18,7 +18,7 @@ from opencensus.trace.reporters import print_reporter
 from opencensus.trace.samplers.always_on import AlwaysOnSampler
 from opencensus.trace.span_context import SpanContext
 from opencensus.trace.trace import Trace
-from opencensus.trace.trace_span import TraceSpan
+from opencensus.trace import trace_span
 
 
 class ContextTracer(object):
@@ -100,7 +100,7 @@ class ContextTracer(object):
         :returns: The Trace object.
         """
         if self.enabled is True:
-            return Trace(trace_id=self.trace_id, reporter=self.reporter)
+            return Trace(trace_id=self.trace_id)
         else:
             return NullObject()
 
@@ -117,6 +117,11 @@ class ContextTracer(object):
             return
 
         # Send the traces when finish
+        traces = self.get_traces_json()
+
+        if traces is not None:
+            self.reporter.report(traces)
+
         self.cur_trace.finish()
 
     def span(self, name='span'):
@@ -145,7 +150,7 @@ class ContextTracer(object):
         """
         if self.enabled is True:
             parent_span_id = self.span_context.span_id
-            span = TraceSpan(
+            span = trace_span.TraceSpan(
                 name,
                 parent_span_id=parent_span_id,
                 context_tracer=self)
@@ -180,6 +185,42 @@ class ContextTracer(object):
 
     def list_collected_spans(self):
         return self.cur_trace.spans
+
+    def add_label_to_spans(self, label_key, label_value):
+        """Add label to the spans in current trace.
+
+        :type label_key: str
+        :param label_key: Label key.
+
+        :type label_value:str
+        :param label_value: Label value.
+        """
+        for span in self.cur_trace.spans:
+            span.add_label(label_key, label_value)
+
+    def get_traces_json(self):
+        """Get the JSON format traces."""
+        spans_list = []
+        for root_span in self.cur_trace.spans:
+            span_tree = list(iter(root_span))
+            span_tree_json = [trace_span.format_span_json(span)
+                              for span in span_tree]
+            spans_list.extend(span_tree_json)
+
+        if len(spans_list) == 0:
+            return
+
+        trace = {
+            'projectId': self.cur_trace.project_id,
+            'traceId': self.cur_trace.trace_id,
+            'spans': spans_list,
+        }
+
+        traces = {
+            'traces': [trace],
+        }
+
+        return traces
 
 
 class NullObject(object):

--- a/trace/tests/unit/test_trace.py
+++ b/trace/tests/unit/test_trace.py
@@ -44,16 +44,13 @@ class TestTrace(unittest.TestCase):
 
     def test_constructor_explicit(self):
         trace_id = 'test_trace_id'
-        reporter = mock.Mock()
 
         trace = self._make_one(
             project_id=self.project,
-            trace_id=trace_id,
-            reporter=reporter)
+            trace_id=trace_id)
 
         self.assertEqual(trace.project_id, self.project)
         self.assertEqual(trace.trace_id, trace_id)
-        self.assertIs(trace.reporter, reporter)
 
     def test_start(self):
         trace = self._make_one(project_id=self.project)
@@ -61,12 +58,11 @@ class TestTrace(unittest.TestCase):
 
         self.assertEqual(trace.spans, [])
 
-    def test_finish_with_valid_span(self):
+    def test_finish(self):
         from opencensus.trace.enums import Enum
         from opencensus.trace.trace_span import TraceSpan
 
-        reporter = mock.Mock()
-        trace = self._make_one(reporter=reporter)
+        trace = self._make_one()
 
         span_name = 'span'
         span_id = 123
@@ -105,104 +101,3 @@ class TestTrace(unittest.TestCase):
         result_span = trace.spans[0]
         self.assertIsInstance(result_span, TraceSpan)
         self.assertEqual(result_span.name, span_name)
-
-    def test_send_without_spans(self):
-        trace_id = 'test_trace_id'
-        reporter = mock.Mock()
-        trace = self._make_one(
-            project_id=self.project,
-            trace_id=trace_id,
-            reporter=reporter)
-        trace.spans = []
-
-        trace.send()
-
-        self.assertFalse(reporter.called)
-        self.assertEqual(trace.project_id, self.project)
-        self.assertEqual(trace.trace_id, trace_id)
-        self.assertEqual(trace.spans, [])
-
-    def test_send_with_spans(self):
-        from opencensus.trace.enums import Enum
-        from opencensus.trace.trace_span import TraceSpan
-
-        trace_id = 'test_trace_id'
-        reporter = mock.Mock()
-        trace = self._make_one(
-            project_id=self.project,
-            trace_id=trace_id,
-            reporter=reporter)
-        child_span_name = 'child_span'
-        root_span_name = 'root_span'
-        child_span_id = 123
-        root_span_id = 456
-        kind = Enum.SpanKind.SPAN_KIND_UNSPECIFIED
-        start_time = '2017-06-25'
-        end_time = '2017-06-26'
-        labels = {
-            '/http/status_code': '200',
-            '/component': 'HTTP load balancer',
-        }
-
-        child_span = mock.Mock(spec=TraceSpan)
-        child_span.name = child_span_name
-        child_span.kind = kind
-        child_span.parent_span_id = root_span_id
-        child_span.span_id = child_span_id
-        child_span.start_time = start_time
-        child_span.end_time = end_time
-        child_span.labels = labels
-        child_span.children = []
-        child_span.__iter__ = mock.Mock(return_value=iter([child_span]))
-
-        root_span = mock.Mock(spec=TraceSpan)
-        root_span.name = root_span_name
-        root_span.kind = kind
-        root_span.parent_span_id = None
-        root_span.span_id = root_span_id
-        root_span.start_time = start_time
-        root_span.end_time = end_time
-        root_span.labels = None
-        root_span.children = []
-        root_span.__iter__ = mock.Mock(
-            return_value=iter([root_span, child_span]))
-
-        child_span_json = {
-            'name': child_span.name,
-            'kind': kind,
-            'parentSpanId': root_span_id,
-            'spanId': child_span_id,
-            'startTime': start_time,
-            'endTime': end_time,
-            'labels': labels,
-        }
-
-        root_span_json = {
-            'name': root_span.name,
-            'kind': kind,
-            'spanId': root_span_id,
-            'startTime': start_time,
-            'endTime': end_time,
-        }
-
-        trace.spans = [root_span]
-        traces = {
-            'traces': [
-                {
-                    'projectId': self.project,
-                    'traceId': trace_id,
-                    'spans': [
-                        root_span_json,
-                        child_span_json
-                    ]
-                }
-            ]
-        }
-
-        trace.send()
-
-        reporter.report.assert_called_with(traces)
-
-        self.assertEqual(trace.project_id, self.project)
-        self.assertEqual(trace.trace_id, trace_id)
-        self.assertEqual(trace.spans, [root_span])


### PR DESCRIPTION
It's better to directly report traces in tracer instead of passing the reporter to Trace object and then send traces.