### PR TITLE
Handle unicode and str in exporters for py2

### DIFF
--- a/opencensus/trace/exporters/jaeger_exporter.py
+++ b/opencensus/trace/exporters/jaeger_exporter.py
@@ -19,6 +19,7 @@ import datetime
 import logging
 import socket
 
+from six import text_type, string_types
 from thrift.protocol import TBinaryProtocol, TCompactProtocol
 from thrift.transport import THttpClient, TTransport
 
@@ -307,12 +308,14 @@ def _extract_tags(attr):
 
 def _convert_attribute_to_tag(key, attr):
     """Convert the attributes to jaeger tags."""
+    if isinstance(attr, string_types):
+        attr = attr.decode('utf8')
     if isinstance(attr, bool):
         return jaeger.Tag(
             key=key,
             vBool=attr,
             vType=jaeger.TagType.BOOL)
-    if isinstance(attr, str):
+    if isinstance(attr, text_type):
         return jaeger.Tag(
             key=key,
             vStr=attr,

--- a/opencensus/trace/exporters/zipkin_exporter.py
+++ b/opencensus/trace/exporters/zipkin_exporter.py
@@ -21,6 +21,8 @@ import logging
 
 import requests
 
+from six import text_type, string_types
+
 from opencensus.trace.exporters import base
 from opencensus.trace.exporters.transports import sync
 from opencensus.trace.utils import check_str_length
@@ -198,9 +200,11 @@ def _extract_tags_from_span(attr):
         return {}
     tags = {}
     for attribute_key, attribute_value in attr.items():
+        if isinstance(attribute_value, string_types):
+            attribute_value = attribute_value.decode('utf8')
         if isinstance(attribute_value, (int, bool)):
             value = str(attribute_value)
-        elif isinstance(attribute_value, str):
+        elif isinstance(attribute_value, text_type):
             res, _ = check_str_length(str_to_check=attribute_value)
             value = res
         else:


### PR DESCRIPTION
Before this commit, in py2 only bytes strings were exported and in py3
only unicode strings were exported.

I'm not sure I'm doing it right, that's at least an opening for a discussion.

Fixes #273