### PR TITLE
jaeger exporter: check whether time_event.annotation is None

### DIFF
--- a/opencensus/trace/exporters/jaeger_exporter.py
+++ b/opencensus/trace/exporters/jaeger_exporter.py
@@ -278,6 +278,8 @@ def _extract_logs_from_span(span):
     logs = []
     for time_event in span.time_events:
         annotation = time_event.annotation
+        if not annotation:
+            continue
         fields = _extract_tags(annotation.attributes)
 
         fields.append(jaeger.Tag(

--- a/tests/unit/trace/exporters/test_jaeger_exporter.py
+++ b/tests/unit/trace/exporters/test_jaeger_exporter.py
@@ -200,7 +200,13 @@ class TestJaegerExporter(unittest.TestCase):
                 timestamp=time,
                 annotation=time_event.Annotation(
                     description='First Annotation',
-                    attributes=annotation_attributes))
+                    attributes=annotation_attributes)),
+            time_event.TimeEvent(
+                timestamp=time,
+                message_event=time_event.MessageEvent(
+                    id='message-event-id',
+                    uncompressed_size_bytes=0,
+                )),
         ]
 
         links = [


### PR DESCRIPTION
When I tried to use grpc intercepter and jaeger exporter, I encountered this error:

`AttributeError: 'NoneType' object has no attribute 'attributes'`

This can be reproduced by simply substituting the stackdriver exporter of the `examples/trace/grpc/hello_world_server.py` to jaeger exporter.