### PR TITLE
Support transport options in exporter

### DIFF
--- a/opencensus/trace/exporters/base.py
+++ b/opencensus/trace/exporters/base.py
@@ -42,6 +42,7 @@ class Exporter(object):
         """
         raise NotImplementedError
 
+
 def init_transport(exporter, transport, config=None):
     """Initiate a transport instance to be used by the exporter.
 

--- a/opencensus/trace/exporters/base.py
+++ b/opencensus/trace/exporters/base.py
@@ -20,7 +20,7 @@ class Exporter(object):
 
     Subclasses of :class:`Exporter` must override :meth:`export`.
     """
-    
+
     def emit(self, span_datas):
         """
         :type span_datas: list of :class:

--- a/opencensus/trace/exporters/base.py
+++ b/opencensus/trace/exporters/base.py
@@ -20,6 +20,7 @@ class Exporter(object):
 
     Subclasses of :class:`Exporter` must override :meth:`export`.
     """
+    
     def emit(self, span_datas):
         """
         :type span_datas: list of :class:

--- a/opencensus/trace/exporters/base.py
+++ b/opencensus/trace/exporters/base.py
@@ -41,16 +41,19 @@ class Exporter(object):
         """
         raise NotImplementedError
 
-    def __init_transport(self, cls, config=None):
-        """Initiate the transport instance to be used by the exporter.
+def init_transport(exporter, transport, config=None):
+    """Initiate a transport instance to be used by the exporter.
 
-        :type cls: :class:
-            `~opencensus.trace.exporters.transports.base.Transport`
-        :param transport class to use for the exporter.
+    :type exporter: :class: `~opencensus.trace.exporters.base.Exporter`
+    :param exporter exporter instance.
 
-        :type config dict
-        :param dict of config options to initiate the transport with.
-        """
-        if config is None:
-            return cls(self)
-        return cls(self, **config)
+    :type transport: :class:
+        `~opencensus.trace.exporters.transports.base.Transport`
+    :param transport class to use for the exporter.
+
+    :type config: :class:`dict`
+    :param dict of config options to initiate the transport with.
+    """
+    if config is None:
+        return transport(exporter)
+    return transport(exporter, **config)

--- a/opencensus/trace/exporters/base.py
+++ b/opencensus/trace/exporters/base.py
@@ -20,7 +20,6 @@ class Exporter(object):
 
     Subclasses of :class:`Exporter` must override :meth:`export`.
     """
-
     def emit(self, span_datas):
         """
         :type span_datas: list of :class:
@@ -41,3 +40,17 @@ class Exporter(object):
             SpanData tuples to export
         """
         raise NotImplementedError
+
+    def __init_transport(self, cls, config=None):
+        """Initiate the transport instance to be used by the exporter.
+
+        :type cls: :class:
+            `~opencensus.trace.exporters.transports.base.Transport`
+        :param transport class to use for the exporter.
+
+        :type config dict
+        :param dict of config options to initiate the transport with.
+        """
+        if config is None:
+            return cls(self)
+        return cls(self, **config)

--- a/opencensus/trace/exporters/file_exporter.py
+++ b/opencensus/trace/exporters/file_exporter.py
@@ -31,14 +31,14 @@ class FileExporter(base.Exporter):
     :type file_mode: str
     :param file_mode: The file mode to open the output file with.
                       Defaults to w+
-                      
+
     :type transport: :class:`type`
     :param transport: Class for creating new transport objects. It should
                       extend from the base :class:`.Transport` type and
                       implement :meth:`.Transport.export`. Defaults to
                       :class:`.SyncTransport`. The other option is
                       :class:`.BackgroundThreadTransport`.
-                      
+
     :type transport_config: :class:`dict`
     :param transport_config: Transport configuration dictionary.
     """

--- a/opencensus/trace/exporters/file_exporter.py
+++ b/opencensus/trace/exporters/file_exporter.py
@@ -41,12 +41,11 @@ class FileExporter(base.Exporter):
 
     """
 
-    def __init__(self, file_name=DEFAULT_FILENAME,
-                 transport=sync.SyncTransport,
-                 file_mode='w+'):
+    def __init__(self, file_name=DEFAULT_FILENAME, file_mode='w+',
+                 transport=sync.SyncTransport, transport_config=None):
         self.file_name = file_name
