### PR TITLE
Quick fix for 3.x deprecation warnings

### DIFF
--- a/tests/unit/metrics/export/test_summary.py
+++ b/tests/unit/metrics/export/test_summary.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from six import assertRaisesRegex
 import unittest
+
 from opencensus.metrics.export import summary as summary_module
 
 
 class TestSummary(unittest.TestCase):
-
     def setUp(self):
         value_at_percentile = [summary_module.ValueAtPercentile(99.5, 10.2)]
         self.snapshot = summary_module.Snapshot(10, 87.07, value_at_percentile)
@@ -26,46 +27,50 @@ class TestSummary(unittest.TestCase):
         summary = summary_module.Summary(10, 6.6, self.snapshot)
 
         self.assertIsNotNone(summary)
-        self.assertEquals(summary.count, 10)
-        self.assertEquals(summary.sum_data, 6.6)
+        self.assertEqual(summary.count, 10)
+        self.assertEqual(summary.sum_data, 6.6)
         self.assertIsNotNone(summary.snapshot)
         self.assertIsInstance(summary.snapshot, summary_module.Snapshot)
 
     def test_constructor_with_negative_count(self):
-        with self.assertRaisesRegexp(ValueError, 'count must be non-negative'):
+        with assertRaisesRegex(self, ValueError, 'count must be non-negative'):
             summary_module.Summary(-10, 87.07, self.snapshot)
 
     def test_constructor_with_negative_sum_data(self):
-        with self.assertRaisesRegexp(ValueError, 'sum_data must be non-negative'):
+        with assertRaisesRegex(self, ValueError,
+                               'sum_data must be non-negative'):
             summary_module.Summary(10, -87.07, self.snapshot)
 
     def test_constructor_with_zero_count_and_sum_data(self):
-        with self.assertRaisesRegexp(ValueError, 'sum_data must be 0 if count is 0'):
+        with assertRaisesRegex(self, ValueError,
+                               'sum_data must be 0 if count is 0'):
             summary_module.Summary(0, 87.07, self.snapshot)
 
     def test_constructor_with_none_snapshot(self):
-        with self.assertRaisesRegexp(ValueError, 'snapshot must not be none'):
+        with assertRaisesRegex(self, ValueError, 'snapshot must not be none'):
             summary_module.Summary(10, 87.07, None)
 
 
 class TestSnapshot(unittest.TestCase):
-
     def setUp(self):
-        self.value_at_percentile = [summary_module.ValueAtPercentile(99.5, 10.2)]
+        self.value_at_percentile = [
+            summary_module.ValueAtPercentile(99.5, 10.2)
+        ]
 
         # Invalid value_at_percentile
-        self.value_at_percentile1 = summary_module.ValueAtPercentile(99.5, 10.2)
+        self.value_at_percentile1 = summary_module.ValueAtPercentile(
+            99.5, 10.2)
 
     def test_constructor(self):
         snapshot = summary_module.Snapshot(10, 87.07, self.value_at_percentile)
 
         self.assertIsNotNone(snapshot)
-        self.assertEquals(snapshot.count, 10)
-        self.assertEquals(snapshot.sum_data, 87.07)
+        self.assertEqual(snapshot.count, 10)
+        self.assertEqual(snapshot.sum_data, 87.07)
         self.assertIsNotNone(snapshot.value_at_percentiles)
-        self.assertEquals(len(snapshot.value_at_percentiles), 1)
-        self.assertEquals(snapshot.value_at_percentiles[0].percentile, 99.5)
-        self.assertEquals(snapshot.value_at_percentiles[0].value, 10.2)
+        self.assertEqual(len(snapshot.value_at_percentiles), 1)
+        self.assertEqual(snapshot.value_at_percentiles[0].percentile, 99.5)
+        self.assertEqual(snapshot.value_at_percentiles[0].value, 10.2)
 
     def test_constructor_invalid_value_at_percentile(self):
         with self.assertRaises(ValueError):
@@ -76,46 +81,48 @@ class TestSnapshot(unittest.TestCase):
 
         self.assertIsNotNone(snapshot)
         self.assertIsNotNone(snapshot.value_at_percentiles)
