### PR TITLE
Update Readme to use OPENCENSUS_TRACE.EXPORTER

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -234,7 +234,7 @@ You can configure the sampler, exporter, propagator using the ``OPENCENSUS_TRACE
 
     OPENCENSUS_TRACE = {
         'SAMPLER': 'opencensus.trace.samplers.probability.ProbabilitySampler',
-        'REPORTER': 'opencensus.trace.exporters.print_exporter.PrintExporter',
+        'EXPORTER': 'opencensus.trace.exporters.print_exporter.PrintExporter',
         'PROPAGATOR': 'opencensus.trace.propagation.google_cloud_format.'
                       'GoogleCloudFormatPropagator',
     }


### PR DESCRIPTION
Trivial documentation update. It looks like OPENCENSUS_TRACE.REPORTER is an old thing. As per https://github.com/census-instrumentation/opencensus-python/blob/master/opencensus/trace/ext/django/config.py#L22