### PR TITLE
Allow Zipkin B3 headers

### DIFF
--- a/opencensus/trace/propagation/google_cloud_format.py
+++ b/opencensus/trace/propagation/google_cloud_format.py
@@ -70,7 +70,7 @@ class GoogleCloudFormatPropagator(object):
         else:
             logging.warning(
                 'Cannot parse the header {}, generate a new context instead.'
-                .format(header))
+                .format(header.encode('utf-8', errors='ignore')))
             return SpanContext()
 
     def to_header(self, span_context):

--- a/opencensus/trace/propagation/text_format.py
+++ b/opencensus/trace/propagation/text_format.py
@@ -28,6 +28,11 @@ class TextFormatPropagator(object):
     information from a carrier which is a dict to form a SpanContext. And
     generating a dict using the provided SpanContext.
     """
+    _TRACE_ID_KEY = _TRACE_ID_KEY
+    _SPAN_ID_KEY = _SPAN_ID_KEY
+    _TRACE_OPTIONS_KEY = _TRACE_OPTIONS_KEY
+    DEFAULT_TRACE_OPTIONS = DEFAULT_TRACE_OPTIONS
+
     def from_carrier(self, carrier):
         """Generate a SpanContext object using the information in the carrier.
 
@@ -44,15 +49,15 @@ class TextFormatPropagator(object):
 
         for key in carrier:
             key = key.lower()
-            if key == _TRACE_ID_KEY:
+            if key == self._TRACE_ID_KEY:
                 trace_id = carrier[key]
-            if key == _SPAN_ID_KEY:
+            if key == self._SPAN_ID_KEY:
                 span_id = carrier[key]
-            if key == _TRACE_OPTIONS_KEY:
-                trace_options = bool(carrier[key])
+            if key == self._TRACE_OPTIONS_KEY:
+                trace_options = carrier[key]
 
         if trace_options is None:
