### PR TITLE
Change config, bump tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ jobs:
 
 deployment:
   tag_build_for_cci2:
-    tag: /(([a-z]+)-)*([0-9]+)\.([0-9]+)\.([0-9]+)/
+    branch: /v([0-9]+)\.([0-9]+)\.([0-9]+)/
+    tag: /v([0-9]+)\.([0-9]+)\.([0-9]+)/
     commands:
       - true


### PR DESCRIPTION
Apply #413 to the release branch and move the `v0.1.9` tag to `HEAD`.