### PR TITLE
Remove pre-release version specifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,11 @@ import io
 from setuptools import setup, find_packages
 
 extras = {
-    "stackdriver": ['google-cloud-trace>=0.17.0, <0.20dev']
+    "stackdriver": ['google-cloud-trace>=0.17.0, <0.20']
 }
 
 install_requires = [
-    'google-api-core >= 0.1.1, < 2.0.0dev',
+    'google-api-core >= 0.1.1, < 2.0.0',
 ]
 
 setup(


### PR DESCRIPTION
To not allow pre-release versions. See https://pip.pypa.io/en/stable/reference/pip_install/#pre-release-versions.