### PR TITLE
Mock out stackdriver client in test case

### DIFF
--- a/tests/unit/trace/ext/flask/test_flask_middleware.py
+++ b/tests/unit/trace/ext/flask/test_flask_middleware.py
@@ -119,7 +119,13 @@ class TestFlaskMiddleware(unittest.TestCase):
             },
         }
 
-        middleware = flask_middleware.FlaskMiddleware(exporter=mock.Mock())
+        class StackdriverExporter(object):
+            def __init__(self, *args, **kwargs):
+                pass
+
+        middleware = flask_middleware.FlaskMiddleware(
+            exporter=StackdriverExporter
+        )
         middleware.init_app(app)
 
         self.assertIs(middleware.app, app)

--- a/tests/unit/trace/ext/flask/test_flask_middleware.py
+++ b/tests/unit/trace/ext/flask/test_flask_middleware.py
@@ -119,7 +119,7 @@ class TestFlaskMiddleware(unittest.TestCase):
             },
         }
 
-        middleware = flask_middleware.FlaskMiddleware()
+        middleware = flask_middleware.FlaskMiddleware(exporter=mock.Mock())
         middleware.init_app(app)
 
         self.assertIs(middleware.app, app)


### PR DESCRIPTION
Causes unit tests to fail if the host machine does not have GCP env variables exported