### PR TITLE
Stats: Allow recording against implicit tag_map.

### DIFF
--- a/opencensus/stats/measurement_map.py
+++ b/opencensus/stats/measurement_map.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from datetime import datetime
+from opencensus.tags import execution_context
 
 
 class MeasurementMap(object):
@@ -47,8 +48,10 @@ class MeasurementMap(object):
         """associates the measure of type Float with the given value"""
         self._measurement_map[measure] = value
 
-    def record(self, tag_map_tags):
-        """records all the measures at the same time with an explicit tag_map
+    def record(self, tag_map_tags=execution_context.get_current_tag_map()):
+        """records all the measures at the same time with a tag_map.
+        tag_map could either be explicitly passed to the method, or implicitly
+        read from current execution context.
         """
         self.measure_to_view_map.record(
                 tags=tag_map_tags,

--- a/tests/unit/stats/test_measurement_map.py
+++ b/tests/unit/stats/test_measurement_map.py
@@ -16,6 +16,7 @@ import unittest
 import mock
 from opencensus.stats import measurement_map as measurement_map_module
 from opencensus.stats.measure_to_view_map import MeasureToViewMap
+from opencensus.tags import execution_context
 
 
 class TestMeasurementMap(unittest.TestCase):
@@ -49,11 +50,21 @@ class TestMeasurementMap(unittest.TestCase):
 
         self.assertEqual({'testKey': 1.0}, measurement_map.measurement_map)
 
-    def test_record(self):
+    def test_record_against_explicit_tag_map(self):
         measure_to_view_map = mock.Mock()
         measurement_map = measurement_map_module.MeasurementMap(
             measure_to_view_map=measure_to_view_map)
 
         tags = {'testtag1': 'testtag1val'}
         measurement_map.record(tag_map_tags=tags)
+        self.assertTrue(measure_to_view_map.record.called)
+
+    def test_record_against_implicit_tag_map(self):
+        measure_to_view_map = mock.Mock()
+        measurement_map = measurement_map_module.MeasurementMap(
+            measure_to_view_map=measure_to_view_map)
+
+        tags = {'testtag1': 'testtag1val'}
+        execution_context.set_current_tag_map(tags)
+        measurement_map.record()
         self.assertTrue(measure_to_view_map.record.called)


### PR DESCRIPTION
Fixes https://github.com/census-instrumentation/opencensus-python/issues/254.