### PR TITLE
Make tracer params configurable in django middleware

### DIFF
--- a/trace/opencensus/trace/ext/django/config.py
+++ b/trace/opencensus/trace/ext/django/config.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import importlib
+import logging
 
 from django.conf import settings as django_settings
 
@@ -23,7 +24,16 @@ DEFAULT_DJANGO_TRACER_CONFIG = {
                   'GoogleCloudFormatPropagator',
 }
 
+DEFAULT_DJANGO_TRACER_PARAMS = {
+    'SAMPLING_RATE': 0.5,
+    'GCP_REPORTER_PROJECT': 'my_project',
+    'ZIPKIN_REPORTER_SERVICE_NAME': 'my_service',
+}
+
+
 PATH_DELIMITER = '.'
+
+log = logging.getLogger(__name__)
 
 
 class DjangoTraceSettings(object):
@@ -38,6 +48,11 @@ class DjangoTraceSettings(object):
             django_settings,
             'OPENCENSUS_TRACE',
             DEFAULT_DJANGO_TRACER_CONFIG)
+
+        self.params = getattr(
+            django_settings,
+            'OPENCENSUS_TRACE_PARAMS',
+            DEFAULT_DJANGO_TRACER_PARAMS)
 
     def __getattr__(self, attr):
         # If not in defaults, it is something we cannot parse.
