### PR TITLE
Bump async transport default batch size to 200

### DIFF
--- a/opencensus/common/transports/async_.py
+++ b/opencensus/common/transports/async_.py
@@ -23,7 +23,7 @@ from six.moves import range
 from opencensus.common.transports import base
 
 _DEFAULT_GRACE_PERIOD = 5.0  # Seconds
-_DEFAULT_MAX_BATCH_SIZE = 10
+_DEFAULT_MAX_BATCH_SIZE = 200
 _WAIT_PERIOD = 60.0  # Seconds
 _WORKER_THREAD_NAME = 'opencensus.common.Worker'
 _WORKER_TERMINATOR = object()


### PR DESCRIPTION
This diff changes the default max batch size of async stats transport to match the [java client](https://github.com/census-instrumentation/opencensus-java/blob/90edbd5a8a0ff10d7658bd78beae9434aee8cdbe/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorker.java#L67).

One unintended consequence of #354 is that it changed the effective default rate of the transport from 10 items/second to .166 items/second, this diff raises it to 3.33 items/second.