### PR TITLE
Send to multiple exporters from tracer

### DIFF
--- a/opencensus/trace/ext/threading/trace.py
+++ b/opencensus/trace/ext/threading/trace.py
@@ -100,7 +100,7 @@ def wrap_apply_async(apply_async_func):
         )
         wrapped_kwargs["kwds"] = kwds
         wrapped_kwargs["sampler"] = _tracer.sampler
-        wrapped_kwargs["exporter"] = _tracer.exporter
+        wrapped_kwargs["exporters"] = _tracer.exporters
         wrapped_kwargs["propagator"] = _tracer.propagator
 
         return apply_async_func(
@@ -125,7 +125,7 @@ def wrap_submit(submit_func):
         )
         wrapped_kwargs["kwds"] = kwargs
         wrapped_kwargs["sampler"] = _tracer.sampler
-        wrapped_kwargs["exporter"] = _tracer.exporter
+        wrapped_kwargs["exporters"] = _tracer.exporters
         wrapped_kwargs["propagator"] = _tracer.propagator
 
         return submit_func(self, wrapped_func, *args, **wrapped_kwargs)

--- a/opencensus/trace/tracers/context_tracer.py
+++ b/opencensus/trace/tracers/context_tracer.py
@@ -31,14 +31,14 @@ class ContextTracer(base.Tracer):
                          the request's trace.
     """
 
-    def __init__(self, exporter=None, span_context=None):
-        if exporter is None:
-            exporter = print_exporter.PrintExporter()
+    def __init__(self, exporters=None, span_context=None):
+        if exporters is None:
+            exporters = [print_exporter.PrintExporter()]
 
         if span_context is None:
             span_context = SpanContext()
 
-        self.exporter = exporter
+        self.exporters = exporters
         self.span_context = span_context
         self.trace_id = span_context.trace_id
         self.root_span_id = span_context.span_id
@@ -120,7 +120,8 @@ class ContextTracer(base.Tracer):
         with self._spans_list_condition:
             if cur_span in self._spans_list:
                 span_datas = self.get_span_datas(cur_span)
-                self.exporter.export(span_datas)
+                for exporter in self.exporters:
+                    exporter.export(span_datas)
                 self._spans_list.remove(cur_span)
 
         return cur_span

--- a/tests/unit/trace/test_tracer.py
+++ b/tests/unit/trace/test_tracer.py
@@ -33,7 +33,8 @@ class TestTracer(unittest.TestCase):
 
         assert isinstance(tracer.span_context, SpanContext)
         assert isinstance(tracer.sampler, AlwaysOnSampler)
-        assert isinstance(tracer.exporter, print_exporter.PrintExporter)
+        [tracer_exporter] = tracer.exporters
+        assert isinstance(tracer_exporter, print_exporter.PrintExporter)
         assert isinstance(
             tracer.propagator,
             google_cloud_format.GoogleCloudFormatPropagator)
@@ -58,7 +59,8 @@ class TestTracer(unittest.TestCase):
 
         self.assertIs(tracer.span_context, span_context)
         self.assertIs(tracer.sampler, sampler)
-        self.assertIs(tracer.exporter, exporter)
+        [tracer_exporter] = tracer.exporters
+        self.assertIs(tracer_exporter, exporter)
         self.assertIs(tracer.propagator, propagator)
         assert isinstance(tracer.tracer, noop_tracer.NoopTracer)
 


### PR DESCRIPTION
This is an experimental branch to address #181. It changes `Tracer` such that it can use multiple exporters at once.

