### PR TITLE
Remove manual version update step from RELEASING.md

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,8 +4,6 @@
 
 ### Update the version number in `setup.py`
 
-### Update the version number in `stackdriver_exporter.py`
-
 ### Create a Github release
 
 Then the Circle CI will build the package and upload it to PyPI automatically.


### PR DESCRIPTION
This step was obsoleted in #369.

cc @liyanhui1228 