### PR TITLE
Add integration for grpc channel from api_core

### DIFF
--- a/opencensus/trace/config_integration.py
+++ b/opencensus/trace/config_integration.py
@@ -18,7 +18,7 @@ import logging
 log = logging.getLogger(__name__)
 
 SUPPORTED_INTEGRATIONS = ['httplib', 'mysql', 'postgresql', 'pymysql',
-                          'requests', 'sqlalchemy']
+                          'requests', 'sqlalchemy', 'google_cloud_clientlibs']
 
 PATH_PREFIX = 'opencensus.trace.ext'
 

--- a/tests/unit/trace/ext/google_cloud_clientlibs/test_google_cloud_clientlibs_trace.py
+++ b/tests/unit/trace/ext/google_cloud_clientlibs/test_google_cloud_clientlibs_trace.py
@@ -112,3 +112,23 @@ class Test_google_cloud_clientlibs_trace(unittest.TestCase):
             wrapped()
 
         self.assertTrue(mock_interceptor.called)
+
+    def test_wrap_create_channel(self):
+        mock_tracer = mock.Mock()
+        mock_interceptor = mock.Mock()
+        mock_func = mock.Mock()
+
+        patch_tracer = mock.patch(
+            'opencensus.trace.ext.google_cloud_clientlibs.trace.execution_context.'
+            'get_opencensus_tracer',
+            return_value=mock_tracer)
+        patch_interceptor = mock.patch(
+            'opencensus.trace.ext.google_cloud_clientlibs.trace.OpenCensusClientInterceptor',
+            mock_interceptor)
+
+        wrapped = trace.wrap_create_channel(mock_func)
+
+        with patch_tracer, patch_interceptor:
+            wrapped()
+
+        self.assertTrue(mock_interceptor.called)


### PR DESCRIPTION
This is for cloud clientlibs integration, the code path for integrating with grpc channel need to support `google.api_core.grpc_helpers.create_channel`, which is used by recently refactored cloud client libraries.