-            trace_options = DEFAULT_TRACE_OPTIONS
+            trace_options = self.DEFAULT_TRACE_OPTIONS
 
         return SpanContext(
             trace_id=trace_id,
@@ -74,12 +79,12 @@ class TextFormatPropagator(object):
         :rtype: dict
         :returns: The carrier which holds the span context information.
         """
-        carrier[_TRACE_ID_KEY] = str(span_context.trace_id)
+        carrier[self._TRACE_ID_KEY] = str(span_context.trace_id)
 
         if span_context.span_id is not None:
-            carrier[_SPAN_ID_KEY] = str(span_context.span_id)
+            carrier[self._SPAN_ID_KEY] = str(span_context.span_id)
 
-        carrier[_TRACE_OPTIONS_KEY] = str(
+        carrier[self._TRACE_OPTIONS_KEY] = str(
             span_context.trace_options.trace_options_byte)
 
         return carrier

--- a/opencensus/trace/propagation/zipkin_b3_format.py
+++ b/opencensus/trace/propagation/zipkin_b3_format.py
@@ -1,0 +1,38 @@
+# Copyright 2017, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from opencensus.trace.propagation.text_format import TextFormatPropagator
+
+_TRACE_PREFIX = 'x-b3'
+_TRACE_ID_KEY = '{}-traceid'.format(_TRACE_PREFIX)
+_SPAN_ID_KEY = '{}-spanid'.format(_TRACE_PREFIX)
+_TRACE_OPTIONS_KEY = '{}-sampled'.format(_TRACE_PREFIX)
+
+DEFAULT_TRACE_OPTIONS = '1'
+
+
+class ZipkinB3FormatPropagator(TextFormatPropagator):
+    """"This class provides the basic utilities for extracting the trace
+    information from a carrier which is a dict to form a SpanContext. And
+    generating a dict using the provided SpanContext.
+
+    The trace prefix is set to match the B3 headers.
+    """
+    _TRACE_ID_KEY = _TRACE_ID_KEY
+    _SPAN_ID_KEY = _SPAN_ID_KEY
+    _TRACE_OPTIONS_KEY = _TRACE_OPTIONS_KEY
+    DEFAULT_TRACE_OPTIONS = DEFAULT_TRACE_OPTIONS
+
+    HEADERS = [_TRACE_ID_KEY, _SPAN_ID_KEY, _TRACE_OPTIONS_KEY]

--- a/opencensus/trace/span_context.py
+++ b/opencensus/trace/span_context.py
@@ -16,6 +16,7 @@
 
 import logging
 import re
+import six
 import uuid
 
 from opencensus.trace import trace_options
@@ -99,7 +100,7 @@ class SpanContext(object):
         """
         if span_id is None:
             return None
-        assert isinstance(span_id, str)
+        assert isinstance(span_id, six.string_types)
 
         if span_id is INVALID_SPAN_ID:
             logging.warning(
@@ -129,7 +130,7 @@ class SpanContext(object):
         :rtype: str
         :returns: Trace_id for the current context.
         """
-        assert isinstance(trace_id, str)
+        assert isinstance(trace_id, six.string_types)
 
         if trace_id is _INVALID_TRACE_ID:
             logging.warning(

--- a/tests/unit/trace/propagation/test_zipkin_b3_format.py
+++ b/tests/unit/trace/propagation/test_zipkin_b3_format.py
@@ -1,0 +1,99 @@
+# Copyright 2017, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import mock
+
+from opencensus.trace.propagation import zipkin_b3_format
+
+
+class TestZipkinB3FormatPropagator(unittest.TestCase):
+
+    def test_from_carrier_keys_exist(self):
+        test_trace_id = '6e0c63257de34c92bf9efcd03927272e'
+        test_span_id = '00f067aa0ba902b7'
+        test_options = 1
+
+        carrier = {
+            zipkin_b3_format._TRACE_ID_KEY: test_trace_id,
+            zipkin_b3_format._SPAN_ID_KEY: test_span_id,
+            zipkin_b3_format._TRACE_OPTIONS_KEY: test_options,
+        }
+
+        propagator = zipkin_b3_format.ZipkinB3FormatPropagator()
+
+        span_context = propagator.from_carrier(carrier)
+
+        self.assertEqual(span_context.trace_id, test_trace_id)
+        self.assertEqual(span_context.span_id, test_span_id)
+        self.assertEqual(span_context.trace_options.enabled, bool(test_options))
+
+    def test_from_carrier_keys_not_exist(self):
+        carrier = {}
+
+        propagator = zipkin_b3_format.ZipkinB3FormatPropagator()
+        span_context = propagator.from_carrier(carrier)
+
+        self.assertIsNotNone(span_context.trace_id)
+        # Span_id should be None here which indicates no parent span_id for
+        # the child spans
+        self.assertIsNone(span_context.span_id)
+        self.assertTrue(span_context.trace_options.enabled)
+
+    def test_to_carrier_has_span_id(self):
+        test_trace_id = '6e0c63257de34c92bf9efcd03927272e'
+        test_span_id = '00f067aa0ba902b7'
+        test_options = '2'
+
+        span_context = mock.Mock()
+        span_context.trace_id = test_trace_id
+        span_context.span_id = test_span_id
+        span_context.trace_options.trace_options_byte = test_options
+
+        carrier = {}
+        propagator = zipkin_b3_format.ZipkinB3FormatPropagator()
+        carrier = propagator.to_carrier(span_context, carrier)
+
+        self.assertEqual(
+            carrier[zipkin_b3_format._TRACE_ID_KEY],
+            test_trace_id)
+        self.assertEqual(
+            carrier[zipkin_b3_format._SPAN_ID_KEY],
+            str(test_span_id))
+        self.assertEqual(
+            carrier[zipkin_b3_format._TRACE_OPTIONS_KEY],
+            test_options)
+
+    def test_to_carrier_no_span_id(self):
+        test_trace_id = '6e0c63257de34c92bf9efcd03927272e'
+        test_options = '1'
+
+        span_context = mock.Mock()
+        span_context.trace_id = test_trace_id
+        span_context.span_id = None
+        span_context.trace_options.trace_options_byte = test_options
+
+        carrier = {}
+        propagator = zipkin_b3_format.ZipkinB3FormatPropagator()
+        carrier = propagator.to_carrier(span_context, carrier)
+
+        self.assertEqual(
+            carrier[zipkin_b3_format._TRACE_ID_KEY],
+            test_trace_id)
+        self.assertIsNone(
+            carrier.get(zipkin_b3_format._SPAN_ID_KEY))
+        self.assertEqual(
+            carrier[zipkin_b3_format._TRACE_OPTIONS_KEY],
+            test_options)


### PR DESCRIPTION
My use case it tying the application level tracing into [Istio](https://istio.io/docs/tasks/telemetry/distributed-tracing.html#understanding-what-happened) which uses the [openzipkin B3 propogation format](https://github.com/openzipkin/b3-propagation).

related to #167 and #46 