### PR TITLE
Update span ids to be 16 char hex strings

### DIFF
--- a/opencensus/trace/propagation/google_cloud_format.py
+++ b/opencensus/trace/propagation/google_cloud_format.py
@@ -18,7 +18,7 @@ import re
 from opencensus.trace.span_context import SpanContext
 from opencensus.trace.trace_options import TraceOptions
 
-_TRACE_CONTEXT_HEADER_FORMAT = '([0-9a-f]{32})(\/(\d+))?(;o=(\d+))?'
+_TRACE_CONTEXT_HEADER_FORMAT = '([0-9a-f]{32})(\/([0-9a-f]{16}))?(;o=(\d+))?'
 _TRACE_CONTEXT_HEADER_RE = re.compile(_TRACE_CONTEXT_HEADER_FORMAT)
 _TRACE_ID_DELIMETER = '/'
 _SPAN_ID_DELIMETER = ';'

--- a/opencensus/trace/propagation/trace_context_http_header_format.py
+++ b/opencensus/trace/propagation/trace_context_http_header_format.py
@@ -61,7 +61,7 @@ class TraceContextPropagator(object):
                 # Need to convert span_id from hex string to int
                 span_context = SpanContext(
                     trace_id=trace_id,
-                    span_id=int(span_id, 16),
+                    span_id=span_id,
                     trace_options=TraceOptions(trace_options),
                     from_header=True)
                 return span_context
@@ -89,10 +89,6 @@ class TraceContextPropagator(object):
         trace_id = span_context.trace_id
         span_id = span_context.span_id
         trace_options = span_context.trace_options.enabled
-
-        # Need to convert span_id from int to hex string
-        span_id_hex = hex(span_id)
-        span_id = span_id_hex[2:].zfill(16)
 
         # Convert the trace options
         trace_options = '01' if trace_options else '00'

--- a/opencensus/trace/span_context.py
+++ b/opencensus/trace/span_context.py
@@ -15,16 +15,17 @@
 """SpanContext encapsulates the current context within the request's trace."""
 
 import logging
-import random
 import re
 import uuid
 
 from opencensus.trace import trace_options
 
 _INVALID_TRACE_ID = '0' * 32
-_INVALID_SPAN_ID = 0
+INVALID_SPAN_ID = '0' * 16
 _TRACE_HEADER_KEY = 'X_CLOUD_TRACE_CONTEXT'
-_TRACE_ID_FORMAT = '[0-9a-f]{32}?'
+
+TRACE_ID_PATTERN = re.compile('[0-9a-f]{32}?')
+SPAN_ID_PATTERN = re.compile('[0-9a-f]{16}?')
 
 # Default options, enable tracing
 DEFAULT_OPTIONS = 1
@@ -42,8 +43,9 @@ class SpanContext(object):
     :param trace_id: (Optional) Trace_id is a 32 digits uuid for the trace.
                      If not given, will generate one automatically.
 
-    :type span_id: int
+    :type span_id: str
     :param span_id: (Optional) Identifier for the span, unique within a trace.
+                    If not given, will generate one automatically.
 
     :type trace_options: :class: `~opencensus.trace.trace_options.TraceOptions`
     :param trace_options: (Optional) TraceOptions indicates 8 trace options.
@@ -64,10 +66,10 @@ class SpanContext(object):
         if trace_options is None:
             trace_options = DEFAULT
 
-        self.trace_id = self.check_trace_id(trace_id)
-        self.span_id = self.check_span_id(span_id)
-        self.trace_options = trace_options
         self.from_header = from_header