-        self.assertEquals(len(snapshot.value_at_percentiles), 0)
+        self.assertEqual(len(snapshot.value_at_percentiles), 0)
 
     def test_constructor_with_negative_count(self):
-        with self.assertRaisesRegexp(ValueError, 'count must be non-negative'):
+        with assertRaisesRegex(self, ValueError, 'count must be non-negative'):
             summary_module.Snapshot(-10, 87.07, self.value_at_percentile)
 
     def test_constructor_with_negative_sum_data(self):
-        with self.assertRaisesRegexp(ValueError, 'sum_data must be non-negative'):
+        with assertRaisesRegex(self, ValueError,
+                               'sum_data must be non-negative'):
             summary_module.Snapshot(10, -87.07, self.value_at_percentile)
 
     def test_constructor_with_zero_count(self):
-        with self.assertRaisesRegexp(ValueError, 'sum_data must be 0 if count is 0'):
+        with assertRaisesRegex(self, ValueError,
+                               'sum_data must be 0 if count is 0'):
             summary_module.Snapshot(0, 87.07, self.value_at_percentile)
 
     def test_constructor_with_zero_count_and_sum_data(self):
         summary_module.Snapshot(0, 0, self.value_at_percentile)
 
     def test_constructor_with_none_count_sum(self):
-        snapshot = summary_module.Snapshot(None, None, self.value_at_percentile)
+        snapshot = summary_module.Snapshot(None, None,
+                                           self.value_at_percentile)
 
         self.assertIsNotNone(snapshot)
         self.assertIsNone(snapshot.count)
         self.assertIsNone(snapshot.sum_data)
         self.assertIsNotNone(snapshot.value_at_percentiles)
-        self.assertEquals(len(snapshot.value_at_percentiles), 1)
+        self.assertEqual(len(snapshot.value_at_percentiles), 1)
 
 
 class TestValueAtPercentile(unittest.TestCase):
-
     def test_constructor(self):
         value_at_percentile = summary_module.ValueAtPercentile(99.5, 10.2)
 
         self.assertIsNotNone(value_at_percentile)
-        self.assertEquals(value_at_percentile.value, 10.2)
-        self.assertEquals(value_at_percentile.percentile, 99.5)
+        self.assertEqual(value_at_percentile.value, 10.2)
+        self.assertEqual(value_at_percentile.percentile, 99.5)
 
     def test_constructor_invalid_percentile(self):
         with self.assertRaises(ValueError):
             summary_module.ValueAtPercentile(100.1, 10.2)
 
     def test_constructor_invalid_value(self):
-        with self.assertRaisesRegexp(ValueError, 'value must be non-negative'):
+        with assertRaisesRegex(self, ValueError, 'value must be non-negative'):
             summary_module.ValueAtPercentile(99.5, -10.2)

--- a/tests/unit/metrics/test_label_value.py
+++ b/tests/unit/metrics/test_label_value.py
@@ -19,7 +19,6 @@ from opencensus.metrics import label_value as label_value_module
 
 
 class TestLabelValue(unittest.TestCase):
-
     def test_constructor(self):
         value = 'value1'
         label_value = label_value_module.LabelValue(value)
@@ -38,11 +37,11 @@ class TestLabelValue(unittest.TestCase):
         label_value = label_value_module.LabelValue(value)
 
         self.assertIsNotNone(label_value)
-        self.assertEquals(label_value.value, '')
+        self.assertEqual(label_value.value, '')
 
     def test_constructor_WithNonAsciiChars(self):
         value = '值'
         label_value = label_value_module.LabelValue(value)
 
         self.assertIsNotNone(label_value)
-        self.assertEquals(label_value.value, value)
+        self.assertEqual(label_value.value, value)


### PR DESCRIPTION
@mayurkale22 this is a fix for some deprecation warnings in metrics tests I noticed while adding the `Metric` class.

Compare the results `python3.4 -m pytest -s tests/unit/metrics/` on this branch to master.