### PR TITLE
Enable agent TraceExporter configuration in django and flask

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -286,7 +286,7 @@ setting in ``settings.py``:
         'BLACKLIST_PATHS': ['/_ah/health'],
         'GCP_EXPORTER_PROJECT': None,
         'SAMPLING_RATE': 0.5,
-        'ZIPKIN_EXPORTER_SERVICE_NAME': 'my_service',
+        'SERVICE_NAME': 'my_service',
         'ZIPKIN_EXPORTER_HOST_NAME': 'localhost',
         'ZIPKIN_EXPORTER_PORT': 9411,
         'ZIPKIN_EXPORTER_PROTOCOL': 'http',

--- a/docs/trace/usage.rst
+++ b/docs/trace/usage.rst
@@ -248,7 +248,7 @@ setting in ``settings.py``:
         'BLACKLIST_PATHS': ['/_ah/health'],
         'GCP_EXPORTER_PROJECT': None,
         'SAMPLING_RATE': 0.5,
-        'ZIPKIN_EXPORTER_SERVICE_NAME': 'my_service',
+        'SERVICE_NAME': 'my_service',
         'ZIPKIN_EXPORTER_HOST_NAME': 'localhost',
         'ZIPKIN_EXPORTER_PORT': 9411,
         'ZIPKIN_EXPORTER_PROTOCOL': 'http',

--- a/opencensus/trace/exporters/ocagent/trace_exporter.py
+++ b/opencensus/trace/exporters/ocagent/trace_exporter.py
@@ -70,7 +70,6 @@ class TraceExporter(base.Exporter):
             client=None,
             transport=sync.SyncTransport):
         self.transport = transport(self)
-
         self.endpoint = DEFAULT_ENDPOINT if endpoint is None else endpoint
 
         if client is None:
@@ -80,6 +79,7 @@ class TraceExporter(base.Exporter):
         else:
             self.client = client
 