-        self.transport = transport(self)
         self.file_mode = file_mode
+        self.transport = self.__init_transport(transport, transport_config)
 
     def emit(self, span_datas):
         """

--- a/opencensus/trace/exporters/file_exporter.py
+++ b/opencensus/trace/exporters/file_exporter.py
@@ -45,7 +45,7 @@ class FileExporter(base.Exporter):
                  transport=sync.SyncTransport, transport_config=None):
         self.file_name = file_name
         self.file_mode = file_mode
-        self.transport = self.__init_transport(transport, transport_config)
+        self.transport = base.init_transport(self, transport, transport_config)
 
     def emit(self, span_datas):
         """

--- a/opencensus/trace/exporters/jaeger_exporter.py
+++ b/opencensus/trace/exporters/jaeger_exporter.py
@@ -72,6 +72,9 @@ class JaegerExporter(base.Exporter):
                       implement :meth:`.Transport.export`. Defaults to
                       :class:`.SyncTransport`. The other option is
                       :class:`.BackgroundThreadTransport`.
+
+    :type transport_config
+    :param
     """
 
     def __init__(
@@ -85,8 +88,9 @@ class JaegerExporter(base.Exporter):
             agent_host_name=DEFAULT_HOST_NAME,
             agent_port=DEFAULT_AGENT_PORT,
             agent_endpoint=DEFAULT_ENDPOINT,
-            transport=sync.SyncTransport):
-        self.transport = transport(self)
+            transport=sync.SyncTransport,
+            transport_config=None
+        ):
         self.service_name = service_name
         self.host_name = host_name
         self.agent_host_name = agent_host_name
@@ -97,6 +101,7 @@ class JaegerExporter(base.Exporter):
         self.password = password
         self._agent_client = None
         self._collector = None
+        self.transport = self.__init_transport(transport, transport_config)
 
     @property
     def agent_client(self):

--- a/opencensus/trace/exporters/jaeger_exporter.py
+++ b/opencensus/trace/exporters/jaeger_exporter.py
@@ -101,7 +101,7 @@ class JaegerExporter(base.Exporter):
         self.password = password
         self._agent_client = None
         self._collector = None
-        self.transport = self.__init_transport(transport, transport_config)
+        self.transport = base.init_transport(self, transport, transport_config)
 
     @property
     def agent_client(self):

--- a/opencensus/trace/exporters/jaeger_exporter.py
+++ b/opencensus/trace/exporters/jaeger_exporter.py
@@ -89,8 +89,7 @@ class JaegerExporter(base.Exporter):
             agent_port=DEFAULT_AGENT_PORT,
             agent_endpoint=DEFAULT_ENDPOINT,
             transport=sync.SyncTransport,
-            transport_config=None
-        ):
+            transport_config=None):
         self.service_name = service_name
         self.host_name = host_name
         self.agent_host_name = agent_host_name

--- a/opencensus/trace/exporters/logging_exporter.py
+++ b/opencensus/trace/exporters/logging_exporter.py
@@ -63,8 +63,7 @@ class LoggingExporter(base.Exporter):
         self.handler = handler
         self.logger.addHandler(handler)
         self.logger.setLevel(logging.INFO)
-
-        self.transport = self.__init_transport(transport, transport_config)
+        self.transport = base.init_transport(self, transport, transport_config)
 
     def emit(self, span_datas):
         """

--- a/opencensus/trace/exporters/logging_exporter.py
+++ b/opencensus/trace/exporters/logging_exporter.py
@@ -53,7 +53,8 @@ class LoggingExporter(base.Exporter):
     will be exported to logging when finished.
     """
 
-    def __init__(self, handler=None, transport=sync.SyncTransport):
+    def __init__(self, handler=None, transport=sync.SyncTransport,
+                 transport_config=None):
         self.logger = logging.getLogger()
 
         if handler is None:
@@ -62,7 +63,8 @@ class LoggingExporter(base.Exporter):
         self.handler = handler
         self.logger.addHandler(handler)
         self.logger.setLevel(logging.INFO)
-        self.transport = transport(self)
+
+        self.transport = self.__init_transport(transport, transport_config)
 
     def emit(self, span_datas):
         """

