### PR TITLE
Set stackdriver stats exporter user agent

### DIFF
--- a/opencensus/stats/exporters/stackdriver_exporter.py
+++ b/opencensus/stats/exporters/stackdriver_exporter.py
@@ -12,17 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import re
 import os
 import platform
-from . import base
-from google.cloud import monitoring_v3
-from opencensus.stats import aggregation
-from opencensus.stats import measure
+import re
+
 from datetime import datetime
-from opencensus.common.transports import async_
+from google.api_core.gapic_v1 import client_info
+from google.cloud import monitoring_v3
+
+from opencensus.__version__ import __version__
 from opencensus.common.monitored_resource_util.monitored_resource_util \
     import MonitoredResourceUtil
+from opencensus.common.transports import async_
+from opencensus.stats import aggregation
+from opencensus.stats import measure
+from opencensus.stats.exporters import base
 
 MAX_TIME_SERIES_PER_UPLOAD = 200
 OPENCENSUS_TASK_DESCRIPTION = "Opencensus task identifier"
@@ -385,7 +389,8 @@ def new_stats_exporter(options):
     if str(options.project_id).strip() == "":
         raise Exception(ERROR_BLANK_PROJECT_ID)
 
-    client = monitoring_v3.MetricServiceClient()
+    ci = client_info.ClientInfo(client_library_version=__version__)
+    client = monitoring_v3.MetricServiceClient(client_info=ci)
 
     exporter = StackdriverStatsExporter(client=client, options=options)
 

--- a/opencensus/stats/exporters/stackdriver_exporter.py
+++ b/opencensus/stats/exporters/stackdriver_exporter.py
@@ -382,6 +382,11 @@ def set_attribute_label(series, resource_labels, attribute_key,
             label_value_prefix + resource_labels[attribute_key]
 
 
+def get_user_agent_slug():
+    """Get the UA fragment to identify this library version."""
+    return "opencensus-{}".format(__version__)
+
+
 def new_stats_exporter(options):
     """ new_stats_exporter returns an exporter that
         uploads stats data to Stackdriver Monitoring.
@@ -389,7 +394,7 @@ def new_stats_exporter(options):
     if str(options.project_id).strip() == "":
         raise Exception(ERROR_BLANK_PROJECT_ID)
 
-    ci = client_info.ClientInfo(client_library_version=__version__)
+    ci = client_info.ClientInfo(client_library_version=get_user_agent_slug())
     client = monitoring_v3.MetricServiceClient(client_info=ci)
 
     exporter = StackdriverStatsExporter(client=client, options=options)

--- a/tests/unit/stats/exporter/test_stackdriver_stats.py
+++ b/tests/unit/stats/exporter/test_stackdriver_stats.py
@@ -108,6 +108,9 @@ class TestStackdriverStatsExporter(unittest.TestCase):
 
         self.assertIsInstance(exporter_created, stackdriver.StackdriverStatsExporter)
 
+    def test_get_user_agent_slug(self):
+        self.assertIn(__version__, stackdriver.get_user_agent_slug())
+
     def test_client_info_user_agent(self):
         """Check that the monitoring client sets a user agent.
 
@@ -124,7 +127,7 @@ class TestStackdriverStatsExporter(unittest.TestCase):
             exporter = stackdriver.new_stats_exporter(
                 stackdriver.Options(project_id=1))
 
-        self.assertIn("gccl/{}".format(__version__),
+        self.assertIn(stackdriver.get_user_agent_slug(),
                       exporter.client.client_info.to_user_agent())
 
     def test_as_float(self):


### PR DESCRIPTION
This diff sets the stackdriver exporter's GC client's `client_library_version` to this library's version, to be included in the user agent that the GC client [attaches to API calls](https://github.com/googleapis/google-cloud-python/blob/0c13d62e807502b6392511108d46bed3e5634ffa/api_core/google/api_core/gapic_v1/method.py#L226-L229).

The form of the user agent before this change:

    gl-python/2.7.10 grpc/1.8.3 gax/1.4.1

And after:

     gl-python/2.7.10 grpc/1.8.3 gax/1.4.1 gccl/opencensus-1.0.8