### PR TITLE
Turn prints into log statements

### DIFF
--- a/opencensus/trace/exporters/transports/background_thread.py
+++ b/opencensus/trace/exporters/transports/background_thread.py
@@ -107,7 +107,7 @@ class _Worker(object):
                 try:
                     self.exporter.emit(span_datas)
                 except Exception:
-                    logger.exception(
+                    logging.exception(
                         '%s failed to emit spans.'
                         'Dropping %s spans from queue.',
                         self.exporter.__class__.__name__,

--- a/opencensus/trace/exporters/transports/background_thread.py
+++ b/opencensus/trace/exporters/transports/background_thread.py
@@ -28,6 +28,8 @@ _WAIT_PERIOD = 1.0  # Seconds
 _WORKER_THREAD_NAME = 'opencensus.trace.Worker'
 _WORKER_TERMINATOR = object()
 
+logger = logging.getLogger(__name__)
+
 
 class _Worker(object):
     """A background thread that exports batches of spans.
@@ -85,7 +87,7 @@ class _Worker(object):
         Pulls pending SpanData tuples off the queue and writes them in
         batches to the specified tracing backend using the exporter.
         """
-        logging.debug('Background thread started.')
+        logger.debug('Background thread started.')
 
         quit_ = False
 
@@ -105,7 +107,7 @@ class _Worker(object):
                 try:
                     self.exporter.emit(span_datas)
                 except Exception:
-                    logging.exception(
+                    logger.exception(
                         '%s failed to emit spans.'
                         'Dropping %s spans from queue.',
                         self.exporter.__class__.__name__,
@@ -121,7 +123,7 @@ class _Worker(object):
             if quit_:
                 break
 
-        logging.debug('Background thread exited.')
+        logger.debug('Background thread exited.')
 
     def start(self):
         """Starts the background thread.
@@ -176,12 +178,12 @@ class _Worker(object):
             return
 
         if not self._queue.empty():
-            logging.info('Sending all pending spans before terminated.')
+            logger.info('Sending all pending spans before terminated.')
 
         if self.stop():
-            logging.info('Sent all pending spans.')
+            logger.info('Sent all pending spans.')
         else:
-            logging.error('Failed to send pending spans.')
+            logger.error('Failed to send pending spans.')
 
     def enqueue(self, span_datas):
         """Queues span_datas to be written by the background thread."""

--- a/opencensus/trace/exporters/transports/background_thread.py
+++ b/opencensus/trace/exporters/transports/background_thread.py
@@ -85,7 +85,7 @@ class _Worker(object):
         Pulls pending SpanData tuples off the queue and writes them in
         batches to the specified tracing backend using the exporter.
         """
-        print('Background thread started.')
+        logging.debug('Background thread started.')
 
         quit_ = False
 
@@ -121,7 +121,7 @@ class _Worker(object):
             if quit_:
                 break
 
-        print('Background thread exited.')
+        logging.debug('Background thread exited.')
 
     def start(self):
         """Starts the background thread.
@@ -176,12 +176,12 @@ class _Worker(object):
             return
 
         if not self._queue.empty():
-            print('Sending all pending spans before terminated.')
+            logging.info('Sending all pending spans before terminated.')
 
         if self.stop():
-            print('Sent all pending spans.')
+            logging.info('Sent all pending spans.')
         else:
-            print('Failed to send pending spans.')
+            logging.error('Failed to send pending spans.')
 
     def enqueue(self, span_datas):
         """Queues span_datas to be written by the background thread."""


### PR DESCRIPTION
We had some hanging 'print' statements in the BackgroundThread: let's turn them into `logging` statements so that an end-user can control what logs they want to see.