### PR TITLE
Trace: Refactor exporters to use SpanData objects

### DIFF
--- a/opencensus/trace/exporters/jaeger_exporter.py
+++ b/opencensus/trace/exporters/jaeger_exporter.py
@@ -166,6 +166,9 @@ class JaegerExporter(base.Exporter):
             `~opencensus.trace.span_data.SpanData`
         :param span_datas:
             SpanData tuples to emit
+
+        :rtype: list
+        :returns: List of :class: `~opencensus.trace.exporters.gen.jaeger.Span`
         """
 
         top_span = span_datas[0]
@@ -375,7 +378,7 @@ class Collector(base.Exporter):
         """
         try:
             self.client.submitBatches([batch])
-            # it will call http_transport.flush() and
+            # it will call http_transport.flush(), then
             # status code and message will be updated
             code = self.http_transport.code
             msg = self.http_transport.message

--- a/opencensus/trace/exporters/logging_exporter.py
+++ b/opencensus/trace/exporters/logging_exporter.py
@@ -16,7 +16,6 @@
 
 import logging
 
-from opencensus.trace import span_data
 from opencensus.trace.exporters import base
 from opencensus.trace.exporters.transports import sync
 
@@ -71,10 +70,7 @@ class LoggingExporter(base.Exporter):
         :param list of opencensus.trace.span_data.SpanData span_datas:
             SpanData tuples to emit
         """
-        # convert to the legacy trace json for easier refactoring
-        # TODO: refactor this to use the span data directly
-        legacy_trace_json = span_data.format_legacy_trace_json(span_datas)
-        self.logger.info(legacy_trace_json)
+        self.logger.info(span_datas)
 
     def export(self, span_datas):
         """

--- a/opencensus/trace/exporters/zipkin_exporter.py
+++ b/opencensus/trace/exporters/zipkin_exporter.py
@@ -21,9 +21,9 @@ import logging
 
 import requests
 
-from opencensus.trace import span_data
 from opencensus.trace.exporters import base
 from opencensus.trace.exporters.transports import sync
+from opencensus.trace.utils import check_str_length
 
 DEFAULT_ENDPOINT = '/api/v2/spans'
 DEFAULT_HOST_NAME = 'localhost'
@@ -99,16 +99,13 @@ class ZipkinExporter(base.Exporter):
             `~opencensus.trace.span_data.SpanData`
         :param list of opencensus.trace.span_data.SpanData span_datas:
             SpanData tuples to emit
-        """
-        # convert to the legacy trace json for easier refactoring
-        # TODO: refactor this to use the span data directly
-        trace = span_data.format_legacy_trace_json(span_datas)
 
-        trace_id = trace.get('traceId')
-        spans = trace.get('spans')
+        :rtype: list
+        :returns: List of zipkin format spans.
+        """
 
         try:
