### PR TITLE
[WIP] feature: asyncio support

### DIFF
--- a/examples/trace/helloworld-async/main.py
+++ b/examples/trace/helloworld-async/main.py
@@ -1,0 +1,70 @@
+# This is just here for me to test
+
+from sanic import Sanic
+from sanic.response import json
+from opencensus.trace.exporters import jaeger_exporter
+from opencensus.trace.ext.aiohttp.trace import trace_integration as aiohttp_integration
+from opencensus.trace.ext.aioredis.trace import trace_integration as aioredis_integration
+from opencensus.trace.ext.sanic.sanic_middleware import SanicMiddleware
+from opencensus.trace.propagation import jaeger_format
+from opencensus.trace.samplers import probability
+from opencensus.trace import asyncio_context
+
+import asyncio
+import aiotask_context as context
+import aiohttp
+import aioredis
+
+
+loop = asyncio.get_event_loop()
+loop.set_task_factory(context.task_factory)
+
+sampler = probability.ProbabilitySampler(rate=0.5)
+propagator = jaeger_format.JaegerFormatPropagator()
+exporter = jaeger_exporter.JaegerExporter(service_name="recs")
+
+# These uses the tracer from the async context
+aiohttp_integration(propagator=propagator)
+aioredis_integration()
+
+
+app = Sanic()
+middleware = SanicMiddleware(
+                app,
+                sampler=sampler,
+                exporter=exporter,
+                propagator=propagator)
+
+
+@app.route('/')
+async def root(req):
+    tracer = asyncio_context.get_opencensus_tracer()
+    with tracer.span(name='span1'):
+        with tracer.span(name='span2'):
+            async with aiohttp.ClientSession() as session:
+                async with session.get("https://slashdot.org") as response:
+                    print(response)
+                    conn = await aioredis.create_connection(
+                               'redis://localhost', loop=loop)
+                    await conn.execute('set', 'foo', 'value')
+                    val = await conn.get('foo')
+                    print(val)
+                    conn.close()
+                    await conn.wait_closed()
+                    return json({"hello": "world"})
+
+
+def main():
+    server = app.create_server(host='0.0.0.0', port=8080)
+    loop = asyncio.get_event_loop()
+    loop.set_task_factory(context.task_factory)
+    asyncio.ensure_future(server)
+    try:
+        loop.run_forever()
+    except SanicException as err:
+        print(err)
+        loop.stop()
+
+
+if __name__ == '__main__':
+    main()

--- a/opencensus/trace/asyncio_context.py
+++ b/opencensus/trace/asyncio_context.py
@@ -1,0 +1,56 @@
+# Copyright 2017, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import aiotask_context as context
+
+from opencensus.trace.tracers import noop_tracer
+
+_TRACER_KEY = 'opencensus.io/trace'
+_ATTRS_KEY = 'opencensus.io/attrs'
+_CURRENT_SPAN_KEY = 'opencensus.io/current-span'
+
+
+def get_opencensus_tracer():
+    return context.get(_TRACER_KEY, default=noop_tracer.NoopTracer())
+
+
+def set_opencensus_tracer(tracer):
+    """Add the tracer to thread local."""
+    context.set(key=_TRACER_KEY, value=tracer)
+
+
+def set_opencensus_attr(attr_key, attr_value):
+    attrs = context.get(_ATTRS_KEY, {})
+    attrs[_ATTRS_KEY] = attr_value
+    context.set(key=_ATTRS_KEY, value=attrs)
+
+
+def get_opencensus_attr(attr_key):
+    attrs = context.get(_ATTRS_KEY, None)
+    if attrs is not None:
+        return attrs.get(_ATTRS_KEY)
+    return None
+
+
+def get_current_span():
+    return context.get(_CURRENT_SPAN_KEY, None)
+
+
+def set_current_span(current_span):
+    context.set(key=_CURRENT_SPAN_KEY, value=current_span)
+
+
+def clear():
+    """Clear the thread local, used in test."""
+    context.clear()

--- a/opencensus/trace/ext/aiohttp/__init__.py
+++ b/opencensus/trace/ext/aiohttp/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2017, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from opencensus.trace.ext.requests import trace
+
+__all__ = ['trace']

