### PR TITLE
Make Django middleware compatible with versions below and above 1.10

### DIFF
--- a/trace/opencensus/trace/ext/django/middleware.py
+++ b/trace/opencensus/trace/ext/django/middleware.py
@@ -22,6 +22,11 @@ from opencensus.trace import request_tracer
 from opencensus.trace import execution_context
 from opencensus.trace.samplers import probability
 
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:  # pragma: NO COVER
+    MiddlewareMixin = object
+
 HTTP_METHOD = labels_helper.COMMON_LABELS['HTTP_METHOD']
 HTTP_URL = labels_helper.COMMON_LABELS['HTTP_URL']
 HTTP_STATUS_CODE = labels_helper.COMMON_LABELS['HTTP_STATUS_CODE']
@@ -86,7 +91,7 @@ def get_django_header():
     return header
 
 
-class OpencensusMiddleware(object):
+class OpencensusMiddleware(MiddlewareMixin):
     """Saves the request in thread local"""
 
     def __init__(self, get_response=None):

--- a/trace/opencensus/trace/request_tracer.py
+++ b/trace/opencensus/trace/request_tracer.py
@@ -95,7 +95,7 @@ class RequestTracer(object):
         """End all spans."""
         self.tracer.finish()
 
-    def span(self, name=None):
+    def span(self, name='span'):
         """Create a new span with the trace using the context information.
 
         :type name: str
@@ -106,7 +106,7 @@ class RequestTracer(object):
         """
         return self.tracer.span(name)
 
-    def start_span(self, name=None):
+    def start_span(self, name='span'):
         return self.tracer.start_span(name)
 
     def end_span(self):

--- a/trace/requirements-test.txt
+++ b/trace/requirements-test.txt
@@ -1,6 +1,6 @@
-Django==1.11.5
+Django==1.11.7
 Flask==0.12.2
-google-cloud-trace==0.15.5
+google-cloud-trace==0.16.0
 mock==2.0.0
 mysql-connector==2.1.6
 psycopg2==2.7.3.1

--- a/trace/tests/system/django/app/settings.py
+++ b/trace/tests/system/django/app/settings.py
@@ -17,6 +17,9 @@
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 
+import django
+
+
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = 'secret_key_for_test'
 
@@ -33,6 +36,20 @@ INSTALLED_APPS = (
     'opencensus.trace.ext.django',
 )
 
+if django.VERSION >= (1, 10):
+    MIDDLEWARE = (
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.common.CommonMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
+        'django.middleware.clickjacking.XFrameOptionsMiddleware',
+        'django.middleware.security.SecurityMiddleware',
+        'opencensus.trace.ext.django.middleware.OpencensusMiddleware',
+    )
+
+# Middleware interface for Django version before 1.10
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',


### PR DESCRIPTION
Closes #79 