### PR TITLE
Bump grpcio to 1.16.1

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,7 +2,7 @@ Django==1.11.15
 Flask==0.12.3
 google-cloud-monitoring==0.29.0
 google-cloud-trace==0.17.0
-grpcio==1.8.3
+grpcio==1.16.1
 mock==2.0.0
 mysql-connector==2.1.6
 psycopg2==2.7.3.1


### PR DESCRIPTION
 This fixes a version incompatibility problem with the [grpc hello world example](https://github.com/census-instrumentation/opencensus-python/blob/87a70bbc21a678d3e57ba85f1fd0ab1c76acbe57/examples/trace/grpc/hello_world_server.py).

To reproduce on master, run the server:

```sh
GOOGLE_APPLICATION_CREDENTIALS=/your/creds.json GOOGLE_CLOUD_PROJECT=your-gcloud-project python3 \
 ./examples/trace/grpc/hello_world_server.py
```
...and watch it crash when you run the client:
```sh
GOOGLE_APPLICATION_CREDENTIALS=/your/creds.json GOOGLE_CLOUD_PROJECT=your-gcloud-project python3 \
 ./examples/trace/grpc/hello_world_client.py
```
```
ERROR:root:Exception calling application: 'grpc._cython.cygrpc.Event' object has no attribute 'call_details'
Traceback (most recent call last):
  File "/usr/local/brew/lib/python3.7/site-packages/grpc/_server.py", line 377, in _call_behavior
    return behavior(argument, context), True
  File "/usr/local/brew/lib/python3.7/site-packages/opencensus/trace/ext/grpc/server_interceptor.py", line 46, in new_behavior
    span = self._start_server_span(servicer_context)
  File "/usr/local/brew/lib/python3.7/site-packages/opencensus/trace/ext/grpc/server_interceptor.py", line 111, in _start_server_span
    name=_get_span_name(servicer_context)
  File "/usr/local/brew/lib/python3.7/site-packages/opencensus/trace/ext/grpc/server_interceptor.py", line 167, in _get_span_name
    method_name = servicer_context._rpc_event.call_details.method[1:]
AttributeError: 'grpc._cython.cygrpc.Event' object has no attribute 'call_details'
```

We should consider running the examples as part of CI or [pinning the test dependencies](#387) to prevent this happening again.