### PR TITLE
Add a Hello World stats example.

### DIFF
--- a/examples/stats/helloworld/main.py
+++ b/examples/stats/helloworld/main.py
@@ -1,0 +1,69 @@
+# Copyright 2018, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import random
+import time
+
+from opencensus.stats import aggregation as aggregation_module
+from opencensus.stats import measure as measure_module
+from opencensus.stats import stats as stats_module
+# from opencensus.stats import view_manager as view_manager_module
+# from opencensus.stats import stats_recorder as stats_recorder_module
+from opencensus.stats import view as view_module
+from opencensus.tags import tag_key as tag_key_module
+from opencensus.tags import tag_map as tag_map_module
+from opencensus.tags import tag_value as tag_value_module
+
+MiB = 1 << 20
+FRONTEND_KEY = tag_key_module.TagKey("my.org/keys/frontend")
+VIDEO_SIZE_MEASURE = measure_module.MeasureInt(
+    "my.org/measure/video_size", "size of processed videos", "By")
+VIDEO_SIZE_VIEW_NAME = "my.org/views/video_size"
+VIDEO_SIZE_DISTRIBUTION = aggregation_module.DistributionAggregation(
+    [0.0, 16.0 * MiB, 256.0 * MiB])
+VIDEO_SIZE_VIEW = view_module.View(VIDEO_SIZE_VIEW_NAME,
+                                   "processed video size over time",
+                                   [FRONTEND_KEY],
+                                   VIDEO_SIZE_MEASURE,
+                                   VIDEO_SIZE_DISTRIBUTION)
+
+
+def main():
+    stats = stats_module.Stats()
+    view_manager = stats.view_manager
+    stats_recorder = stats.stats_recorder
+    # view_manager = view_manager_module.ViewManager()
+    # stats_recorder = stats_recorder_module.StatsRecorder(view_manager.measure_to_view_map)
+
+    # Register view.
+    view_manager.register_view(VIDEO_SIZE_VIEW)
+
+    # Sleep for [0, 10] milliseconds to fake work.
+    time.sleep(random.randint(1, 10) / 1000.0)
+
+    # Process video.
+    # Record the processed video size.
+    tag_value = tag_value_module.TagValue("mobile-ios9.3.5")
+    tag_map = tag_map_module.TagMap().insert(FRONTEND_KEY, tag_value)
+    measure_map = stats_recorder.new_measurement_map()
+    measure_map.measure_int_put(VIDEO_SIZE_MEASURE, 25 * MiB)
+    measure_map.record(tag_map)
+
+    # Get aggregated stats and print it to console.
+    view_data = view_manager.get_view(VIDEO_SIZE_VIEW_NAME)
+    print(view_data)  # TODO: print more meaningful info for view_data
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/stats/helloworld/main.py
+++ b/examples/stats/helloworld/main.py
@@ -18,8 +18,6 @@ import time
 from opencensus.stats import aggregation as aggregation_module
 from opencensus.stats import measure as measure_module
 from opencensus.stats import stats as stats_module
-# from opencensus.stats import view_manager as view_manager_module
-# from opencensus.stats import stats_recorder as stats_recorder_module
 from opencensus.stats import view as view_module
 from opencensus.tags import tag_key as tag_key_module
 from opencensus.tags import tag_map as tag_map_module
@@ -43,8 +41,6 @@ def main():
     stats = stats_module.Stats()
     view_manager = stats.view_manager
     stats_recorder = stats.stats_recorder
-    # view_manager = view_manager_module.ViewManager()
-    # stats_recorder = stats_recorder_module.StatsRecorder(view_manager.measure_to_view_map)
 
     # Register view.
     view_manager.register_view(VIDEO_SIZE_VIEW)


### PR DESCRIPTION
Hello world stats example in Python, similar to [Java](https://github.com/census-instrumentation/opencensus-java/blob/master/examples/src/main/java/io/opencensus/examples/helloworld/QuickStart.java), [C++](https://github.com/census-instrumentation/opencensus-cpp/blob/master/examples/helloworld/helloworld.cc) and [Go](https://github.com/census-instrumentation/opencensus-go/blob/master/examples/helloworld/main.go).

Demonstrate:
1. defines `Measure`, `TagKey` and `View`;
2. registers a `View`;
3. records stats against a `Measure`;
4. gets stats (i.e `ViewData`) for a `View`.

This could also be used as an E2E test for stats implementation. I've found a few bugs (https://github.com/census-instrumentation/opencensus-python/pull/183, https://github.com/census-instrumentation/opencensus-python/pull/184, https://github.com/census-instrumentation/opencensus-python/issues/191, https://github.com/census-instrumentation/opencensus-python/issues/190). Please keep updating the Stats implementation until this example produces similar output to examples in other language (e.g [Java](https://opencensus.io/java.html)).