--- a/opencensus/trace/ext/aiohttp/trace.py
+++ b/opencensus/trace/ext/aiohttp/trace.py
@@ -1,0 +1,58 @@
+# Copyright 2017, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import aiohttp
+
+from opencensus.trace import asyncio_context
+
+log = logging.getLogger(__name__)
+
+MODULE_NAME = 'aiohttp'
+
+
+def trace_integration(tracer=None, propagator=None):
+    """Wrap the requests library to trace it."""
+    log.info('Integrated module: {}'.format(MODULE_NAME))
+    # Wrap the aiohttp functions
+    aiohttp_func = getattr(aiohttp.ClientSession, '__init__')
+    wrapped = wrap_aiohttp(aiohttp_func)
+    setattr(aiohttp.ClientSession, aiohttp_func.__name__, wrapped)
+
+
+def wrap_aiohttp(aiohttp_func):
+    """Wrap the aiohttp function to trace it."""
+    def call(*args, **kwargs):
+        async def on_request_start(session, context, params):
+            _tracer = asyncio_context.get_opencensus_tracer()
+            _span = _tracer.start_span()
+            _span.name = '[aiohttp]{}'.format(params.method)
+            _tracer.add_attribute_to_current_span('aiohttp/url', params.url)
+            return
+
+        async def on_request_end(session, context, params):
+            _tracer = asyncio_context.get_opencensus_tracer()
+            _tracer.add_attribute_to_current_span(
+                'aiohttp/status_code', str(params.response.status))
+            _tracer.end_span()
+            return
+
+        trace_config = aiohttp.TraceConfig()
+        trace_config.on_request_start.append(on_request_start)
+        trace_config.on_request_end.append(on_request_end)
+        kwargs['trace_configs'] = [trace_config]
+
+        return aiohttp_func(*args, **kwargs)
+
+    return call

--- a/opencensus/trace/ext/aioredis/__init__.py
+++ b/opencensus/trace/ext/aioredis/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2017, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from opencensus.trace.ext.requests import trace
+
+__all__ = ['trace']

--- a/opencensus/trace/ext/aioredis/trace.py
+++ b/opencensus/trace/ext/aioredis/trace.py
@@ -1,0 +1,46 @@
+# Copyright 2017, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import aioredis
+import wrapt
+
+from opencensus.trace import asyncio_context
+
+log = logging.getLogger(__name__)
+
+MODULE_NAME = 'aioredis'
+
+CONNECTION_WRAP_METHODS = 'execute'
+CONNECTION_CLASS_NAME = 'RedisConnection'
+
+
+def trace_integration(tracer=None):
+    # Wrap Session class
+    wrapt.wrap_function_wrapper(
+        MODULE_NAME, 'RedisConnection.execute', wrap_execute)
+
+
+async def wrap_execute(wrapped, instance, args, kwargs):
+    """Wrap the session function to trace it."""
+    command = args[0]
+    _tracer = execution_context.get_opencensus_tracer()
+    _span = _tracer.start_span()
+    _span.name = '[aioredis]{}'.format(command)
+
+    # Add the requests url to attributes
+    result = await wrapped(*args, **kwargs)
+
+    _tracer.end_span()
+    return result

