### PR TITLE
Remove sql query from span name

### DIFF
--- a/trace/opencensus/trace/ext/dbapi/trace.py
+++ b/trace/opencensus/trace/ext/dbapi/trace.py
@@ -54,7 +54,7 @@ def trace_cursor_query(query_func):
     def call(query, *args, **kwargs):
         _tracer = execution_context.get_opencensus_tracer()
         _span = _tracer.start_span()
-        _span.name = '[mysql.query]{}'.format(query)
+        _span.name = 'mysql.query'
         _tracer.add_label_to_current_span('mysql/query', query)
         _tracer.add_label_to_current_span(
             'mysql/cursor/method/name',

--- a/trace/opencensus/trace/ext/postgresql/trace.py
+++ b/trace/opencensus/trace/ext/postgresql/trace.py
@@ -49,7 +49,7 @@ def trace_cursor_query(query_func):
     def call(query, *args, **kwargs):
         _tracer = execution_context.get_opencensus_tracer()
         _span = _tracer.start_span()
-        _span.name = '[{}.query]{}'.format(MODULE_NAME, query)
+        _span.name = '{}.query'.format(MODULE_NAME)
         _tracer.add_label_to_current_span(
             '{}/query'.format(MODULE_NAME), query)
         _tracer.add_label_to_current_span(


### PR DESCRIPTION
Since the query is already in the span labels, we don't need it in the span name to avoid name length exceeds the limit.