@@ -57,9 +72,15 @@ def convert_to_import(path):
     class to import.
     """
     # Split the path string to module name and class name
-    module_name, class_name = path.rsplit(PATH_DELIMITER, 1)
-    module = importlib.import_module(module_name)
-    return getattr(module, class_name)
+    try:
+        module_name, class_name = path.rsplit(PATH_DELIMITER, 1)
+        module = importlib.import_module(module_name)
+        return getattr(module, class_name)
+    except (ImportError, AttributeError):
+        msg = 'Failed to import {}'.format(path)
+        log.error(msg)
+
+        raise ImportError(msg)
 
 
 settings = DjangoTraceSettings()

--- a/trace/opencensus/trace/ext/django/config.py
+++ b/trace/opencensus/trace/ext/django/config.py
@@ -20,7 +20,7 @@ from django.conf import settings as django_settings
 DEFAULT_DJANGO_TRACER_CONFIG = {
     'SAMPLER': 'opencensus.trace.samplers.always_on.AlwaysOnSampler',
     'REPORTER':
-        'opencensus.trace.reporters.google_cloud_reporter.GoogleCloudReporter',
+        'opencensus.trace.reporters.print_reporter.PrintReporter',
     'PROPAGATOR': 'opencensus.trace.propagation.google_cloud_format.'
                   'GoogleCloudFormatPropagator',
 }

--- a/trace/opencensus/trace/ext/django/config.py
+++ b/trace/opencensus/trace/ext/django/config.py
@@ -19,15 +19,18 @@ from django.conf import settings as django_settings
 
 DEFAULT_DJANGO_TRACER_CONFIG = {
     'SAMPLER': 'opencensus.trace.samplers.always_on.AlwaysOnSampler',
-    'REPORTER': 'opencensus.trace.reporters.print_reporter.PrintReporter',
+    'REPORTER':
+        'opencensus.trace.reporters.google_cloud_reporter.GoogleCloudReporter',
     'PROPAGATOR': 'opencensus.trace.propagation.google_cloud_format.'
                   'GoogleCloudFormatPropagator',
 }
 
 DEFAULT_DJANGO_TRACER_PARAMS = {
     'SAMPLING_RATE': 0.5,
-    'GCP_REPORTER_PROJECT': 'my_project',
+    'GCP_REPORTER_PROJECT': None,
     'ZIPKIN_REPORTER_SERVICE_NAME': 'my_service',
+    'ZIPKIN_REPORTER_HOST_NAME': 'localhost',
+    'ZIPKIN_REPORTER_PORT': 9411,
 }
 
 

--- a/trace/tests/unit/ext/django/app/settings.py
+++ b/trace/tests/unit/ext/django/app/settings.py
@@ -72,6 +72,10 @@ OPENCENSUS_TRACE = {
                   'GoogleCloudFormatPropagator',
 }
 
+OPENCENSUS_TRACE_PARAMS = {
+    'SAMPLING_RATE': 0.5,
+}
+
 # Internationalization
 # https://docs.djangoproject.com/en/1.8/topics/i18n/
 

--- a/trace/tests/unit/ext/django/test_middleware.py
+++ b/trace/tests/unit/ext/django/test_middleware.py
@@ -35,19 +35,123 @@ class TestOpencensusMiddleware(unittest.TestCase):
 
         teardown_test_environment()
 
-    def test_constructor(self):
+    def test_constructor_default(self):
         from opencensus.trace.ext.django import middleware
         from opencensus.trace.samplers import always_on
-        from opencensus.trace.reporters import print_reporter
+        from opencensus.trace.reporters import google_cloud_reporter
         from opencensus.trace.propagation import google_cloud_format
 
-        middleware = middleware.OpencensusMiddleware()
+        project_id = 'my_project'
+        params = {
+            'GCP_REPORTER_PROJECT': project_id,
+        }
+
+        patch = mock.patch(
+            'opencensus.trace.ext.django.config.settings.params', params)
+
+        with patch:
+            middleware = middleware.OpencensusMiddleware()
 
         self.assertIs(middleware._sampler, always_on.AlwaysOnSampler)
-        self.assertIs(middleware._reporter, print_reporter.PrintReporter)
+        self.assertIs(
+            middleware._reporter, google_cloud_reporter.GoogleCloudReporter)
         self.assertIs(
             middleware._propagator,
             google_cloud_format.GoogleCloudFormatPropagator)
+
+        assert isinstance(middleware.sampler, always_on.AlwaysOnSampler)
+        assert isinstance(
+            middleware.reporter, google_cloud_reporter.GoogleCloudReporter)
+        assert isinstance(
+            middleware.propagator,
+            google_cloud_format.GoogleCloudFormatPropagator)
+
+        self.assertEqual(middleware.reporter.project_id, project_id)
+
+    def test_constructor_zipkin(self):
+        from opencensus.trace.ext.django import middleware
+        from opencensus.trace.samplers import always_on
+        from opencensus.trace.reporters import zipkin_reporter
+        from opencensus.trace.propagation import google_cloud_format
+
+        service_name = 'test_service'
+        host_name = 'test_hostname'
+        port = 2333
+        params = {
+            'ZIPKIN_REPORTER_SERVICE_NAME': service_name,
+            'ZIPKIN_REPORTER_HOST_NAME': host_name,
+            'ZIPKIN_REPORTER_PORT': port,
+        }
+
+        patch_zipkin = mock.patch(
+            'opencensus.trace.ext.django.config.settings.REPORTER',
+            zipkin_reporter.ZipkinReporter)
+
+        patch_params = mock.patch(
+            'opencensus.trace.ext.django.config.settings.params',
+            params)
+
+        with patch_zipkin, patch_params:
+            middleware = middleware.OpencensusMiddleware()
+
+        self.assertIs(middleware._sampler, always_on.AlwaysOnSampler)
+        self.assertIs(
+            middleware._reporter, zipkin_reporter.ZipkinReporter)
+        self.assertIs(
+            middleware._propagator,
+            google_cloud_format.GoogleCloudFormatPropagator)
+
+        assert isinstance(middleware.sampler, always_on.AlwaysOnSampler)
+        assert isinstance(
+            middleware.reporter, zipkin_reporter.ZipkinReporter)
+        assert isinstance(
+            middleware.propagator,
+            google_cloud_format.GoogleCloudFormatPropagator)
+
+        self.assertEqual(middleware.reporter.service_name, service_name)
+        self.assertEqual(middleware.reporter.host_name, host_name)
+        self.assertEqual(middleware.reporter.port, port)
+
+    def test_constructor_fixed_rate_sampler(self):
+        from opencensus.trace.ext.django import middleware
+        from opencensus.trace.samplers import fixed_rate
+        from opencensus.trace.reporters import print_reporter
+        from opencensus.trace.propagation import google_cloud_format
+
+        rate = 0.8
+        params = {
+            'SAMPLING_RATE': 0.8,
+        }
+
+        patch_sampler = mock.patch(
+            'opencensus.trace.ext.django.config.settings.SAMPLER',
+            fixed_rate.FixedRateSampler)
+        patch_reporter = mock.patch(
+            'opencensus.trace.ext.django.config.settings.REPORTER',
+            print_reporter.PrintReporter)
+
+        patch_params = mock.patch(
+            'opencensus.trace.ext.django.config.settings.params',
+            params)
+
+        with patch_sampler, patch_reporter, patch_params:
+            middleware = middleware.OpencensusMiddleware()
+
+        self.assertIs(middleware._sampler, fixed_rate.FixedRateSampler)
+        self.assertIs(
+            middleware._reporter, print_reporter.PrintReporter)
+        self.assertIs(
+            middleware._propagator,
+            google_cloud_format.GoogleCloudFormatPropagator)
+
+        assert isinstance(middleware.sampler, fixed_rate.FixedRateSampler)
+        assert isinstance(
+            middleware.reporter, print_reporter.PrintReporter)
+        assert isinstance(
+            middleware.propagator,
+            google_cloud_format.GoogleCloudFormatPropagator)
+
+        self.assertEqual(middleware.sampler.rate, rate)
 
     def test_process_request(self):
         from django.test import RequestFactory

--- a/trace/tests/unit/ext/django/test_middleware.py
+++ b/trace/tests/unit/ext/django/test_middleware.py
@@ -35,7 +35,7 @@ class TestOpencensusMiddleware(unittest.TestCase):
 
         teardown_test_environment()
 
-    def test_constructor_default(self):
+    def test_constructor_cloud(self):
         from opencensus.trace.ext.django import middleware
         from opencensus.trace.samplers import always_on
         from opencensus.trace.reporters import google_cloud_reporter
@@ -46,10 +46,13 @@ class TestOpencensusMiddleware(unittest.TestCase):
             'GCP_REPORTER_PROJECT': project_id,
         }
 
-        patch = mock.patch(
+        patch_params = mock.patch(
             'opencensus.trace.ext.django.config.settings.params', params)
+        patch_reporter = mock.patch(
+            'opencensus.trace.ext.django.config.settings.REPORTER',
+            google_cloud_reporter.GoogleCloudReporter)
 
-        with patch:
+        with patch_params, patch_reporter:
             middleware = middleware.OpencensusMiddleware()
 
         self.assertIs(middleware._sampler, always_on.AlwaysOnSampler)


### PR DESCRIPTION
Get the params like sampling rate from the django settings file, and use them to initialize samplers and reporters.