--- a/opencensus/trace/exporters/print_exporter.py
+++ b/opencensus/trace/exporters/print_exporter.py
@@ -30,7 +30,7 @@ class PrintExporter(base.Exporter):
     """
 
     def __init__(self, transport=sync.SyncTransport, transport_config=None):
-        self.transport = self.__init_transport(transport, transport_config)
+        self.transport = base.init_transport(self, transport, transport_config)
 
     def emit(self, span_datas):
         """

--- a/opencensus/trace/exporters/print_exporter.py
+++ b/opencensus/trace/exporters/print_exporter.py
@@ -27,7 +27,7 @@ class PrintExporter(base.Exporter):
                       implement :meth:`.Transport.export`. Defaults to
                       :class:`.SyncTransport`. The other option is
                       :class:`.BackgroundThreadTransport`.
-                      
+
     :type transport_config: :class:`dict`
     :param transport_config: Transport configuration dictionary.
     """

--- a/opencensus/trace/exporters/print_exporter.py
+++ b/opencensus/trace/exporters/print_exporter.py
@@ -29,8 +29,8 @@ class PrintExporter(base.Exporter):
                       :class:`.BackgroundThreadTransport`.
     """
 
-    def __init__(self, transport=sync.SyncTransport):
-        self.transport = transport(self)
+    def __init__(self, transport=sync.SyncTransport, transport_config=None):
+        self.transport = self.__init_transport(transport, transport_config)
 
     def emit(self, span_datas):
         """

--- a/opencensus/trace/exporters/stackdriver_exporter.py
+++ b/opencensus/trace/exporters/stackdriver_exporter.py
@@ -192,14 +192,14 @@ class StackdriverExporter(base.Exporter):
     """
 
     def __init__(self, client=None, project_id=None,
-                 transport=sync.SyncTransport):
+                 transport=sync.SyncTransport, transport_config=None):
         # The client will handle the case when project_id is None
         if client is None:
             client = Client(project=project_id)
 
         self.client = client
         self.project_id = client.project
-        self.transport = transport(self)
+        self.transport = self.__init_transport(transport, transport_config)
 
     def emit(self, span_datas):
         """

--- a/opencensus/trace/exporters/stackdriver_exporter.py
+++ b/opencensus/trace/exporters/stackdriver_exporter.py
@@ -199,7 +199,7 @@ class StackdriverExporter(base.Exporter):
 
         self.client = client
         self.project_id = client.project
-        self.transport = self.__init_transport(transport, transport_config)
+        self.transport = base.init_transport(self, transport, transport_config)
 
     def emit(self, span_datas):
         """

--- a/opencensus/trace/exporters/stackdriver_exporter.py
+++ b/opencensus/trace/exporters/stackdriver_exporter.py
@@ -189,7 +189,7 @@ class StackdriverExporter(base.Exporter):
                       implement :meth:`.Transport.export`. Defaults to
                       :class:`.SyncTransport`. The other option is
                       :class:`.BackgroundThreadTransport`.
-                      
+
     :type transport_config: :class:`dict`
     :param transport_config: Transport configuration dictionary.
     """

--- a/opencensus/trace/exporters/transports/background_thread.py
+++ b/opencensus/trace/exporters/transports/background_thread.py
@@ -121,7 +121,7 @@ class _Worker(object):
             if quit_:
                 break
 
-        logging.debug('Background thread exited.')
+        print('Background thread exited.')
 
     def start(self):
         """Starts the background thread.
@@ -176,12 +176,12 @@ class _Worker(object):
             return
 
         if not self._queue.empty():
-            logging.info('Sending all pending spans before terminated.')
+            print('Sending all pending spans before terminated.')
 
         if self.stop():
-            logging.info('Sent all pending spans.')
+            print('Sent all pending spans.')
         else:
-            logging.error('Failed to send pending spans.')
+            print('Failed to send pending spans.')
 
     def enqueue(self, span_datas):
         """Queues span_datas to be written by the background thread."""

