### PR TITLE
Change default port of the Jaeger agent

### DIFF
--- a/opencensus/trace/exporters/jaeger_exporter.py
+++ b/opencensus/trace/exporters/jaeger_exporter.py
@@ -28,7 +28,7 @@ from opencensus.trace.exporters.gen.jaeger import agent, jaeger
 from opencensus.trace.exporters.transports import sync
 
 DEFAULT_HOST_NAME = 'localhost'
-DEFAULT_AGENT_PORT = 6931
+DEFAULT_AGENT_PORT = 6831
 DEFAULT_ENDPOINT = '/api/traces?format=jaeger.thrift'
 
 ISO_DATETIME_REGEX = '%Y-%m-%dT%H:%M:%S.%fZ'

--- a/tests/unit/trace/exporters/test_jaeger_exporter.py
+++ b/tests/unit/trace/exporters/test_jaeger_exporter.py
@@ -27,8 +27,8 @@ class TestJaegerExporter(unittest.TestCase):
         service_name = 'my_service'
         host_name = 'localhost'
         thrift_port = None
-        agent_port = 6931
-        agent_address = ('localhost', 6931)
+        agent_port = 6831
+        agent_address = ('localhost', 6831)
         max_packet_size = 65000
         exporter = jaeger_exporter.JaegerExporter()
         agent_client = exporter.agent_client


### PR DESCRIPTION
According to the Jaeger [documentation](https://www.jaegertracing.io/docs/getting-started/), default port is *6831*.

In the [golang version](https://github.com/census-instrumentation/opencensus-go/blob/master/exporter/jaeger/jaeger.go#L43), *6831* is documented.