### PR TITLE
Don't build gh-pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,9 @@ version: 2
 
 jobs:
   build:
+    branches:
+      ignore:
+        - gh-pages
     docker:
       - image: googleapis/nox:0.17.0
       - image: mysql:5.7


### PR DESCRIPTION
The `gh-pages` branch is for generated documentation but CircleCI still tries to build it by default, resulting in failed builds like https://circleci.com/gh/census-instrumentation/opencensus-python/1054.

This diff should prevent CircleCI from building this branch.