+        self.trace_id = self._check_trace_id(trace_id)
+        self.span_id = self._check_span_id(span_id)
+        self.trace_options = trace_options
 
     def __str__(self):
         """Returns a string form of the SpanContext. This is the format of
@@ -84,41 +86,42 @@ class SpanContext(object):
             int(enabled))
         return header
 
-    def check_span_id(self, span_id):
-        """Check the type of span_id to ensure it is int. If it is not int,
-        first try to convert it to int, if failed to convert, then log a
-        warning message and set the span_id to None.
+    def _check_span_id(self, span_id):
+        """Check the format of the span_id to ensure it is 16-character hex
+        value representing a 64-bit number. If span_id is invalid, logs a
+        warning message and returns None
 
-        :type span_id: int
-        :param span_id: Identifier for the span, unique within a trace.
+        :type span_id: str
+        :param span_id: Identifier for the span, unique within a span.
 
-        :rtype: int
+        :rtype: str
         :returns: Span_id for the current span.
         """
         if span_id is None:
             return None
+        assert isinstance(span_id, str)
 
-        if span_id == 0:
+        if span_id is INVALID_SPAN_ID:
             logging.warning(
-                'Span_id {} is invalid, cannot be zero.'.format(span_id))
+                'Span_id {} is invalid (cannot be all zero)'.format(span_id))
             self.from_header = False
             return None
 
-        if not isinstance(span_id, int):
-            try:
-                span_id = int(span_id)
-            except (TypeError, ValueError):
-                logging.warning(
-                    'The type of span_id should be int, got {}.'.format(
-                        span_id.__class__.__name__))
-                self.from_header = False
-                span_id = None
+        match = SPAN_ID_PATTERN.match(span_id)
 
-        return span_id
+        if match:
+            return span_id
+        else:
+            logging.warning(
+                'Span_id {} does not the match the '
+                'required format'.format(span_id))
+            self.from_header = False
+            return None
 
-    def check_trace_id(self, trace_id):
+    def _check_trace_id(self, trace_id):
         """Check the format of the trace_id to ensure it is 32-character hex
-        value representing a 128-bit number. Also the trace_id cannot be zero.
+        value representing a 128-bit number. If trace_id is invalid, returns a
+        randomly generated trace id
 
         :type trace_id: str
         :param trace_id:
@@ -126,46 +129,47 @@ class SpanContext(object):
         :rtype: str
         :returns: Trace_id for the current context.
         """
+        if trace_id is None:
+            return generate_span_id()
+
         assert isinstance(trace_id, str)
 
         if trace_id is _INVALID_TRACE_ID:
             logging.warning(
                 'Trace_id {} is invalid (cannot be all zero), '
-                'generate a new one.'.format(trace_id))
+                'generating a new one.'.format(trace_id))
             self.from_header = False
             return generate_trace_id()
 
-        trace_id_pattern = re.compile(_TRACE_ID_FORMAT)
-
-        match = trace_id_pattern.match(trace_id)
+        match = TRACE_ID_PATTERN.match(trace_id)
 
         if match:
             return trace_id
         else:
             logging.warning(
                 'Trace_id {} does not the match the required format,'
-                'generate a new one instead.'.format(trace_id))
+                'generating a new one instead.'.format(trace_id))
             self.from_header = False
             return generate_trace_id()
 
 
 def generate_span_id():
-    """Return the random generated span ID for a span. Must be 16 digits
-    as Stackdriver Trace V2 API only accepts 16 digits span ID.
+    """Return the random generated span ID for a span. Must be a 16 character
+    hexadecimal encoded string
 
-    :rtype: int
-    :returns: Identifier for the span. Must be a 64-bit integer other
-              than 0 and unique within a trace.
+    :rtype: str
+    :returns: 16 digit randomly generated hex trace id.
     """
-    span_id = random.randint(10**15, 10**16 - 1)
+    span_id = uuid.uuid4().hex[:16]
     return span_id
 
 
 def generate_trace_id():
-    """Generate a trace_id randomly.
+    """Generate a trace_id randomly. Must be a 32 character
+    hexadecimal encoded string
 
     :rtype: str
-    :returns: 32 digit randomly generated trace ID.
+    :returns: 32 digit randomly generated hex trace id.
     """
     trace_id = uuid.uuid4().hex
     return trace_id

