### PR TITLE
[MySQL] Set the wrapped methods as the object attributes

### DIFF
--- a/trace/opencensus/trace/ext/mysql/trace.py
+++ b/trace/opencensus/trace/ext/mysql/trace.py
@@ -41,10 +41,22 @@ def wrap_conn(conn_func):
     def call(*args, **kwargs):
         try:
             conn = conn_func(*args, **kwargs)
-            cursor_func = getattr(conn, CURSOR_WRAP_METHOD)
+            conn_dict = conn.__dict__
+            TracedConn = type(
+                'TracedConn',
+                (conn.__class__,),
+                {})
+            traced_conn = TracedConn()
+
+            traced_conn.__dict__ = dict(
+                list(traced_conn.__dict__.items()) +
+                list(conn_dict.items()))
+
+            cursor_func = getattr(traced_conn, CURSOR_WRAP_METHOD)
             wrapped = wrap_cursor(cursor_func)
-            setattr(conn.__class__, cursor_func.__name__, wrapped)
-            return conn
+            setattr(traced_conn.__class__, cursor_func.__name__, wrapped)
+
+            return traced_conn
         except Exception:  # pragma: NO COVER
             log.warning('Fail to wrap conn, mysql not traced.')
             return conn_func(*args, **kwargs)
@@ -55,11 +67,23 @@ def wrap_cursor(cursor_func):
     def call(*args, **kwargs):
         try:
             cursor = cursor_func(*args, **kwargs)
+            cursor_dict = cursor.__dict__
+            TracedCursor = type(
+                'TracedCursor',
+                (cursor.__class__,),
+                {})
+            traced_cursor = TracedCursor()
+
+            traced_cursor.__dict__ = dict(
+                list(traced_cursor.__dict__.items()) +
+                list(cursor_dict.items()))
+
             for func in QUERY_WRAP_METHODS:
-                query_func = getattr(cursor, func)
+                query_func = getattr(traced_cursor, func)
                 wrapped = trace_cursor_query(query_func)
-                setattr(cursor.__class__, query_func.__name__, wrapped)
-            return cursor
+                setattr(traced_cursor.__class__, query_func.__name__, wrapped)
+
+            return traced_cursor
         except Exception:  # pragma: NO COVER
             log.warning('Fail to wrap cursor, mysql not traced.')
             return cursor_func(*args, **kwargs)

--- a/trace/tests/unit/ext/flask/app/main.py
+++ b/trace/tests/unit/ext/flask/app/main.py
@@ -57,6 +57,9 @@ def mysql_query():
         for item in cursor:
             result.append(item)
 
+        cursor.close()
+        conn.close()
+
         return str(result)
 
     except Exception:
@@ -81,6 +84,9 @@ def postgresql_query():
 
         for item in cursor.fetchall():
             result.append(item)
+
+        cursor.close()
+        conn.close()
 
         return str(result)
 

--- a/trace/tests/unit/ext/mysql/test_mysql_trace.py
+++ b/trace/tests/unit/ext/mysql/test_mysql_trace.py
@@ -68,7 +68,7 @@ class Test_mysql_trace(unittest.TestCase):
 
         self.assertEqual(wrapped.__class__.__name__, 'function')
         self.assertEqual(
-            getattr(mock_return.__class__, cursor_func_name, None),
+            getattr(mock_return, cursor_func_name, None),
             wrap_func_name)
 
     def test_wrap_cursor(self):
@@ -98,7 +98,7 @@ class Test_mysql_trace(unittest.TestCase):
 
         for func in trace.QUERY_WRAP_METHODS:
             self.assertEqual(
-                getattr(mock_return.__class__, func, None),
+                getattr(mock_return, func, None),
                 wrap_func_name + func)
 
     def test_trace_cursor_query(self):


### PR DESCRIPTION
The wrapped cursor will fail when creating multiple connection objects. Changed to set the wrapped methods as the object attributes instead of the class attributes.