### PR TITLE
Fix jaeger_exporter to properly handle root spans and timestamps

### DIFF
--- a/opencensus/trace/exporters/jaeger_exporter.py
+++ b/opencensus/trace/exporters/jaeger_exporter.py
@@ -178,11 +178,15 @@ class JaegerExporter(base.Exporter):
         for span in span_datas:
             start_datetime = datetime.datetime.strptime(
                 span.start_time, ISO_DATETIME_REGEX)
-            start_microsec = calendar.timegm(start_datetime.timetuple()) * 1000
+            start_microsec = calendar.timegm(start_datetime.timetuple()) \
+                * 1e6 \
+                + start_datetime.microsecond
 
             end_datetime = datetime.datetime.strptime(
                 span.end_time, ISO_DATETIME_REGEX)
-            end_microsec = calendar.timegm(end_datetime.timetuple()) * 1000
+            end_microsec = calendar.timegm(end_datetime.timetuple()) \
+                * 1e6 \
+                + end_datetime.microsecond
 
             duration_microsec = end_microsec - start_microsec
 
@@ -222,7 +226,7 @@ class JaegerExporter(base.Exporter):
                 logs=logs,
                 references=refs,
                 flags=flags,
-                parentSpanId=_convert_hex_str_to_int(parent_span_id))
+                parentSpanId=_convert_hex_str_to_int(parent_span_id or '0'))
 
             jaeger_spans.append(jaeger_span)
 

--- a/tests/unit/trace/exporters/test_jaeger_exporter.py
+++ b/tests/unit/trace/exporters/test_jaeger_exporter.py
@@ -269,8 +269,8 @@ class TestJaegerExporter(unittest.TestCase):
                 spanId=7929822056569588882,
                 parentSpanId=1229782938247303441,
                 operationName='test1',
-                startTime=1502820146000,
-                duration=10000,
+                startTime=1502820146071158,
+                duration=10000000,
                 flags=1,
                 tags=[
                     jaeger.Tag(
@@ -331,8 +331,9 @@ class TestJaegerExporter(unittest.TestCase):
                 traceIdHigh=1846305573,
                 traceIdLow=2112048274,
                 spanId=7929822056569588882,
-                startTime=1502820146000,
-                duration=10000)
+                parentSpanId=0,
+                startTime=1502820146071158,
+                duration=10000000)
         ]
 
         spans_json = [span.format_span_json() for span in spans]
@@ -372,6 +373,7 @@ class TestJaegerExporter(unittest.TestCase):
         jaeger_exporter._convert_hex_str_to_int(invalid_id)
         valid_id = '290c63257de34c92'
         jaeger_exporter._convert_hex_str_to_int(valid_id)
+        self.assertIsNone(jaeger_exporter._convert_hex_str_to_int(None))
 
 
 class MockBatch(object):


### PR DESCRIPTION
Currently exporting to jaeger doesn't work due to two problems:
1. root span has a null parent id, therefore thirft message sent
by jaeger_exporter.Collector to jaeger results in silent failure to
deserialize as parent span id is unset but is a required field.

2. It constructed start/end timestamp with second precision expanded to
milisecond units. Spec requires them to be expanded to microseconds

This PR fixes:
1. by setting parent_span_id to 0 (per jaeger docs) if missing.

2. by expanding timestamp to microsecond precision by multiplying it by
1e6 instead of 1e3 and adding dt.microseconds. This mirrors existing
implementation in zipkin exporter

Fixes: #185