--- a/opencensus/trace/span_context.py
+++ b/opencensus/trace/span_context.py
@@ -129,9 +129,6 @@ class SpanContext(object):
         :rtype: str
         :returns: Trace_id for the current context.
         """
-        if trace_id is None:
-            return generate_span_id()
-
         assert isinstance(trace_id, str)
 
         if trace_id is _INVALID_TRACE_ID:

--- a/tests/system/trace/basic_trace/basic_trace_system_test.py
+++ b/tests/system/trace/basic_trace/basic_trace_system_test.py
@@ -32,7 +32,7 @@ class TestBasicTrace(unittest.TestCase):
         from opencensus.trace.propagation import google_cloud_format
 
         trace_id = 'f8739df974a4481f98748cd92b27177d'
-        span_id = '16971691944144156899'
+        span_id = '6e0c63257de34c92'
         trace_option = 1
 
         trace_header = '{}/{};o={}'.format(trace_id, span_id, trace_option)

--- a/tests/system/trace/django/django_system_test.py
+++ b/tests/system/trace/django/django_system_test.py
@@ -43,7 +43,7 @@ def wait_app_to_start():
 def generate_header():
     """Generate a trace header."""
     trace_id = uuid.uuid4().hex
-    span_id = random.randint(10**15, 10**16 - 1)
+    span_id = uuid.uuid4().hex[:16]
     trace_option = 1
 
     header = '{}/{};o={}'.format(trace_id, span_id, trace_option)

--- a/tests/system/trace/flask/flask_system_test.py
+++ b/tests/system/trace/flask/flask_system_test.py
@@ -42,7 +42,7 @@ def wait_app_to_start():
 def generate_header():
     """Generate a trace header."""
     trace_id = uuid.uuid4().hex
-    span_id = random.randint(10**15, 10**16 - 1)
+    span_id = uuid.uuid4().hex[:16]
     trace_option = 1
 
     header = '{}/{};o={}'.format(trace_id, span_id, trace_option)

--- a/tests/unit/trace/exporters/test_stackdriver_exporter.py
+++ b/tests/unit/trace/exporters/test_stackdriver_exporter.py
@@ -144,7 +144,7 @@ class TestStackdriverExporter(unittest.TestCase):
         project_id = 'PROJECT'
         trace_id = '6e0c63257de34c92bf9efcd03927272e'
         span_name = 'test span'
-        span_id = 1234
+        span_id = '6e0c63257de34c92'
         attributes = {
             'attributeMap': {
                 'key': {
@@ -155,7 +155,7 @@ class TestStackdriverExporter(unittest.TestCase):
                }
             }
         }
-        parent_span_id = 1111
+        parent_span_id = '6e0c63257de34c93'
         start_time = 'test start time'
         end_time = 'test end time'
         trace = {

--- a/tests/unit/trace/exporters/test_zipkin_exporter.py
+++ b/tests/unit/trace/exporters/test_zipkin_exporter.py
@@ -98,8 +98,8 @@ class TestZipkinExporter(unittest.TestCase):
             span_data_module.SpanData(
                 name='child_span',
                 context=span_context.SpanContext(trace_id=trace_id),
-                span_id=1234567890,
-                parent_span_id=1111111111,
+                span_id='6e0c63257de34c92',
+                parent_span_id='6e0c63257de34c93',
                 attributes={'test_key': 'test_value'},
                 start_time='2017-08-15T18:02:26.071158Z',
                 end_time='2017-08-15T18:02:36.071158Z',
@@ -114,8 +114,8 @@ class TestZipkinExporter(unittest.TestCase):
             span_data_module.SpanData(
                 name='child_span',
                 context=span_context.SpanContext(trace_id=trace_id),
-                span_id=1234567890,
-                parent_span_id=1111111111,
+                span_id='6e0c63257de34c92',
+                parent_span_id='6e0c63257de34c93',
                 attributes={'test_key': 1},
                 start_time='2017-08-15T18:02:26.071158Z',
                 end_time='2017-08-15T18:02:36.071158Z',
@@ -134,7 +134,7 @@ class TestZipkinExporter(unittest.TestCase):
             span_data_module.SpanData(
                 name='child_span',
                 context=span_context.SpanContext(trace_id=trace_id),
-                span_id=1234567890,
+                span_id='6e0c63257de34c92',
                 parent_span_id=None,
                 attributes={
                     'test_key': False,
@@ -172,8 +172,8 @@ class TestZipkinExporter(unittest.TestCase):
         expected_zipkin_spans_ipv4 = [
             {
                 'traceId': '6e0c63257de34c92bf9efcd03927272e',
-                'id': '1234567890',
-                'parentId': '1111111111',
+                'id': '6e0c63257de34c92',
+                'parentId': '6e0c63257de34c93',
                 'name': 'child_span',
                 'timestamp': 1502820146000000,
                 'duration': 10000000,
@@ -182,8 +182,8 @@ class TestZipkinExporter(unittest.TestCase):
             },
             {
                 'traceId': '6e0c63257de34c92bf9efcd03927272e',
-                'id': '1234567890',
-                'parentId': '1111111111',
+                'id': '6e0c63257de34c92',
+                'parentId': '6e0c63257de34c93',
                 'name': 'child_span',
                 'timestamp': 1502820146000000,
                 'duration': 10000000,
@@ -195,7 +195,7 @@ class TestZipkinExporter(unittest.TestCase):
         expected_zipkin_spans_ipv6 = [
             {
                 'traceId': '6e0c63257de34c92bf9efcd03927272e',
-                'id': '1234567890',
+                'id': '6e0c63257de34c92',
                 'name': 'child_span',
                 'timestamp': 1502820146000000,
                 'duration': 10000000,

--- a/tests/unit/trace/ext/flask/test_flask_middleware.py
+++ b/tests/unit/trace/ext/flask/test_flask_middleware.py
@@ -17,17 +17,23 @@
 
 import unittest
 
+import flask
 import mock
 
+from opencensus.trace import execution_context
+from opencensus.trace.exporters import print_exporter
 from opencensus.trace.ext.flask import flask_middleware
+from opencensus.trace.propagation import google_cloud_format
+from opencensus.trace.samplers import always_off
+from opencensus.trace.samplers import always_on
+from opencensus.trace.tracers import base
+from opencensus.trace.tracers import noop_tracer
 
 
 class TestFlaskMiddleware(unittest.TestCase):
 
     @staticmethod
     def create_app():
-        import flask
-
         app = flask.Flask(__name__)
 
         @app.route('/')
@@ -46,10 +52,6 @@ class TestFlaskMiddleware(unittest.TestCase):
         execution_context.clear()
 
     def test_constructor_default(self):
-        from opencensus.trace.exporters import print_exporter
-        from opencensus.trace.samplers import always_on
-        from opencensus.trace.propagation import google_cloud_format
-
         app = mock.Mock()
         middleware = flask_middleware.FlaskMiddleware(app=app)
 
@@ -86,7 +88,7 @@ class TestFlaskMiddleware(unittest.TestCase):
 
         flask_trace_header = 'X_CLOUD_TRACE_CONTEXT'
         trace_id = '2dd43a1d6b2549c6bc2a1a54c2fc0b05'
-        span_id = 1234
+        span_id = '6e0c63257de34c92'
         flask_trace_id = '{}/{}'.format(trace_id, span_id)
 
         app = self.create_app()
@@ -114,13 +116,9 @@ class TestFlaskMiddleware(unittest.TestCase):
             self.assertEqual(span_context.trace_id, trace_id)
 
     def test__before_request_blacklist(self):
-        from opencensus.trace import execution_context
-        from opencensus.trace.tracers import base
-        from opencensus.trace.tracers import noop_tracer
-
         flask_trace_header = 'X_CLOUD_TRACE_CONTEXT'
         trace_id = '2dd43a1d6b2549c6bc2a1a54c2fc0b05'
-        span_id = 1234
+        span_id = '6e0c63257de34c92'
         flask_trace_id = '{}/{}'.format(trace_id, span_id)
 
         app = self.create_app()
@@ -144,12 +142,10 @@ class TestFlaskMiddleware(unittest.TestCase):
         # This test case is expected to fail at the check_trace_id method
         # in SpanContext because it cannot match the pattern for trace_id,
         # And a new trace_id will generate for the context.
-        from opencensus.trace import execution_context
-        from opencensus.trace.tracers import base
 
         flask_trace_header = 'X_CLOUD_TRACE_CONTEXT'
         trace_id = "你好"
-        span_id = 1234
+        span_id = '6e0c63257de34c92'
         flask_trace_id = '{}/{}'.format(trace_id, span_id)
 
         app = self.create_app()
@@ -177,9 +173,6 @@ class TestFlaskMiddleware(unittest.TestCase):
             self.assertNotEqual(span_context.trace_id, trace_id)
 
     def test_header_is_none(self):
-        from opencensus.trace import execution_context
-        from opencensus.trace.tracers import base
-
         app = self.create_app()
         flask_middleware.FlaskMiddleware(app=app)
         context = app.test_request_context(
@@ -201,11 +194,9 @@ class TestFlaskMiddleware(unittest.TestCase):
             assert isinstance(span.parent_span, base.NullContextManager)
 
     def test__after_request_not_sampled(self):
-        from opencensus.trace.samplers import always_off
-
         flask_trace_header = 'X_CLOUD_TRACE_CONTEXT'
         trace_id = '2dd43a1d6b2549c6bc2a1a54c2fc0b05'
-        span_id = 1234
+        span_id = '6e0c63257de34c92'
         flask_trace_id = '{}/{}'.format(trace_id, span_id)
         sampler = always_off.AlwaysOffSampler()
 
@@ -221,7 +212,7 @@ class TestFlaskMiddleware(unittest.TestCase):
     def test__after_request_sampled(self):
         flask_trace_header = 'X_CLOUD_TRACE_CONTEXT'
         trace_id = '2dd43a1d6b2549c6bc2a1a54c2fc0b05'
-        span_id = 1234
+        span_id = '6e0c63257de34c92'
         flask_trace_id = '{}/{}'.format(trace_id, span_id)
 
         app = self.create_app()
@@ -234,12 +225,9 @@ class TestFlaskMiddleware(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test__after_request_blacklist(self):
-        from opencensus.trace import execution_context
-        from opencensus.trace.tracers import noop_tracer
-
         flask_trace_header = 'X_CLOUD_TRACE_CONTEXT'
         trace_id = '2dd43a1d6b2549c6bc2a1a54c2fc0b05'
-        span_id = 1234
+        span_id = '6e0c63257de34c92'
         flask_trace_id = '{}/{}'.format(trace_id, span_id)
 
         app = self.create_app()

--- a/tests/unit/trace/propagation/test_binary_format.py
+++ b/tests/unit/trace/propagation/test_binary_format.py
@@ -39,12 +39,11 @@ class TestBinaryFormat(unittest.TestCase):
         self.assertFalse(span_context.from_header)
 
     def test_from_header(self):
-        binary_header = b'\x00\x00\xa0\xb7,\xa1\\\x1aK\xd1\x89b\xd0' \
-                        b'\xacY\xdc\x90\xb9\x01g)U\xf6\xf5\x01\x12' \
-                        b'\xb6\x02\x01'
+        binary_header = b'\x00\x00\xa0\xb7,\xa1\\\x1aK\xd1\x89b\xd0\xacY\xdc' \
+                        b'\x90\xb9\x01\xa0\xb7,\xa1\\\x1aK\xd1\x02\x01'
 
         expected_trace_id = 'a0b72ca15c1a4bd18962d0ac59dc90b9'
-        expected_span_id = 7433567179112518326
+        expected_span_id = 'a0b72ca15c1a4bd1'
         expected_trace_option = True
 
         propagator = binary_format.BinaryFormatPropagator()
@@ -74,8 +73,8 @@ class TestBinaryFormat(unittest.TestCase):
         binary_header = propagator.to_header(span_context)
 
         expected_binary_header = b'\x00\x00\xa0\xb7,\xa1\\\x1aK\xd1\x89b\xd0' \
-                                 b'\xacY\xdc\x90\xb9\x01\x00\x00\x00\x00\x00' \
-                                 b'\x00\x00\x00\x02\x01'
+                                 b'\xacY\xdc\x90\xb9\x01\x00\x00\x00\x00' \
+                                 b'\x00\x00\x00\x00\x02\x01'
 
         self.assertEqual(expected_binary_header, binary_header)
 
@@ -85,7 +84,7 @@ class TestBinaryFormat(unittest.TestCase):
 
         span_context = mock.Mock(spec=SpanContext)
         trace_id = 'a0b72ca15c1a4bd18962d0ac59dc90b9'
-        span_id = 7433567179112518326
+        span_id = 'a0b72ca15c1a4bd1'
         trace_options = '1'
         span_context.trace_id = trace_id
         span_context.span_id = span_id
@@ -95,8 +94,8 @@ class TestBinaryFormat(unittest.TestCase):
 
         binary_header = propagator.to_header(span_context)
 
-        expected_binary_header = b'\x00\x00\xa0\xb7,\xa1\\\x1aK\xd1\x89b\xd0' \
-                                 b'\xacY\xdc\x90\xb9\x01g)U\xf6\xf5\x01\x12' \
-                                 b'\xb6\x02\x01'
+        expected_binary_header = b'\x00\x00\xa0\xb7,\xa1\\\x1aK' \
+                                 b'\xd1\x89b\xd0\xacY\xdc' \
+                                 b'\x90\xb9\x01\xa0\xb7,\xa1\\\x1aK\xd1\x02\x01'
 
         self.assertEqual(expected_binary_header, binary_header)

--- a/tests/unit/trace/propagation/test_google_cloud_format.py
+++ b/tests/unit/trace/propagation/test_google_cloud_format.py
@@ -37,9 +37,9 @@ class TestGoogleCloudFormatPropagator(unittest.TestCase):
 
     def test_header_match(self):
         # Trace option is not enabled.
-        header = '6e0c63257de34c92bf9efcd03927272e/1234;o=0'
+        header = '6e0c63257de34c92bf9efcd03927272e/00f067aa0ba902b7;o=0'
         expected_trace_id = '6e0c63257de34c92bf9efcd03927272e'
-        expected_span_id = 1234
+        expected_span_id = '00f067aa0ba902b7'
 
         propagator = google_cloud_format.GoogleCloudFormatPropagator()
         span_context = propagator.from_header(header)
@@ -49,9 +49,9 @@ class TestGoogleCloudFormatPropagator(unittest.TestCase):
         self.assertFalse(span_context.trace_options.enabled)
 
         # Trace option is enabled.
-        header = '6e0c63257de34c92bf9efcd03927272e/1234;o=1'
+        header = '6e0c63257de34c92bf9efcd03927272e/00f067aa0ba902b7;o=1'
         expected_trace_id = '6e0c63257de34c92bf9efcd03927272e'
-        expected_span_id = 1234
+        expected_span_id = '00f067aa0ba902b7'
 
         propagator = google_cloud_format.GoogleCloudFormatPropagator()
         span_context = propagator.from_header(header)
@@ -61,9 +61,9 @@ class TestGoogleCloudFormatPropagator(unittest.TestCase):
         self.assertTrue(span_context.trace_options.enabled)
 
     def test_header_match_no_option(self):
-        header = '6e0c63257de34c92bf9efcd03927272e/1234'
+        header = '6e0c63257de34c92bf9efcd03927272e/00f067aa0ba902b7'
         expected_trace_id = '6e0c63257de34c92bf9efcd03927272e'
-        expected_span_id = 1234
+        expected_span_id = '00f067aa0ba902b7'
 
         propagator = google_cloud_format.GoogleCloudFormatPropagator()
         span_context = propagator.from_header(header)
@@ -86,7 +86,7 @@ class TestGoogleCloudFormatPropagator(unittest.TestCase):
         from opencensus.trace import trace_options
 
         trace_id = '6e0c63257de34c92bf9efcd03927272e'
-        span_id = 1234
+        span_id = '00f067aa0ba902b7'
         span_context = span_context.SpanContext(
             trace_id=trace_id,
             span_id=span_id,

--- a/tests/unit/trace/propagation/test_text_format.py
+++ b/tests/unit/trace/propagation/test_text_format.py
@@ -18,11 +18,12 @@ import mock
 
 from opencensus.trace.propagation import text_format
 
+
 class Test_from_carrier(unittest.TestCase):
 
     def test_from_carrier_keys_exist(self):
         test_trace_id = '6e0c63257de34c92bf9efcd03927272e'
-        test_span_id = 1234
+        test_span_id = '00f067aa0ba902b7'
         test_options = 1
 
         carrier = {
@@ -53,7 +54,7 @@ class Test_from_carrier(unittest.TestCase):
 
     def test_to_carrier_has_span_id(self):
         test_trace_id = '6e0c63257de34c92bf9efcd03927272e'
-        test_span_id = 1234
+        test_span_id = '00f067aa0ba902b7'
         test_options = '2'
 
         span_context = mock.Mock()

--- a/tests/unit/trace/propagation/test_trace_context_http_header_format.py
+++ b/tests/unit/trace/propagation/test_trace_context_http_header_format.py
@@ -51,7 +51,7 @@ class TestTraceContextPropagator(unittest.TestCase):
         # Trace option is not enabled.
         header = '00-6e0c63257de34c92bf9efcd03927272e-00f067aa0ba902b7-00'
         expected_trace_id = '6e0c63257de34c92bf9efcd03927272e'
-        expected_span_id = 67667974448284343
+        expected_span_id = '00f067aa0ba902b7'
 
         propagator = trace_context_http_header_format.\
             TraceContextPropagator()
@@ -64,7 +64,7 @@ class TestTraceContextPropagator(unittest.TestCase):
         # Trace option is enabled.
         header = '00-6e0c63257de34c92bf9efcd03927272e-00f067aa0ba902b7-01'
         expected_trace_id = '6e0c63257de34c92bf9efcd03927272e'
-        expected_span_id = 67667974448284343
+        expected_span_id = '00f067aa0ba902b7'
 
         propagator = trace_context_http_header_format.\
             TraceContextPropagator()
@@ -77,7 +77,7 @@ class TestTraceContextPropagator(unittest.TestCase):
     def test_header_match_no_option(self):
         header = '00-6e0c63257de34c92bf9efcd03927272e-00f067aa0ba902b7'
         expected_trace_id = '6e0c63257de34c92bf9efcd03927272e'
-        expected_span_id = 67667974448284343
+        expected_span_id = '00f067aa0ba902b7'
 
         propagator = trace_context_http_header_format.\
             TraceContextPropagator()
@@ -102,11 +102,10 @@ class TestTraceContextPropagator(unittest.TestCase):
         from opencensus.trace import trace_options
 
         trace_id = '6e0c63257de34c92bf9efcd03927272e'
-        span_id = 67667974448284343
         span_id_hex = '00f067aa0ba902b7'
         span_context = span_context.SpanContext(
             trace_id=trace_id,
-            span_id=span_id,
+            span_id=span_id_hex,
             trace_options=trace_options.TraceOptions('1'))
 
         propagator = trace_context_http_header_format.\

--- a/tests/unit/trace/test_span_data.py
+++ b/tests/unit/trace/test_span_data.py
@@ -28,8 +28,8 @@ class TestSpanData(unittest.TestCase):
         span_data_module.SpanData(
             name='root',
             context=None,
-            span_id=2,
-            parent_span_id=1,
+            span_id='6e0c63257de34c92',
+            parent_span_id='6e0c63257de34c93',
             attributes={'key1': 'value1'},
             start_time=datetime.datetime.utcnow().isoformat() + 'Z',
             end_time=datetime.datetime.utcnow().isoformat() + 'Z',
@@ -46,8 +46,8 @@ class TestSpanData(unittest.TestCase):
         span_data = span_data_module.SpanData(
             name='root',
             context=None,
-            span_id=2,
-            parent_span_id=1,
+            span_id='6e0c63257de34c92',
+            parent_span_id='6e0c63257de34c93',
             attributes={'key1': 'value1'},
             start_time=datetime.datetime.utcnow().isoformat() + 'Z',
             end_time=datetime.datetime.utcnow().isoformat() + 'Z',
@@ -71,15 +71,15 @@ class TestSpanData(unittest.TestCase):
             name='root',
             context=span_context.SpanContext(
                 trace_id=trace_id,
-                span_id=1111
+                span_id='6e0c63257de34c92'
             ),
-            span_id=2,
-            parent_span_id=1,
+            span_id='6e0c63257de34c92',
+            parent_span_id='6e0c63257de34c93',
             attributes={'key1': 'value1'},
             start_time=datetime.datetime.utcnow().isoformat() + 'Z',
             end_time=datetime.datetime.utcnow().isoformat() + 'Z',
             stack_trace=stack_trace.StackTrace(stack_trace_hash_id='111'),
-            links=[link.Link('1111', span_id='111')],
+            links=[link.Link('1111', span_id='6e0c63257de34c92')],
             status=status.Status(code=0, message='pok'),
             time_events=[
                 time_event.TimeEvent(

--- a/tests/unit/trace/tracers/test_context_tracer.py
+++ b/tests/unit/trace/tracers/test_context_tracer.py
@@ -20,7 +20,6 @@ from opencensus.trace.tracers import context_tracer
 
 
 class TestContextTracer(unittest.TestCase):
-
     def test_constructor_defaults(self):
         from opencensus.trace import span_context
         from opencensus.trace.exporters import print_exporter
@@ -68,7 +67,7 @@ class TestContextTracer(unittest.TestCase):
     def test_start_span(self, current_span_mock):
         from opencensus.trace import span_context
 
-        span_id = 1234
+        span_id = '6e0c63257de34c92'
         span_name = 'test_span'
         mock_span = mock.Mock()
         mock_span.span_id = span_id
@@ -87,7 +86,7 @@ class TestContextTracer(unittest.TestCase):
     def test_span(self, current_span_mock):
         from opencensus.trace import span_context
 
-        span_id = 1234
+        span_id = '6e0c63257de34c92'
         span_name = 'test_span'
         mock_span = mock.Mock()
         mock_span.span_id = span_id
@@ -126,7 +125,7 @@ class TestContextTracer(unittest.TestCase):
         mock_span.attributes = {}
         mock_span.__iter__ = mock.Mock(
             return_value=iter([mock_span]))
-        parent_span_id = 1234
+        parent_span_id = '6e0c63257de34c92'
         mock_span.parent_span.span_id = parent_span_id
         mock_current_span.return_value = mock_span
         tracer.end_span()
@@ -174,7 +173,7 @@ class TestContextTracer(unittest.TestCase):
         mock_span.attributes = {}
         mock_span.__iter__ = mock.Mock(
             return_value=iter([mock_span]))
-        parent_span_id = 1234
+        parent_span_id = '6e0c63257de34c92'
         mock_span.parent_span.span_id = parent_span_id
         mock_current_span.return_value = mock_span
         tracer.end_span()


### PR DESCRIPTION
Sets span id generation and propagation to match the spec at https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/Span.md#spanid.

Not quite sure how to test this outside of the existing system tests.