--- a/opencensus/trace/ext/sanic/sanic_middleware.py
+++ b/opencensus/trace/ext/sanic/sanic_middleware.py
@@ -1,0 +1,241 @@
+# Copyright 2017, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+import logging
+import sys
+
+from sanic.exceptions import SanicException
+
+from google.rpc import code_pb2
+
+from opencensus.trace import attributes_helper
+from opencensus.trace import asyncio_context
+from opencensus.trace import stack_trace
+from opencensus.trace import status
+from opencensus.trace.tracers import asyncio_context_tracer as tracer_module
+from opencensus.trace.exporters import print_exporter
+from opencensus.trace.exporters.transports import sync
+from opencensus.trace.ext import utils
+from opencensus.trace.propagation import google_cloud_format
+from opencensus.trace.samplers import always_on, probability
+
+
+_SANIC_TRACE_HEADER = 'X_CLOUD_TRACE_CONTEXT'
+
+HTTP_METHOD = attributes_helper.COMMON_ATTRIBUTES['HTTP_METHOD']
+HTTP_URL = attributes_helper.COMMON_ATTRIBUTES['HTTP_URL']
+HTTP_STATUS_CODE = attributes_helper.COMMON_ATTRIBUTES['HTTP_STATUS_CODE']
+
+BLACKLIST_PATHS = 'BLACKLIST_PATHS'
+GCP_EXPORTER_PROJECT = 'GCP_EXPORTER_PROJECT'
+SAMPLING_RATE = 'SAMPLING_RATE'
+TRANSPORT = 'TRANSPORT'
+ZIPKIN_EXPORTER_SERVICE_NAME = 'ZIPKIN_EXPORTER_SERVICE_NAME'
+ZIPKIN_EXPORTER_HOST_NAME = 'ZIPKIN_EXPORTER_HOST_NAME'
+ZIPKIN_EXPORTER_PORT = 'ZIPKIN_EXPORTER_PORT'
+
+log = logging.getLogger(__name__)
+
+
+class SanicMiddleware(object):
+    DEFAULT_SAMPLER = always_on.AlwaysOnSampler
+    DEFAULT_EXPORTER = print_exporter.PrintExporter
+    DEFAULT_PROPAGATOR = google_cloud_format.GoogleCloudFormatPropagator
+
+    """sanic middleware to automatically trace requests.
+
+    :type app: :class: `~sanic.sanic`
+    :param app: A sanic application.
+
+    :type blacklist_paths: list
+    :param blacklist_paths: Paths that do not trace.
+
+    :type sampler: :class: `type`
+    :param sampler: Class for creating new Sampler objects. It should extend
+                    from the base :class:`.Sampler` type and implement
+                    :meth:`.Sampler.should_sample`. Defaults to
+                    :class:`.AlwaysOnSampler`. The rest options are
+                    :class:`.AlwaysOffSampler`, :class:`.FixedRateSampler`.
+
+    :type exporter: :class: `type`
+    :param exporter: Class for creating new exporter objects. Default to
+                     :class:`.PrintExporter`. The rest option is
+                     :class:`.FileExporter`.
+
+    :type propagator: :class: 'type'
+    :param propagator: Class for creating new propagator objects. Default to
+                       :class:`.GoogleCloudFormatPropagator`. The rest option
+                       are :class:`.BinaryFormatPropagator`,
+                       :class:`.TextFormatPropagator` and
+                       :class:`.TraceContextPropagator`.
+    """
+    def __init__(self, app=None, blacklist_paths=None, sampler=None,
+                 exporter=None, propagator=None):
+        self.app = app
+        self.blacklist_paths = blacklist_paths
+        self.sampler = sampler
+        self.exporter = exporter
+        self.propagator = propagator
+
+        if self.app is not None:
+            self.init_app(app)
+
+    def init_app(self, app):
+        self.app = app
+
+        # get settings from app config
+        settings = self.app.config.get('OPENCENSUS_TRACE', {})
+
+        self.sampler = (self.sampler
+                        or settings.get('SAMPLER',
+                                        self.DEFAULT_SAMPLER))
+        self.exporter = (self.exporter
+                         or settings.get('EXPORTER',
+                                         self.DEFAULT_EXPORTER))
+        self.propagator = (self.propagator
+                           or settings.get('PROPAGATOR',
+                                           self.DEFAULT_PROPAGATOR))
+
+        # get params from app config
+        params = self.app.config.get('OPENCENSUS_TRACE_PARAMS', {})
+
+        self.blacklist_paths = params.get(BLACKLIST_PATHS,
+                                          self.blacklist_paths)
+
+        # Initialize the sampler
+        if not inspect.isclass(self.sampler):
+            pass  # handling of instantiated sampler
+        elif self.sampler.__name__ == 'ProbabilitySampler':
+            _rate = params.get(SAMPLING_RATE,
+                               probability.DEFAULT_SAMPLING_RATE)
+            self.sampler = self.sampler(_rate)
+        else:
+            self.sampler = self.sampler()
+
+        transport = params.get(TRANSPORT, sync.SyncTransport)
+
+        # Initialize the exporter
+        if not inspect.isclass(self.exporter):
+            pass  # handling of instantiated exporter
+        elif self.exporter.__name__ == 'StackdriverExporter':
+            _project_id = params.get(GCP_EXPORTER_PROJECT, None)
+            self.exporter = self.exporter(
+                project_id=_project_id,
+                transport=transport)
+        elif self.exporter.__name__ == 'ZipkinExporter':
+            _zipkin_service_name = params.get(
+                ZIPKIN_EXPORTER_SERVICE_NAME, 'my_service')
+            _zipkin_host_name = params.get(
+                ZIPKIN_EXPORTER_HOST_NAME, 'localhost')
+            _zipkin_port = params.get(
+                ZIPKIN_EXPORTER_PORT, 9411)
+            self.exporter = self.exporter(
+                service_name=_zipkin_service_name,
+                host_name=_zipkin_host_name,
+                port=_zipkin_port,
+                transport=transport)
+        else:
+            self.exporter = self.exporter(transport=transport)
+
+        # Initialize the propagator
+        if inspect.isclass(self.propagator):
+            self.propagator = self.propagator()
+
+        @app.middleware('request')
+        async def trace_request(request):
+            self.do_trace_request(request)
+
+        @app.middleware('response')
+        async def trace_response(request, response):
+            self.do_trace_response(request, response)
+
+        @app.exception(SanicException)
+        async def trace_exception(request, exception):
+            self.do_trace_exception(request, exception)
+
+    def do_trace_request(self, request):
+        if utils.disable_tracing_url(request.url, self.blacklist_paths):
+            return
+
+        try:
+            span_context = self.propagator.from_headers(request.headers)
+            print("span_context: . ${}", span_context)
+
+#            tracer = tracer_module.Tracer(
+#                span_context=span_context,
+#                exporter=self.exporter,
+#                propagator=self.propagator)
+
+            tracer = tracer_module.ContextTracer(
+                span_context=span_context,
+                exporter=self.exporter)
+
+            span = tracer.start_span()
+
+            # Set the span name as the name of the current module name
+            span.name = '[{}]{}'.format(
+                request.method,
+                request.url)
+            tracer.add_attribute_to_current_span(
+                HTTP_METHOD, request.method)
+            tracer.add_attribute_to_current_span(HTTP_URL, request.url)
+            asyncio_context.set_opencensus_tracer(tracer)
+        except Exception:  # pragma: NO COVER
+            log.error('Failed to trace request', exc_info=True)
+
+    def do_trace_response(self, request, response):
+        """A function to be run after each request.
+        """
+        # Do not trace if the url is blacklisted
+        if utils.disable_tracing_url(request.url, self.blacklist_paths):
+            return response
+
+        try:
+            tracer = asyncio_context.get_opencensus_tracer()
+            tracer.add_attribute_to_current_span(
+                HTTP_STATUS_CODE,
+                str(response.status))
+            tracer.end_span()
+            tracer.finish()
+        except Exception:  # pragma: NO COVER
+            log.error('Failed to trace request', exc_info=True)
+
+    def do_trace_exception(self, request, exception):
+        # Do not trace if the url is blacklisted
+        if utils.disable_tracing_url(request.url, self.blacklist_paths):
+            return
+
+        try:
+            tracer = asyncio_context.get_opencensus_tracer()
+
+            if exception is not None:
+                span = asyncio_context.get_current_span()
+                span.status = status.Status(
+                    code=code_pb2.UNKNOWN,
+                    message=str(exception)
+                )
+                # try attaching the stack trace to the span, only populated if
+                # the app has 'PROPAGATE_EXCEPTIONS', 'DEBUG', or 'TESTING'
+                # enabled
+                exc_type, _, exc_traceback = sys.exc_info()
+                if exc_traceback is not None:
+                    span.stack_trace = stack_trace.StackTrace.from_traceback(
+                        exc_traceback
+                    )
+
+            tracer.end_span()
+            tracer.finish()
+        except Exception:  # pragma: NO COVER
+            log.error('Failed to trace request', exc_info=True)

