### PR TITLE
Change CircleCI config to build from vX.Y.Z tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ jobs:
 
 deployment:
   tag_build_for_cci2:
-    tag: /(([a-z]+)-)*([0-9]+)\.([0-9]+)\.([0-9]+)/
+    branch: /v([0-9]+)\.([0-9]+)\.([0-9]+)/
+    tag: /v([0-9]+)\.([0-9]+)\.([0-9]+)/
     commands:
       - true


### PR DESCRIPTION
Change the CI config so tags named `vX.Y.Z` result in a build, and only on similarly named branches.