### PR TITLE
Store fake Tracer when parent_span is None

### DIFF
--- a/opencensus/trace/span.py
+++ b/opencensus/trace/span.py
@@ -114,7 +114,6 @@ class Span(object):
             context_tracer=None,
             span_kind=SpanKind.UNSPECIFIED):
         self.name = name
-        self.parent_span = parent_span
         self.start_time = start_time
         self.end_time = end_time
 
@@ -128,6 +127,7 @@ class Span(object):
         # make sure to use the Tracer.
         if parent_span is None:
             parent_span = base.NullContextManager()
+        self.parent_span = parent_span
 
         if time_events is None:
             time_events = []


### PR DESCRIPTION
Right now, the code checks if parent_span is None only after it's stored.
Either the checks runs when it's too late or  it's not needed in the first place. Assume the former.