--- a/opencensus/trace/tracers/asyncio_context_tracer.py
+++ b/opencensus/trace/tracers/asyncio_context_tracer.py
@@ -1,0 +1,174 @@
+# Copyright 2017, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from opencensus.trace import asyncio_context
+from opencensus.trace.span_context import SpanContext
+from opencensus.trace import span as trace_span
+from opencensus.trace import span_data as span_data_module
+from opencensus.trace.exporters import print_exporter
+from opencensus.trace.tracers import base
+
+
+class ContextTracer(base.Tracer):
+    """The interface for tracing a request context.
+
+    :type span_context: :class:`~opencensus.trace.span_context.SpanContext`
+    :param span_context: SpanContext encapsulates the current context within
+                         the request's trace.
+    """
+
+    def __init__(self, exporter=None, span_context=None):
+        if exporter is None:
+            exporter = print_exporter.PrintExporter()
+
+        if span_context is None:
+            span_context = SpanContext()
+
+        self.exporter = exporter
+        self.span_context = span_context
+        self.trace_id = span_context.trace_id
+        self.root_span_id = span_context.span_id
+
+        # List of spans to report
+        self._spans_list = []
+
+    def finish(self):
+        """Finish all spans
+
+        :rtype: dict
+        :returns: JSON format trace.
+        """
+        while self._spans_list:
+            self.end_span()
+
+    def span(self, name='span'):
+        """Create a new span with the trace using the context information.
+
+        :type name: str
+        :param name: The name of the span.
+
+        :rtype: :class:`~opencensus.trace.span.Span`
+        :returns: The Span object.
+        """
+        span = self.start_span(name=name)
+        return span
+
+    def start_span(self, name='span'):
+        """Start a span.
+
+        :type name: str
+        :param name: The name of the span.
+
+        :rtype: :class:`~opencensus.trace.span.Span`
+        :returns: The Span object.
+        """
+        parent_span = self.current_span()
+
+        # If a span has remote parent span, then the parent_span.span_id
+        # should be the span_id from the request header.
+        if parent_span is None:
+            parent_span = base.NullContextManager(
+                span_id=self.span_context.span_id)
+
+        span = trace_span.Span(
+            name,
+            parent_span=parent_span,
+            context_tracer=self)
+        self._spans_list.append(span)
+        self.span_context.span_id = span.span_id
+        asyncio_context.set_current_span(span)
+        span.start()
+        return span
+
+    def end_span(self, *args, **kwargs):
+        """End a span. Update the span_id in SpanContext to the current span's
+        parent span id; Update the current span.
+        """
+        cur_span = self.current_span()
+        if cur_span is None and self._spans_list:
+            cur_span = self._spans_list[-1]
+
+        if cur_span is None:
+            logging.warning('No active span, cannot do end_span.')
+            return
+
+        cur_span.finish()
+        self.span_context.span_id = cur_span.parent_span.span_id if \
+            cur_span.parent_span else None
+
+        if isinstance(cur_span.parent_span, trace_span.Span):
+            asyncio_context.set_current_span(cur_span.parent_span)
+        else:
+            asyncio_context.set_current_span(None)
+
+        if cur_span in self._spans_list:
+            span_datas = self.get_span_datas(cur_span)
+            self.exporter.export(span_datas)
+            self._spans_list.remove(cur_span)
+
+        return cur_span
+
+    def current_span(self):
+        """Return the current span."""
+        current_span = asyncio_context.get_current_span()
+
+        return current_span
+
+    def list_collected_spans(self):
+        return self._spans_list
+
+    def add_attribute_to_current_span(self, attribute_key, attribute_value):
+        """Add attribute to current span.
+
+        :type attribute_key: str
+        :param attribute_key: Attribute key.
+
+        :type attribute_value:str
+        :param attribute_value: Attribute value.
+        """
+        current_span = self.current_span()
+        current_span.add_attribute(attribute_key, attribute_value)
+
+    def get_span_datas(self, span):
+        """Extracts a list of SpanData tuples from a span
+
+        :rtype: list of opencensus.trace.span_data.SpanData
+        :return list of SpanData tuples
+        """
+        span_tree = list(iter(span))
+        span_datas = [
+            span_data_module.SpanData(
+                name=span.name,
+                context=self.span_context,
+                span_id=span.span_id,
+                parent_span_id=span.parent_span.span_id if
+                span.parent_span else None,
+                attributes=span.attributes,
+                start_time=span.start_time,
+                end_time=span.end_time,
+                child_span_count=len(span.children),
+                stack_trace=span.stack_trace,
+                time_events=span.time_events,
+                links=span.links,
+                status=span.status,
+                same_process_as_parent_span=span.same_process_as_parent_span,
+                span_kind=span.span_kind
+
+            )
+            for span in span_tree
+        ]
+
+        return span_datas

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,6 @@
 Django==1.11.7
 Flask==0.12.2