--- a/opencensus/trace/exporters/transports/background_thread.py
+++ b/opencensus/trace/exporters/transports/background_thread.py
@@ -85,7 +85,7 @@ class _Worker(object):
         Pulls pending SpanData tuples off the queue and writes them in
         batches to the specified tracing backend using the exporter.
         """
-        logging.debug('Background thread started.')
+        print('Background thread started.')
 
         quit_ = False
 

--- a/opencensus/trace/exporters/transports/background_thread.py
+++ b/opencensus/trace/exporters/transports/background_thread.py
@@ -217,7 +217,7 @@ class BackgroundThreadTransport(base.Transport):
         self.worker.start()
 
     def export(self, span_datas):
-        """Put the trace to be exported into queue."""
+        """Put the traces to be exported into queue."""
         self.worker.enqueue(span_datas)
 
     def flush(self):

--- a/opencensus/trace/exporters/transports/background_thread.py
+++ b/opencensus/trace/exporters/transports/background_thread.py
@@ -85,7 +85,7 @@ class _Worker(object):
         Pulls pending SpanData tuples off the queue and writes them in
         batches to the specified tracing backend using the exporter.
         """
-        print('Background thread started.')
+        logging.debug('Background thread started.')
 
         quit_ = False
 
@@ -121,7 +121,7 @@ class _Worker(object):
             if quit_:
                 break
 
-        print('Background thread exited.')
+        logging.debug('Background thread exited.')
 
     def start(self):
         """Starts the background thread.
@@ -176,12 +176,12 @@ class _Worker(object):
             return
 
         if not self._queue.empty():
-            print('Sending all pending spans before terminated.')
+            logging.info('Sending all pending spans before terminated.')
 
         if self.stop():
-            print('Sent all pending spans.')
+            logging.info('Sent all pending spans.')
         else:
-            print('Failed to send pending spans.')
+            logging.error('Failed to send pending spans.')
 
     def enqueue(self, span_datas):
         """Queues span_datas to be written by the background thread."""

--- a/opencensus/trace/exporters/zipkin_exporter.py
+++ b/opencensus/trace/exporters/zipkin_exporter.py
@@ -86,7 +86,7 @@ class ZipkinExporter(base.Exporter):
         self.url = self.get_url
         self.ipv4 = ipv4
         self.ipv6 = ipv6
-        self.transport = self.__init_transport(transport, transport_config)
+        self.transport = base.init_transport(self, transport, transport_config)
 
     @property
     def get_url(self):

--- a/opencensus/trace/exporters/zipkin_exporter.py
+++ b/opencensus/trace/exporters/zipkin_exporter.py
@@ -65,6 +65,9 @@ class ZipkinExporter(base.Exporter):
                       implement :meth:`.Transport.export`. Defaults to
                       :class:`.SyncTransport`. The other option is
                       :class:`.BackgroundThreadTransport`.
+
+    :type transport_config: :class:`dict`
+    :param transport_config: Transport configuration dictionary.
     """
 
     def __init__(

--- a/opencensus/trace/exporters/zipkin_exporter.py
+++ b/opencensus/trace/exporters/zipkin_exporter.py
@@ -75,6 +75,7 @@ class ZipkinExporter(base.Exporter):
             endpoint=DEFAULT_ENDPOINT,
             protocol=DEFAULT_PROTOCOL,
             transport=sync.SyncTransport,
+            transport_config=None,
             ipv4=None,
             ipv6=None):
         self.service_name = service_name
@@ -83,9 +84,9 @@ class ZipkinExporter(base.Exporter):
         self.endpoint = endpoint
         self.protocol = protocol
         self.url = self.get_url
-        self.transport = transport(self)
         self.ipv4 = ipv4
         self.ipv6 = ipv6
+        self.transport = self.__init_transport(transport, transport_config)
 
     @property
     def get_url(self):


### PR DESCRIPTION
This PR adds support to pass options to the transport initialized in our exporters.

This will allow, for instance, to set the grace_period and max_batch_size for the BackgroundThread transport when initializing the exporter:
```
from opencensus.trace.exporters.stackdriver_exporter import StackdriverExporter
from opencensus.trace.exporters.transports.background_thread import BackgroundThreadTransport

exporter = StackdriverExporter(
    transport=BackgroundThreadTransport, 
    transport_config={'grace_period': 1, 'max_batch_size': 30})
```