+        self.service_name = service_name
         self.node = common_pb2.Node(
             identifier=common_pb2.ProcessIdentifier(
                 host_name=socket.gethostname() if host_name is None
@@ -92,7 +92,7 @@ class TraceExporter(base.Exporter):
                 language=common_pb2.LibraryInfo.Language.Value('PYTHON'),
                 version=VERSION
             ),
-            service_info=common_pb2.ServiceInfo(name=service_name))
+            service_info=common_pb2.ServiceInfo(name=self.service_name))
 
     def emit(self, span_datas):
         """

--- a/opencensus/trace/ext/django/config.py
+++ b/opencensus/trace/ext/django/config.py
@@ -31,10 +31,12 @@ DEFAULT_DJANGO_TRACER_PARAMS = {
     'BLACKLIST_PATHS': ['_ah/health'],
     'GCP_EXPORTER_PROJECT': None,
     'SAMPLING_RATE': 0.5,
+    'SERVICE_NAME': 'my_service',
     'ZIPKIN_EXPORTER_SERVICE_NAME': 'my_service',
     'ZIPKIN_EXPORTER_HOST_NAME': 'localhost',
     'ZIPKIN_EXPORTER_PORT': 9411,
     'ZIPKIN_EXPORTER_PROTOCOL': 'http',
+    'OCAGENT_TRACE_EXPORTER_ENDPOINT': None,
     'TRANSPORT': 'opencensus.trace.exporters.transports.sync.SyncTransport',
 }
 

--- a/opencensus/trace/ext/django/middleware.py
+++ b/opencensus/trace/ext/django/middleware.py
@@ -38,11 +38,12 @@ BLACKLIST_PATHS = 'BLACKLIST_PATHS'
 GCP_EXPORTER_PROJECT = 'GCP_EXPORTER_PROJECT'
 SAMPLING_RATE = 'SAMPLING_RATE'
 TRANSPORT = 'TRANSPORT'
+SERVICE_NAME = 'SERVICE_NAME'
 ZIPKIN_EXPORTER_SERVICE_NAME = 'ZIPKIN_EXPORTER_SERVICE_NAME'
 ZIPKIN_EXPORTER_HOST_NAME = 'ZIPKIN_EXPORTER_HOST_NAME'
 ZIPKIN_EXPORTER_PORT = 'ZIPKIN_EXPORTER_PORT'
 ZIPKIN_EXPORTER_PROTOCOL = 'ZIPKIN_EXPORTER_PROTOCOL'
-
+OCAGENT_TRACE_EXPORTER_ENDPOINT = 'OCAGENT_TRACE_EXPORTER_ENDPOINT'
 
 log = logging.getLogger(__name__)
 
@@ -121,8 +122,7 @@ class OpencensusMiddleware(MiddlewareMixin):
                 project_id=_project_id,
                 transport=transport)
         elif self._exporter.__name__ == 'ZipkinExporter':
-            _zipkin_service_name = settings.params.get(
-                ZIPKIN_EXPORTER_SERVICE_NAME, 'my_service')
+            _service_name = self._get_service_name(settings.params)
             _zipkin_host_name = settings.params.get(
                 ZIPKIN_EXPORTER_HOST_NAME, 'localhost')
             _zipkin_port = settings.params.get(
@@ -130,10 +130,18 @@ class OpencensusMiddleware(MiddlewareMixin):
             _zipkin_protocol = settings.params.get(
                 ZIPKIN_EXPORTER_PROTOCOL, 'http')
             self.exporter = self._exporter(
-                service_name=_zipkin_service_name,
+                service_name=_service_name,
                 host_name=_zipkin_host_name,
                 port=_zipkin_port,
                 protocol=_zipkin_protocol,
+                transport=transport)
+        elif self._exporter.__name__ == 'TraceExporter':
+            _service_name = self._get_service_name(settings.params)
+            _endpoint = settings.params.get(
+                OCAGENT_TRACE_EXPORTER_ENDPOINT, None)
+            self.exporter = self._exporter(
+                service_name=_service_name,
+                endpoint=_endpoint,
                 transport=transport)
         else:
             self.exporter = self._exporter(transport=transport)
@@ -216,3 +224,13 @@ class OpencensusMiddleware(MiddlewareMixin):
             log.error('Failed to trace request', exc_info=True)
         finally:
             return response
+
+    def _get_service_name(self, params):
+        _service_name = params.get(
+            SERVICE_NAME, None)
+
+        if _service_name is None:
+            _service_name = params.get(
+                ZIPKIN_EXPORTER_SERVICE_NAME, 'my_service')
+
+        return _service_name

--- a/tests/unit/trace/ext/django/test_config.py
+++ b/tests/unit/trace/ext/django/test_config.py
@@ -80,10 +80,12 @@ class Test__set_default_configs(unittest.TestCase):
             'BLACKLIST_PATHS': ['_ah/health', ],
             'GCP_EXPORTER_PROJECT': None,
             'SAMPLING_RATE': 0.6,
+            'SERVICE_NAME': 'my_service',
             'ZIPKIN_EXPORTER_SERVICE_NAME': 'my_service',
             'ZIPKIN_EXPORTER_HOST_NAME': 'localhost',
             'ZIPKIN_EXPORTER_PORT': 9411,
             'ZIPKIN_EXPORTER_PROTOCOL': 'http',
+            'OCAGENT_TRACE_EXPORTER_ENDPOINT': None,
             'TRANSPORT':
                 'opencensus.trace.exporters.transports.sync.SyncTransport',
         }

--- a/tests/unit/trace/ext/django/test_middleware.py
+++ b/tests/unit/trace/ext/django/test_middleware.py
@@ -22,6 +22,7 @@ from opencensus.trace import execution_context
 from opencensus.trace import span as span_module
 from opencensus.trace.exporters import print_exporter
 from opencensus.trace.exporters import zipkin_exporter
+from opencensus.trace.exporters.ocagent import trace_exporter
 from opencensus.trace.exporters.transports import sync
 from opencensus.trace.ext import utils
 from opencensus.trace.propagation import google_cloud_format
@@ -131,6 +132,102 @@ class TestOpencensusMiddleware(unittest.TestCase):
         self.assertEqual(middleware.exporter.service_name, service_name)
         self.assertEqual(middleware.exporter.host_name, host_name)
         self.assertEqual(middleware.exporter.port, port)
+
+    def test_constructor_zipkin_service_name_param(self):
+        from opencensus.trace.ext.django import middleware
+
+        service_name = 'test_service'
+        host_name = 'test_hostname'
+        port = 2333
+        protocol = 'http'
+        params = {
+            'SERVICE_NAME': service_name,
+            'ZIPKIN_EXPORTER_HOST_NAME': host_name,
+            'ZIPKIN_EXPORTER_PORT': port,
+            'ZIPKIN_EXPORTER_PROTOCOL': protocol,
+            'TRANSPORT':
+                'opencensus.trace.exporters.transports.sync.SyncTransport',
+        }
+
+        patch_zipkin = mock.patch(
+            'opencensus.trace.ext.django.config.settings.EXPORTER',
+            zipkin_exporter.ZipkinExporter)
+
+        patch_params = mock.patch(
+            'opencensus.trace.ext.django.config.settings.params',
+            params)
+
+        with patch_zipkin, patch_params:
+            middleware = middleware.OpencensusMiddleware()
+
+        self.assertEqual(middleware.exporter.service_name, service_name)
+        self.assertEqual(middleware.exporter.host_name, host_name)
+        self.assertEqual(middleware.exporter.port, port)
+
+    def test_constructor_ocagent_trace_exporter(self):
+        from opencensus.trace.ext.django import middleware
+
+        service_name = 'test_service'
+        endpoint = 'localhost:50001'
+        params = {
+            'SERVICE_NAME': service_name,
+            'OCAGENT_TRACE_EXPORTER_ENDPOINT': endpoint,
+            'TRANSPORT':
+                'opencensus.trace.exporters.transports.sync.SyncTransport',
+        }
+
+        patch_ocagent_trace = mock.patch(
+            'opencensus.trace.ext.django.config.settings.EXPORTER',
+            trace_exporter.TraceExporter)
+
+        patch_params = mock.patch(
+            'opencensus.trace.ext.django.config.settings.params',
+            params)
+
+        with patch_ocagent_trace, patch_params:
+            middleware = middleware.OpencensusMiddleware()
+
+        self.assertIs(middleware._sampler, always_on.AlwaysOnSampler)
+        self.assertIs(
+            middleware._exporter, trace_exporter.TraceExporter)
+        self.assertIs(
+            middleware._propagator,
+            google_cloud_format.GoogleCloudFormatPropagator)
+
+        assert isinstance(middleware.sampler, always_on.AlwaysOnSampler)
+        assert isinstance(
+            middleware.exporter, trace_exporter.TraceExporter)
+        assert isinstance(
+            middleware.propagator,
+            google_cloud_format.GoogleCloudFormatPropagator)
+
+        self.assertEqual(middleware.exporter.service_name, service_name)
+        self.assertEqual(middleware.exporter.endpoint, endpoint)
+
+    def test_constructor_ocagent_trace_exporter_default_endpoint(self):
+        from opencensus.trace.ext.django import middleware
+
+        service_name = 'test_service'
+        params = {
+            'SERVICE_NAME': service_name,
+            'TRANSPORT':
+                'opencensus.trace.exporters.transports.sync.SyncTransport',
+        }
+
+        patch_ocagent_trace = mock.patch(
+            'opencensus.trace.ext.django.config.settings.EXPORTER',
+            trace_exporter.TraceExporter)
+
+        patch_params = mock.patch(
+            'opencensus.trace.ext.django.config.settings.params',
+            params)
+
+        with patch_ocagent_trace, patch_params:
+            middleware = middleware.OpencensusMiddleware()
+
+        self.assertEqual(middleware.exporter.service_name, service_name)
+        self.assertEqual(middleware.exporter.endpoint,
+                         trace_exporter.DEFAULT_ENDPOINT)
 
     def test_constructor_probability_sampler(self):
         from opencensus.trace.ext.django import middleware

--- a/tests/unit/trace/ext/flask/test_flask_middleware.py
+++ b/tests/unit/trace/ext/flask/test_flask_middleware.py
@@ -28,6 +28,7 @@ from opencensus.trace import stack_trace
 from opencensus.trace import status
 from opencensus.trace.exporters import print_exporter, stackdriver_exporter, \
     zipkin_exporter
+from opencensus.trace.exporters.ocagent import trace_exporter
 from opencensus.trace.ext.flask import flask_middleware
 from opencensus.trace.propagation import google_cloud_format
 from opencensus.trace.samplers import always_off, always_on, ProbabilitySampler
@@ -135,6 +136,10 @@ class TestFlaskMiddleware(unittest.TestCase):
         self.assertTrue(app.after_request.called)
 
     def test_init_app_config_zipkin_exporter(self):
+
+        service_name = 'foo'
+        host_name = 'localhost'
+        port = 1234
         app = mock.Mock()
         app.config = {
             'OPENCENSUS_TRACE': {
@@ -143,9 +148,9 @@ class TestFlaskMiddleware(unittest.TestCase):
                 'PROPAGATOR': google_cloud_format.GoogleCloudFormatPropagator,
             },
             'OPENCENSUS_TRACE_PARAMS': {
-                'ZIPKIN_EXPORTER_SERVICE_NAME': 'my_service',
-                'ZIPKIN_EXPORTER_HOST_NAME': 'localhost',
-                'ZIPKIN_EXPORTER_PORT': 9411,
+                'ZIPKIN_EXPORTER_SERVICE_NAME': service_name,
+                'ZIPKIN_EXPORTER_HOST_NAME': host_name,
+                'ZIPKIN_EXPORTER_PORT': port,
                 'ZIPKIN_EXPORTER_PROTOCOL': 'http',
             },
         }
@@ -154,6 +159,97 @@ class TestFlaskMiddleware(unittest.TestCase):
         middleware.init_app(app)
 
         self.assertIs(middleware.app, app)
+        self.assertTrue(app.before_request.called)
+        self.assertTrue(app.after_request.called)
+
+        assert isinstance(
+            middleware.exporter, zipkin_exporter.ZipkinExporter)
+        self.assertEqual(middleware.exporter.service_name, service_name)
+        self.assertEqual(middleware.exporter.host_name, host_name)
+        self.assertEqual(middleware.exporter.port, port)
+
+    def test_init_app_config_zipkin_exporter_service_name_param(self):
+
+        service_name = 'foo'
+        host_name = 'localhost'
+        port = 1234
+        app = mock.Mock()
+        app.config = {
+            'OPENCENSUS_TRACE': {
+                'SAMPLER': ProbabilitySampler,
+                'EXPORTER': zipkin_exporter.ZipkinExporter,
+                'PROPAGATOR': google_cloud_format.GoogleCloudFormatPropagator,
+            },
+            'OPENCENSUS_TRACE_PARAMS': {
+                'SERVICE_NAME': service_name,
+                'ZIPKIN_EXPORTER_HOST_NAME': host_name,
+                'ZIPKIN_EXPORTER_PORT': port,
+                'ZIPKIN_EXPORTER_PROTOCOL': 'http',
+            },
+        }
+
+        middleware = flask_middleware.FlaskMiddleware()
+        middleware.init_app(app)
+
+        self.assertIs(middleware.app, app)
+        self.assertTrue(app.before_request.called)
+        self.assertTrue(app.after_request.called)
+
+        assert isinstance(
+            middleware.exporter, zipkin_exporter.ZipkinExporter)
+        self.assertEqual(middleware.exporter.service_name, service_name)
+        self.assertEqual(middleware.exporter.host_name, host_name)
+        self.assertEqual(middleware.exporter.port, port)
+
+    def test_init_app_config_ocagent_trace_exporter(self):
+        app = mock.Mock()
+        app.config = {
+            'OPENCENSUS_TRACE': {
+                'SAMPLER': ProbabilitySampler,
+                'EXPORTER': trace_exporter.TraceExporter,
+                'PROPAGATOR': google_cloud_format.GoogleCloudFormatPropagator,
+            },
+            'OPENCENSUS_TRACE_PARAMS': {
+                'SERVICE_NAME': 'foo',
+                'OCAGENT_TRACE_EXPORTER_ENDPOINT': 'localhost:50001'
+            }
+        }
+
+        middleware = flask_middleware.FlaskMiddleware()
+        middleware.init_app(app)
+
+        self.assertIs(middleware.app, app)
+        assert isinstance(
+            middleware.exporter, trace_exporter.TraceExporter)
+        self.assertEqual(middleware.exporter.service_name, 'foo')
+        self.assertEqual(middleware.exporter.endpoint, 'localhost:50001')
+
+        self.assertTrue(app.before_request.called)
+        self.assertTrue(app.after_request.called)
+
+    def test_init_app_config_ocagent_trace_exporter_default_endpoint(self):
+        app = mock.Mock()
+        app.config = {
+            'OPENCENSUS_TRACE': {
+                'SAMPLER': ProbabilitySampler,
+                'EXPORTER': trace_exporter.TraceExporter,
+                'PROPAGATOR': google_cloud_format.GoogleCloudFormatPropagator,
+            },
+            'OPENCENSUS_TRACE_PARAMS': {
+                'SERVICE_NAME': 'foo'
+            }
+        }
+
+        middleware = flask_middleware.FlaskMiddleware()
+        middleware.init_app(app)
+
+        self.assertIs(middleware.app, app)
+        assert isinstance(
+            middleware.exporter, trace_exporter.TraceExporter)
+        self.assertEqual(middleware.exporter.service_name, 'foo')
+        self.assertEqual(middleware.exporter.endpoint,
+                         trace_exporter.DEFAULT_ENDPOINT)
+
         self.assertTrue(app.before_request.called)
         self.assertTrue(app.after_request.called)
 


### PR DESCRIPTION
This change allows to use TraceExporter for ocagent with django and flask.

SERVICE_NAME setting is added with the intention to deprecate ZIPKIN_EXPORTER_SERVICE_NAME: if SERVICE_NAME is not present, we check for ZIPKIN_EXPORTER_SERVICE_NAME 