### PR TITLE
s/1.0.8/0.1.8

### DIFF
--- a/opencensus/__version__.py
+++ b/opencensus/__version__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '1.0.8'
+__version__ = '0.1.8'


### PR DESCRIPTION
Fixes a typo from #369; the version should be `0.1.8`, not `1.0.8`. #369 was not supposed to be a major version update!