### PR TITLE
Stats: fix a few bugs in measure_to_view_map.

### DIFF
--- a/opencensus/stats/measure_to_view_map.py
+++ b/opencensus/stats/measure_to_view_map.py
@@ -87,7 +87,8 @@ class MeasureToViewMap(object):
             view_datas = []
             for key, value in self._map.items():
                 if key == measure.name:
-                    view_datas.extend(self._map[key])  # self._map is a multi-map
+                    # note that self._map is a multi-map.
+                    view_datas.extend(self._map[key])
             for view_data in view_datas:
                 view_data.record(context=tags,
                                  value=view_data.view.measure,

--- a/opencensus/stats/measure_to_view_map.py
+++ b/opencensus/stats/measure_to_view_map.py
@@ -79,16 +79,15 @@ class MeasureToViewMap(object):
                                                      start_time=timestamp,
                                                      end_time=timestamp))
 
-    def record(self, tags, stats, timestamp):
+    def record(self, tags, measurement_map, timestamp):
         """records stats with a set of tags"""
-        for measurement, value in stats.items():
-            measure = measurement.measure
+        for measure, value in measurement_map.items():
             if measure != self._registered_measures.get(measure.name):
                 return
             view_datas = []
             for key, value in self._map.items():
                 if key == measure.name:
-                    view_datas.append(self._map[key])
+                    view_datas.extend(self._map[key])  # self._map is a multi-map
             for view_data in view_datas:
                 view_data.record(context=tags,
                                  value=view_data.view.measure,

--- a/tests/unit/stats/test_measure_to_view_map.py
+++ b/tests/unit/stats/test_measure_to_view_map.py
@@ -141,14 +141,13 @@ class TestMeasureToViewMap(unittest.TestCase):
         view = View(name=view_name, description=view_description, columns=view_columns, measure=view_measure, aggregation=view_aggregation)
 
         measure_value = 5
-        value = "testValue"
         tags = {"testTag1": "testTag1Value"}
-        stats = {Measurement(measure=measure, value=measure_value): value}
+        measurement_map = {measure: measure_value}
         timestamp = mock.Mock()
 
         measure_to_view_map = measure_to_view_map_module.MeasureToViewMap()
         measure_to_view_map._registered_measures = {}
-        record = measure_to_view_map.record(tags=tags, stats=stats, timestamp=timestamp)
+        record = measure_to_view_map.record(tags=tags, measurement_map=measurement_map, timestamp=timestamp)
         self.assertNotEqual(measure,
                             measure_to_view_map._registered_measures.get(
                                 measure.name))
@@ -156,23 +155,23 @@ class TestMeasureToViewMap(unittest.TestCase):
 
         measure_to_view_map._registered_measures = {measure.name: measure}
         measure_to_view_map._map = {}
-        record = measure_to_view_map.record(tags=tags, stats=stats,
+        record = measure_to_view_map.record(tags=tags, measurement_map=measurement_map,
                                    timestamp=timestamp)
         self.assertEqual(measure,
                          measure_to_view_map._registered_measures.get(
                              measure.name))
         self.assertIsNone(record)
 
-        measure_to_view_map._map = {measure.name: mock.Mock()}
-        measure_to_view_map.record(tags=tags, stats=stats,
+        measure_to_view_map._map = {measure.name: [mock.Mock()]}
+        measure_to_view_map.record(tags=tags, measurement_map=measurement_map,
                                    timestamp=timestamp)
         self.assertEqual(measure,
                          measure_to_view_map._registered_measures.get(
                              measure.name))
         self.assertTrue(measure.name in measure_to_view_map._map)
 
-        measure_to_view_map._map = {"testing": mock.Mock()}
-        measure_to_view_map.record(tags=tags, stats=stats,
+        measure_to_view_map._map = {"testing": [mock.Mock()]}
+        measure_to_view_map.record(tags=tags, measurement_map=measurement_map,
                                    timestamp=timestamp)
         self.assertTrue(measure.name not in measure_to_view_map._map)
 
@@ -188,7 +187,7 @@ class TestMeasureToViewMap(unittest.TestCase):
         self.assertTrue(measure_to_view_map_mock.record.called)
 
         tags = {"testTag1": "testTag1Value"}
-        stats = {}
+        measurement_map = {}
         measure_to_view_map = measure_to_view_map_module.MeasureToViewMap()
-        record = measure_to_view_map.record(tags=tags, stats=stats, timestamp=timestamp)
+        record = measure_to_view_map.record(tags=tags, measurement_map=measurement_map, timestamp=timestamp)
         self.assertIsNone(record)


### PR DESCRIPTION
1. The arg `stats` that `measure_to_view_map.record()` takes is a `measurement_map`. Its key is a `Measure`, rather than a `Measurement`.
2. `measure_to_view_map.map` is a multi-map, the value of it is a list. `view_datas` needs to extend this list rather than append it.