### PR TITLE
Support the 0.19 version of google-cloud-trace

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ import io
 from setuptools import setup, find_packages
 
 extras = {
-    "stackdriver": ['google-cloud-trace>=0.17.0, <0.18dev']
+    "stackdriver": ['google-cloud-trace>=0.17.0, <0.20dev']
 }
 
 install_requires = [


### PR DESCRIPTION
google-cloud-trace is at version 0.19.0:
https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/trace/setup.py

We should support that version to prevent errors when installing google-cloud-trace and opencensus i.e.
$ pip install google-cloud-trace opencensus
...
opencensus 0.1.4 has requirement google-cloud-trace<0.18dev,>=0.17.0, but you'll have google-cloud-trace 0.19.0 which is incompatible.