+aiohttp==3.3.2
 google-cloud-monitoring==0.29.0
 google-cloud-trace==0.17.0
 grpcio==1.8.3
@@ -11,6 +12,7 @@ pyramid==1.9.1
 pytest==3.2.2
 pytest-cov==2.5.1
 retrying==1.3.3
+sanic==0.7.0
 SQLAlchemy==1.1.14
 webapp2==2.5.2
 WebOb==1.7.3


### PR DESCRIPTION
This branch attempt to implement some asyncio support. The existing thread based execution context fails in programs using asyncio (per thread storage is shared amount asyncio context spans are mis-associated based on the thread code happens to run in)

This branch:
- adds basic support for asyncio
- adds an example middleware for sanic
- add example "integrations" to monkeypatch aiohttp and aioredis
- adds a simple example to show how to set things up and play with the overall API

I should probably confess that this is my first exposure to asyncio in python, and I'm not python programmer to begin with. The basics of this do seem to work for now (error handling needs tidying up).

Current concerns. it feels wrong that the sanic middleware setups up the initial tracer, rather than have it passed in, but passing it in doesn't work well either.

I've raised this mostly to get API feedback. It may be that you don't want the sanic/aiohttp/aioredis parts, but having a standard way of setting you tracing in asyncio probably does make sense to have in the core.