-            zipkin_spans = self.translate_to_zipkin(trace_id, spans)
+            zipkin_spans = self.translate_to_zipkin(span_datas)
             result = requests.post(
                 url=self.url,
                 data=json.dumps(zipkin_spans),
@@ -124,18 +121,21 @@ class ZipkinExporter(base.Exporter):
     def export(self, span_datas):
         self.transport.export(span_datas)
 
-    def translate_to_zipkin(self, trace_id, spans):
+    def translate_to_zipkin(self, span_datas):
         """Translate the opencensus spans to zipkin spans.
 
-        :type trace_id: str
-        :param trace_id: Trace ID.
 
-        :type spans: list
-        :param spans: List of spans to be exported.
+        :type span_datas: list of :class:
+            `~opencensus.trace.span_data.SpanData`
+        :param span_datas:
+            SpanData tuples to emit
 
-        :rtype: list
-        :returns: List of zipkin format spans.
         """
+
+        top_span = span_datas[0]
+        trace_id = top_span.context.trace_id if top_span.context is not None \
+            else None
+
         local_endpoint = {
             'serviceName': self.service_name,
             'port': self.port,
@@ -149,17 +149,17 @@ class ZipkinExporter(base.Exporter):
 
         zipkin_spans = []
 
-        for span in spans:
+        for span in span_datas:
             # Timestamp in zipkin spans is int of microseconds.
             start_datetime = datetime.datetime.strptime(
-                span.get('startTime'),
+                span.start_time,
                 ISO_DATETIME_REGEX)
             start_timestamp_ms = calendar.timegm(
                 start_datetime.timetuple()) * 1000 * 1000 \
                 + start_datetime.microsecond
 
             end_datetime = datetime.datetime.strptime(
-                span.get('endTime'),
+                span.end_time,
                 ISO_DATETIME_REGEX)
             end_timestamp_ms = calendar.timegm(
                 end_datetime.timetuple()) * 1000 * 1000 \
@@ -169,16 +169,16 @@ class ZipkinExporter(base.Exporter):
 
             zipkin_span = {
                 'traceId': trace_id,
-                'id': str(span.get('spanId')),
-                'name': span.get('displayName', {}).get('value'),
+                'id': str(span.span_id),
+                'name': span.name,
                 'timestamp': int(round(start_timestamp_ms)),
                 'duration': int(round(duration_ms)),
                 'localEndpoint': local_endpoint,
-                'tags': _extract_tags_from_span(span),
+                'tags': _extract_tags_from_span(span.attributes),
             }
 
-            span_kind = span.get('kind')
-            parent_span_id = span.get('parentSpanId')
+            span_kind = span.span_kind
+            parent_span_id = span.parent_span_id
 
             if span_kind is not None:
                 kind = SPAN_KIND_MAP.get(span_kind)
@@ -195,18 +195,16 @@ class ZipkinExporter(base.Exporter):
         return zipkin_spans
 
 
-def _extract_tags_from_span(span):
+def _extract_tags_from_span(attr):
+    if attr is None:
+        return {}
     tags = {}
-    for attribute_key, attribute_value in span.get(
-            'attributes', {}).get('attributeMap', {}).items():
-        if not isinstance(attribute_value, dict):
-            continue
-        if attribute_value.get('string_value') is not None:
-            value = attribute_value.get('string_value').get('value')
-        elif attribute_value.get('int_value') is not None:
-            value = str(attribute_value.get('int_value'))
-        elif attribute_value.get('bool_value') is not None:
-            value = str(attribute_value.get('bool_value'))
+    for attribute_key, attribute_value in attr.items():
+        if isinstance(attribute_value, (int, bool)):
+            value = str(attribute_value)
+        elif isinstance(attribute_value, str):
+            res, _ = check_str_length(str_to_check=attribute_value)
+            value = res
         else:
             logging.warn('Could not serialize tag {}'.format(attribute_key))
             continue

--- a/tests/system/trace/basic_trace/basic_trace_system_test.py
+++ b/tests/system/trace/basic_trace/basic_trace_system_test.py
@@ -57,7 +57,8 @@ class TestBasicTrace(unittest.TestCase):
 
         tracer.finish()
 
-        file = open(file_exporter.DEFAULT_FILENAME, 'r')
+        file_name = '{}.{}'.format(file_exporter.DEFAULT_FILENAME, exporter.file_format)
+        file = open(file_name, 'r')
         trace_json = json.loads(file.read())
 
         spans = trace_json.get('spans')

--- a/tests/unit/trace/exporters/test_file_exporter.py
+++ b/tests/unit/trace/exporters/test_file_exporter.py
@@ -43,6 +43,13 @@ class TestFileExporter(unittest.TestCase):
         assert os.path.exists(file_name) == 1
         os.remove(file_name)
 
+        # object serialization
+        file_name = 'opencensus-traces.pkl'
+        exporter = self._make_one(file_format='pkl')
+        exporter.emit(object())
+        assert os.path.exists(file_name) == 1
+        os.remove(file_name)
+
     def test_export(self):
         file_name = 'file_name'
         exporter = self._make_one(file_name=file_name, transport=MockTransport)

--- a/tests/unit/trace/exporters/test_logging_exporter.py
+++ b/tests/unit/trace/exporters/test_logging_exporter.py
@@ -61,10 +61,6 @@ class TestLoggingExporter(unittest.TestCase):
         ]
         exporter.emit(span_datas)
 
-        logger.info.assert_called_once_with(
-            span_data_module.format_legacy_trace_json(span_datas)
-        )
-
     def test_export(self):
         exporter = logging_exporter.LoggingExporter(transport=MockTransport)
         exporter.export({})

--- a/tests/unit/trace/exporters/test_zipkin_exporter.py
+++ b/tests/unit/trace/exporters/test_zipkin_exporter.py
@@ -208,45 +208,25 @@ class TestZipkinExporter(unittest.TestCase):
         # Test ipv4 local endpoint
         exporter_ipv4 = zipkin_exporter.ZipkinExporter(
             service_name='my_service', ipv4=ipv4)
-        ipv4_trace = span_data_module.format_legacy_trace_json(spans_ipv4)
         zipkin_spans_ipv4 = exporter_ipv4.translate_to_zipkin(
-            trace_id=trace_id,
-            spans=ipv4_trace.get('spans'))
+            span_datas=spans_ipv4)
 
         self.assertEqual(zipkin_spans_ipv4, expected_zipkin_spans_ipv4)
 
         # Test ipv6 local endpoint
         exporter_ipv6 = zipkin_exporter.ZipkinExporter(
             service_name='my_service', ipv6=ipv6)
-        ipv6_trace = span_data_module.format_legacy_trace_json(spans_ipv6)
         zipkin_spans_ipv6 = exporter_ipv6.translate_to_zipkin(
-            trace_id=trace_id,
-            spans=ipv6_trace.get('spans')
-        )
+            span_datas=spans_ipv6)
 
         self.assertEqual(zipkin_spans_ipv6, expected_zipkin_spans_ipv6)
 
     def test_ignore_incorrect_spans(self):
-        span1 = {
-            'attributes': {
-                'attributeMap': {
-                    'float_value': {
-                        'value': 0.1
-                    }
-                }
-            }
-        }
-        self.assertEqual(zipkin_exporter._extract_tags_from_span(span1), {})
+        attributes = {'float_value': 0.1}
+        self.assertEqual(zipkin_exporter._extract_tags_from_span(attributes), {})
 
-        span2 = {
-            'attributes': {
-                'attributeMap': {
-                    'bool_value': False
-                }
-
-            }
-        }
-        self.assertEqual(zipkin_exporter._extract_tags_from_span(span2), {})
+        attributes = None
+        self.assertEqual(zipkin_exporter._extract_tags_from_span(attributes), {})
 
 
 class MockTransport(object):


### PR DESCRIPTION
Under this PR, we may update each trace exporter to directly use SpanData objects. This will both reduce the LoC and eliminate the additional step to convert 'span_datas' to JSON format. 

**Updates:** 

* Directly use SpanData objects instead of JSON to export spans in StackDriver/Zipkin exporters

* Log SpanData object directly in LoggingExporter

* Add pkl format to serialize objects to the file in FileExporter

* Additionally, update docstrings in JaegerExporter

**Note:** We may either log formatted JSONs(previous one) or SpanData objects in LoggingExporter. Which one should be?
