### PR TITLE
Format all code with Google style

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,6 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
-
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -85,7 +84,6 @@ pygments_style = 'sphinx'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 
-
 # -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
@@ -125,7 +123,6 @@ html_sidebars = {
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'OPENCENSUSdoc'
 
-
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
@@ -154,16 +151,12 @@ latex_documents = [
      'OpenCensus Authors', 'manual'),
 ]
 
-
 # -- Options for manual page output ---------------------------------------
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'opencensus', 'OPENCENSUS Documentation',
-     [author], 1)
-]
-
+man_pages = [(master_doc, 'opencensus', 'OPENCENSUS Documentation', [author],
+              1)]
 
 # -- Options for Texinfo output -------------------------------------------
 
@@ -171,7 +164,6 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'OPENCENSUS', 'OPENCENSUS Documentation',
-     author, 'OPENCENSUS', 'One line description of project.',
-     'Miscellaneous'),
+    (master_doc, 'OPENCENSUS', 'OPENCENSUS Documentation', author, 'OPENCENSUS',
+     'One line description of project.', 'Miscellaneous'),
 ]

--- a/examples/stats/exporter/prometheus.py
+++ b/examples/stats/exporter/prometheus.py
@@ -29,16 +29,14 @@ from pprint import pprint
 
 MiB = 1 << 20
 FRONTEND_KEY = tag_key_module.TagKey("my.org/keys/frontend")
-VIDEO_SIZE_MEASURE = measure_module.MeasureInt(
-    "my.org/measures/video_size", "size of processed videos", "By")
+VIDEO_SIZE_MEASURE = measure_module.MeasureInt("my.org/measures/video_size",
+                                               "size of processed videos", "By")
 VIDEO_SIZE_VIEW_NAME = "my.org/views/video_size"
 VIDEO_SIZE_DISTRIBUTION = aggregation_module.DistributionAggregation(
     [0.0, 16.0 * MiB, 256.0 * MiB])
-VIDEO_SIZE_VIEW = view_module.View(VIDEO_SIZE_VIEW_NAME,
-                                   "processed video size over time",
-                                   [FRONTEND_KEY],
-                                   VIDEO_SIZE_MEASURE,
-                                   VIDEO_SIZE_DISTRIBUTION)
+VIDEO_SIZE_VIEW = view_module.View(
+    VIDEO_SIZE_VIEW_NAME, "processed video size over time", [FRONTEND_KEY],
+    VIDEO_SIZE_MEASURE, VIDEO_SIZE_DISTRIBUTION)
 
 
 def main():
@@ -46,7 +44,8 @@ def main():
     view_manager = stats.view_manager
     stats_recorder = stats.stats_recorder
 
-    exporter = prometheus.new_stats_exporter(prometheus.Options(namespace="opencensus"))
+    exporter = prometheus.new_stats_exporter(
+        prometheus.Options(namespace="opencensus"))
     view_manager.register_exporter(exporter)
 
     # Register view.
@@ -72,8 +71,8 @@ def main():
     view_data = view_manager.get_view(VIDEO_SIZE_VIEW_NAME)
     pprint(vars(view_data))
     for k, v in view_data._tag_value_aggregation_data_map.items():
-      pprint(k)
-      pprint(vars(v))
+        pprint(k)
+        pprint(vars(v))
 
 
 if __name__ == '__main__':

--- a/examples/stats/exporter/stackdriver.py
+++ b/examples/stats/exporter/stackdriver.py
@@ -29,20 +29,17 @@ VIDEO_SIZE_MEASURE = measure_module.MeasureInt(
     "my.org/measure/video_size_test2", "size of processed videos", "By")
 VIDEO_SIZE_VIEW_NAME = "my.org/views/video_size_test2"
 VIDEO_SIZE_DISTRIBUTION = aggregation_module.DistributionAggregation(
-                            [0.0, 16.0 * MiB, 256.0 * MiB])
-VIDEO_SIZE_VIEW = view_module.View(VIDEO_SIZE_VIEW_NAME,
-                                "processed video size over time",
-                                [FRONTEND_KEY],
-                                VIDEO_SIZE_MEASURE,
-                                VIDEO_SIZE_DISTRIBUTION)
-
-
+    [0.0, 16.0 * MiB, 256.0 * MiB])
+VIDEO_SIZE_VIEW = view_module.View(
+    VIDEO_SIZE_VIEW_NAME, "processed video size over time", [FRONTEND_KEY],
+    VIDEO_SIZE_MEASURE, VIDEO_SIZE_DISTRIBUTION)
 
 stats = stats_module.Stats()
 view_manager = stats.view_manager
 stats_recorder = stats.stats_recorder
 
-exporter = stackdriver.new_stats_exporter(stackdriver.Options(project_id="opencenus-node"))
+exporter = stackdriver.new_stats_exporter(
+    stackdriver.Options(project_id="opencenus-node"))
 view_manager.register_exporter(exporter)
 
 # Register view.

--- a/examples/stats/helloworld/main.py
+++ b/examples/stats/helloworld/main.py
@@ -28,16 +28,14 @@ from pprint import pprint
 
 MiB = 1 << 20
 FRONTEND_KEY = tag_key_module.TagKey("my.org/keys/frontend")
-VIDEO_SIZE_MEASURE = measure_module.MeasureInt(
-    "my.org/measures/video_size", "size of processed videos", "By")
+VIDEO_SIZE_MEASURE = measure_module.MeasureInt("my.org/measures/video_size",
+                                               "size of processed videos", "By")
 VIDEO_SIZE_VIEW_NAME = "my.org/views/video_size"
 VIDEO_SIZE_DISTRIBUTION = aggregation_module.DistributionAggregation(
     [0.0, 16.0 * MiB, 256.0 * MiB])
-VIDEO_SIZE_VIEW = view_module.View(VIDEO_SIZE_VIEW_NAME,
-                                   "processed video size over time",
-                                   [FRONTEND_KEY],
-                                   VIDEO_SIZE_MEASURE,
-                                   VIDEO_SIZE_DISTRIBUTION)
+VIDEO_SIZE_VIEW = view_module.View(
+    VIDEO_SIZE_VIEW_NAME, "processed video size over time", [FRONTEND_KEY],
+    VIDEO_SIZE_MEASURE, VIDEO_SIZE_DISTRIBUTION)
 
 
 def main():
@@ -64,8 +62,8 @@ def main():
     view_data = view_manager.get_view(VIDEO_SIZE_VIEW_NAME)
     pprint(vars(view_data))
     for k, v in view_data._tag_value_aggregation_data_map.items():
-      pprint(k)
-      pprint(vars(v))
+        pprint(k)
+        pprint(vars(v))
 
 
 if __name__ == '__main__':

--- a/examples/trace/grpc/hello_world_client.py
+++ b/examples/trace/grpc/hello_world_client.py
@@ -30,8 +30,7 @@ def main():
     exporter = stackdriver_exporter.StackdriverExporter()
     tracer = Tracer(exporter=exporter)
     tracer_interceptor = client_interceptor.OpenCensusClientInterceptor(
-        tracer,
-        host_port=HOST_PORT)
+        tracer, host_port=HOST_PORT)
     channel = grpc.insecure_channel(HOST_PORT)
     channel = grpc.intercept_channel(channel, tracer_interceptor)
     stub = hello_world_pb2_grpc.GreeterStub(channel)

--- a/examples/trace/grpc/hello_world_pb2.py
+++ b/examples/trace/grpc/hello_world_pb2.py
@@ -2,7 +2,7 @@
 # source: hello_world.proto
 
 import sys
-_b=sys.version_info[0]<3 and (lambda x:x) or (lambda x:x.encode('latin1'))
+_b = sys.version_info[0] < 3 and (lambda x: x) or (lambda x: x.encode('latin1'))
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
@@ -12,121 +12,136 @@ from google.protobuf import descriptor_pb2
 
 _sym_db = _symbol_database.Default()
 
-
-
-
 DESCRIPTOR = _descriptor.FileDescriptor(
-  name='hello_world.proto',
-  package='helloworld',
-  syntax='proto3',
-  serialized_pb=_b('\n\x11hello_world.proto\x12\nhelloworld\"\x1c\n\x0cHelloRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\"\x1d\n\nHelloReply\x12\x0f\n\x07message\x18\x01 \x01(\t2I\n\x07Greeter\x12>\n\x08SayHello\x12\x18.helloworld.HelloRequest\x1a\x16.helloworld.HelloReply\"\x00\x42\x30\n\x1bio.grpc.examples.helloworldB\x0fHelloWorldProtoP\x01\x62\x06proto3')
-)
-
-
-
+    name='hello_world.proto',
+    package='helloworld',
+    syntax='proto3',
+    serialized_pb=_b(
+        '\n\x11hello_world.proto\x12\nhelloworld\"\x1c\n\x0cHelloRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\"\x1d\n\nHelloReply\x12\x0f\n\x07message\x18\x01 \x01(\t2I\n\x07Greeter\x12>\n\x08SayHello\x12\x18.helloworld.HelloRequest\x1a\x16.helloworld.HelloReply\"\x00\x42\x30\n\x1bio.grpc.examples.helloworldB\x0fHelloWorldProtoP\x01\x62\x06proto3'
+    ))
 
 _HELLOREQUEST = _descriptor.Descriptor(
-  name='HelloRequest',
-  full_name='helloworld.HelloRequest',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='name', full_name='helloworld.HelloRequest.name', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=33,
-  serialized_end=61,
+    name='HelloRequest',
+    full_name='helloworld.HelloRequest',
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name='name',
+            full_name='helloworld.HelloRequest.name',
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b("").decode('utf-8'),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            options=None,
+            file=DESCRIPTOR),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    options=None,
+    is_extendable=False,
+    syntax='proto3',
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=33,
+    serialized_end=61,
 )
 
-
 _HELLOREPLY = _descriptor.Descriptor(
-  name='HelloReply',
-  full_name='helloworld.HelloReply',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='message', full_name='helloworld.HelloReply.message', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=63,
-  serialized_end=92,
+    name='HelloReply',
+    full_name='helloworld.HelloReply',
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name='message',
+            full_name='helloworld.HelloReply.message',
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b("").decode('utf-8'),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            options=None,
+            file=DESCRIPTOR),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    options=None,
+    is_extendable=False,
+    syntax='proto3',
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=63,
+    serialized_end=92,
 )
 
 DESCRIPTOR.message_types_by_name['HelloRequest'] = _HELLOREQUEST
 DESCRIPTOR.message_types_by_name['HelloReply'] = _HELLOREPLY
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
-HelloRequest = _reflection.GeneratedProtocolMessageType('HelloRequest', (_message.Message,), dict(
-  DESCRIPTOR = _HELLOREQUEST,
-  __module__ = 'hello_world_pb2'
-  # @@protoc_insertion_point(class_scope:helloworld.HelloRequest)
-  ))
+HelloRequest = _reflection.GeneratedProtocolMessageType(
+    'HelloRequest',
+    (_message.Message,),
+    dict(
+        DESCRIPTOR=_HELLOREQUEST,
+        __module__='hello_world_pb2'
+        # @@protoc_insertion_point(class_scope:helloworld.HelloRequest)
+    ))
 _sym_db.RegisterMessage(HelloRequest)
 
-HelloReply = _reflection.GeneratedProtocolMessageType('HelloReply', (_message.Message,), dict(
-  DESCRIPTOR = _HELLOREPLY,
-  __module__ = 'hello_world_pb2'
-  # @@protoc_insertion_point(class_scope:helloworld.HelloReply)
-  ))
+HelloReply = _reflection.GeneratedProtocolMessageType(
+    'HelloReply',
+    (_message.Message,),
+    dict(
+        DESCRIPTOR=_HELLOREPLY,
+        __module__='hello_world_pb2'
+        # @@protoc_insertion_point(class_scope:helloworld.HelloReply)
+    ))
 _sym_db.RegisterMessage(HelloReply)
 
-
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\n\033io.grpc.examples.helloworldB\017HelloWorldProtoP\001'))
+DESCRIPTOR._options = _descriptor._ParseOptions(
+    descriptor_pb2.FileOptions(),
+    _b('\n\033io.grpc.examples.helloworldB\017HelloWorldProtoP\001'))
 
 _GREETER = _descriptor.ServiceDescriptor(
-  name='Greeter',
-  full_name='helloworld.Greeter',
-  file=DESCRIPTOR,
-  index=0,
-  options=None,
-  serialized_start=94,
-  serialized_end=167,
-  methods=[
-  _descriptor.MethodDescriptor(
-    name='SayHello',
-    full_name='helloworld.Greeter.SayHello',
+    name='Greeter',
+    full_name='helloworld.Greeter',
+    file=DESCRIPTOR,
     index=0,
-    containing_service=None,
-    input_type=_HELLOREQUEST,
-    output_type=_HELLOREPLY,
     options=None,
-  ),
-])
+    serialized_start=94,
+    serialized_end=167,
+    methods=[
+        _descriptor.MethodDescriptor(
+            name='SayHello',
+            full_name='helloworld.Greeter.SayHello',
+            index=0,
+            containing_service=None,
+            input_type=_HELLOREQUEST,
+            output_type=_HELLOREPLY,
+            options=None,
+        ),
+    ])
 _sym_db.RegisterServiceDescriptor(_GREETER)
 
 DESCRIPTOR.services_by_name['Greeter'] = _GREETER

--- a/examples/trace/grpc/hello_world_pb2_grpc.py
+++ b/examples/trace/grpc/hello_world_pb2_grpc.py
@@ -5,42 +5,43 @@ import hello_world_pb2 as hello__world__pb2
 
 
 class GreeterStub(object):
-  """The hello world service definition.
+    """The hello world service definition.
   """
 
-  def __init__(self, channel):
-    """Constructor.
+    def __init__(self, channel):
+        """Constructor.
 
     Args:
       channel: A grpc.Channel.
     """
-    self.SayHello = channel.unary_unary(
-        '/helloworld.Greeter/SayHello',
-        request_serializer=hello__world__pb2.HelloRequest.SerializeToString,
-        response_deserializer=hello__world__pb2.HelloReply.FromString,
+        self.SayHello = channel.unary_unary(
+            '/helloworld.Greeter/SayHello',
+            request_serializer=hello__world__pb2.HelloRequest.SerializeToString,
+            response_deserializer=hello__world__pb2.HelloReply.FromString,
         )
 
 
 class GreeterServicer(object):
-  """The hello world service definition.
+    """The hello world service definition.
   """
 
-  def SayHello(self, request, context):
-    """Say hello to the request sender (unary-unary)
+    def SayHello(self, request, context):
+        """Say hello to the request sender (unary-unary)
     """
-    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-    context.set_details('Method not implemented!')
-    raise NotImplementedError('Method not implemented!')
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
 
 
 def add_GreeterServicer_to_server(servicer, server):
-  rpc_method_handlers = {
-      'SayHello': grpc.unary_unary_rpc_method_handler(
-          servicer.SayHello,
-          request_deserializer=hello__world__pb2.HelloRequest.FromString,
-          response_serializer=hello__world__pb2.HelloReply.SerializeToString,
-      ),
-  }
-  generic_handler = grpc.method_handlers_generic_handler(
-      'helloworld.Greeter', rpc_method_handlers)
-  server.add_generic_rpc_handlers((generic_handler,))
+    rpc_method_handlers = {
+        'SayHello':
+        grpc.unary_unary_rpc_method_handler(
+            servicer.SayHello,
+            request_deserializer=hello__world__pb2.HelloRequest.FromString,
+            response_serializer=hello__world__pb2.HelloReply.SerializeToString,
+        ),
+    }
+    generic_handler = grpc.method_handlers_generic_handler(
+        'helloworld.Greeter', rpc_method_handlers)
+    server.add_generic_rpc_handlers((generic_handler,))

--- a/examples/trace/helloworld/django/app/settings.py
+++ b/examples/trace/helloworld/django/app/settings.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Django settings for test app."""
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -66,10 +65,13 @@ TEMPLATES = [
 ]
 
 OPENCENSUS_TRACE = {
-    'SAMPLER': 'opencensus.trace.samplers.always_on.AlwaysOnSampler',
-    'EXPORTER': 'opencensus.trace.exporters.stackdriver_exporter.StackdriverExporter',
-    'PROPAGATOR': 'opencensus.trace.propagation.google_cloud_format.'
-                  'GoogleCloudFormatPropagator',
+    'SAMPLER':
+    'opencensus.trace.samplers.always_on.AlwaysOnSampler',
+    'EXPORTER':
+    'opencensus.trace.exporters.stackdriver_exporter.StackdriverExporter',
+    'PROPAGATOR':
+    'opencensus.trace.propagation.google_cloud_format.'
+    'GoogleCloudFormatPropagator',
 }
 
 OPENCENSUS_TRACE_PARAMS = {
@@ -88,7 +90,6 @@ USE_I18N = True
 USE_L10N = True
 
 USE_TZ = True
-
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.8/howto/static-files/

--- a/examples/trace/helloworld/django/app/urls.py
+++ b/examples/trace/helloworld/django/app/urls.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """project_name URL Configuration
 
 The `urlpatterns` list routes URLs to views. For more information please see:
@@ -31,7 +30,6 @@ from django.conf.urls import include, url
 from django.contrib import admin
 
 import app.views
-
 
 urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),

--- a/examples/trace/helloworld/django/app/views.py
+++ b/examples/trace/helloworld/django/app/views.py
@@ -51,8 +51,7 @@ def greetings(request):
         if form.is_valid():
             first_name = form.cleaned_data['fname']
             last_name = form.cleaned_data['lname']
-            return HttpResponse(
-                "Hello, {} {}".format(first_name, last_name))
+            return HttpResponse("Hello, {} {}".format(first_name, last_name))
         else:
             return render(request, 'home.html')
 
@@ -67,9 +66,7 @@ def trace_requests(request):
 def mysql_trace(request):
     try:
         conn = mysql.connector.connect(
-            host=DB_HOST,
-            user='root',
-            password=MYSQL_PASSWORD)
+            host=DB_HOST, user='root', password=MYSQL_PASSWORD)
         cursor = conn.cursor()
 
         query = 'SELECT 2*3'
@@ -114,8 +111,8 @@ def postgresql_trace(request):
 def sqlalchemy_mysql_trace(request):
     try:
         engine = sqlalchemy.create_engine(
-            'mysql+mysqlconnector://{}:{}@{}'.format(
-                'root', MYSQL_PASSWORD, DB_HOST))
+            'mysql+mysqlconnector://{}:{}@{}'.format('root', MYSQL_PASSWORD,
+                                                     DB_HOST))
         conn = engine.connect()
 
         query = 'SELECT 2*3'
@@ -136,10 +133,8 @@ def sqlalchemy_mysql_trace(request):
 
 def sqlalchemy_postgresql_trace(request):
     try:
-        engine = sqlalchemy.create_engine(
-            'postgresql://{}:{}@{}/{}'.format(
-                'postgres', POSTGRES_PASSWORD,
-                DB_HOST, 'postgres'))
+        engine = sqlalchemy.create_engine('postgresql://{}:{}@{}/{}'.format(
+            'postgres', POSTGRES_PASSWORD, DB_HOST, 'postgres'))
         conn = engine.connect()
 
         query = 'SELECT 2*3'

--- a/examples/trace/helloworld/flask/custom.py
+++ b/examples/trace/helloworld/flask/custom.py
@@ -71,9 +71,7 @@ def trace_requests():
 def mysql_query():
     try:
         conn = mysql.connector.connect(
-            host=DB_HOST,
-            user='root',
-            password=MYSQL_PASSWORD)
+            host=DB_HOST, user='root', password=MYSQL_PASSWORD)
         cursor = conn.cursor()
 
         query = 'SELECT 2*3'
@@ -126,8 +124,8 @@ def postgresql_query():
 def sqlalchemy_mysql_query():
     try:
         engine = sqlalchemy.create_engine(
-            'mysql+mysqlconnector://{}:{}@{}'.format(
-                'root', MYSQL_PASSWORD, DB_HOST))
+            'mysql+mysqlconnector://{}:{}@{}'.format('root', MYSQL_PASSWORD,
+                                                     DB_HOST))
         conn = engine.connect()
 
         query = 'SELECT 2*3'
@@ -149,10 +147,8 @@ def sqlalchemy_mysql_query():
 @app.route('/sqlalchemy-postgresql')
 def sqlalchemy_postgresql_query():
     try:
-        engine = sqlalchemy.create_engine(
-            'postgresql://{}:{}@{}/{}'.format(
-                'postgres', POSTGRES_PASSWORD,
-                DB_HOST, 'postgres'))
+        engine = sqlalchemy.create_engine('postgresql://{}:{}@{}/{}'.format(
+            'postgres', POSTGRES_PASSWORD, DB_HOST, 'postgres'))
         conn = engine.connect()
 
         query = 'SELECT 2*3'
@@ -173,9 +169,8 @@ def sqlalchemy_postgresql_query():
 
 @app.route('/greet/<name>')
 def greet(name):
-    stub = _get_grpc_stub(
-        hello_world_pb2_grpc.GreeterStub, HELLO_WORLD_HOST_PORT
-    )
+    stub = _get_grpc_stub(hello_world_pb2_grpc.GreeterStub,
+                          HELLO_WORLD_HOST_PORT)
     response = stub.SayHello(hello_world_pb2.HelloRequest(name=name))
     return str(response)
 
@@ -187,8 +182,7 @@ def _get_grpc_stub(stub_cls, host_port):
 
     channel = grpc.insecure_channel(host_port)
     tracer_interceptor = client_interceptor.OpenCensusClientInterceptor(
-        host_port=HELLO_WORLD_HOST_PORT
-    )
+        host_port=HELLO_WORLD_HOST_PORT)
     channel = grpc.intercept_channel(channel, tracer_interceptor)
     stub = stub_cls(channel)
     _stub_cache[(stub_cls, host_port)] = stub

--- a/examples/trace/helloworld/flask/simple.py
+++ b/examples/trace/helloworld/flask/simple.py
@@ -17,7 +17,6 @@ import flask
 from opencensus.trace.exporters import stackdriver_exporter
 from opencensus.trace.ext.flask.flask_middleware import FlaskMiddleware
 
-
 app = flask.Flask(__name__)
 
 # Enable tracing the requests

--- a/examples/trace/helloworld/main.py
+++ b/examples/trace/helloworld/main.py
@@ -30,8 +30,8 @@ def main():
     tracer = Tracer(sampler=sampler, exporter=exporter)
 
     with tracer.span(name='root') as root_span:
-        tracer.add_attribute_to_current_span(attribute_key='example key',
-                                             attribute_value='example value')
+        tracer.add_attribute_to_current_span(
+            attribute_key='example key', attribute_value='example value')
         function_to_trace()
         with tracer.span(name='child') as child_span:
             function_to_trace()

--- a/examples/trace/helloworld/pyramid/app/__init__.py
+++ b/examples/trace/helloworld/pyramid/app/__init__.py
@@ -37,9 +37,10 @@ def main(global_config, **settings):
     config.add_route('hello', '/')
     config.add_route('trace_requests', '/requests')
 
-    config.add_tween('opencensus.trace.ext.pyramid'
-                     '.pyramid_middleware.OpenCensusTweenFactory',
-                     over=MAIN)
+    config.add_tween(
+        'opencensus.trace.ext.pyramid'
+        '.pyramid_middleware.OpenCensusTweenFactory',
+        over=MAIN)
 
     config.scan()
 

--- a/examples/trace/helloworld/pyramid/simple.py
+++ b/examples/trace/helloworld/pyramid/simple.py
@@ -20,9 +20,7 @@ from opencensus.trace.samplers import probability
 
 from app import main
 
-
 INTEGRATIONS = ['requests']
-
 
 config_integration.trace_integrations(INTEGRATIONS)
 

--- a/nox.py
+++ b/nox.py
@@ -32,17 +32,9 @@ def unit(session, py):
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
-    session.run(
-        'py.test',
-        '--quiet',
-        '--cov=opencensus',
-        '--cov-append',
-        '--cov-config=.coveragerc',
-        '--cov-report=',
-        '--cov-fail-under=97',
-        'tests/unit/',
-        *session.posargs
-    )
+    session.run('py.test', '--quiet', '--cov=opencensus', '--cov-append',
+                '--cov-config=.coveragerc', '--cov-report=',
+                '--cov-fail-under=97', 'tests/unit/', *session.posargs)
 
 
 @nox.session
@@ -66,12 +58,7 @@ def system(session, py):
     session.install('.')
 
     # Run py.test against the system tests.
-    session.run(
-        'py.test',
-        '-s',
-        'tests/system/',
-        *session.posargs
-    )
+    session.run('py.test', '-s', 'tests/system/', *session.posargs)
 
 
 @nox.session
@@ -83,10 +70,9 @@ def lint(session):
     session.interpreter = 'python3.6'
     session.install('flake8')
     session.install('.')
-    session.run(
-        'flake8',
-        '--exclude=opencensus/trace/exporters/gen/opencensus/',
-        'opencensus/')
+    session.run('flake8', '--max-line-length=80',
+                '--exclude=opencensus/trace/exporters/gen/opencensus/',
+                'opencensus/')
 
 
 @nox.session
@@ -94,8 +80,7 @@ def lint_setup_py(session):
     """Verify that setup.py is valid (including RST check)."""
     session.interpreter = 'python3.6'
     session.install('docutils', 'pygments')
-    session.run(
-        'python', 'setup.py', 'check', '--restructuredtext', '--strict')
+    session.run('python', 'setup.py', 'check', '--restructuredtext', '--strict')
 
 
 @nox.session
@@ -125,5 +110,4 @@ def docs(session):
     session.install('-r', os.path.join('docs', 'requirements.txt'))
 
     # Build the docs!
-    session.run(
-        'bash', os.path.join('.', 'scripts', 'update_docs.sh'))
+    session.run('bash', os.path.join('.', 'scripts', 'update_docs.sh'))

--- a/opencensus/common/http_handler.py
+++ b/opencensus/common/http_handler.py
@@ -21,7 +21,6 @@ except ImportError:
     from urllib2 import urlopen, Request
     from urllib2 import HTTPError, URLError
 
-
 import socket
 
 _REQUEST_TIMEOUT = 2  # in secs

--- a/opencensus/common/monitored_resource_util/gcp_metadata_config.py
+++ b/opencensus/common/monitored_resource_util/gcp_metadata_config.py
@@ -145,9 +145,9 @@ class GcpMetadataConfig(object):
         computeMetadata/v1 prefix
         :return:  The value read from the metadata service or None
         """
-        attribute_value = get_request(_GCP_METADATA_URI +
-                                      _GKE_ATTRIBUTES[attribute_key],
-                                      _GCP_METADATA_URI_HEADER)
+        attribute_value = get_request(
+            _GCP_METADATA_URI + _GKE_ATTRIBUTES[attribute_key],
+            _GCP_METADATA_URI_HEADER)
 
         if attribute_value is not None and isinstance(attribute_value, bytes):
             # At least in python3, bytes are are returned from

--- a/opencensus/common/monitored_resource_util/monitored_resource.py
+++ b/opencensus/common/monitored_resource_util/monitored_resource.py
@@ -77,6 +77,7 @@ class AwsMonitoredResource(MonitoredResource):
     For definition refer to
     https://cloud.google.com/monitoring/api/resources#tag_aws_ec2_instance
     """
+
     @property
     def resource_type(self):
         return _AWS_EC2_INSTANCE

--- a/opencensus/common/transports/async_.py
+++ b/opencensus/common/transports/async_.py
@@ -46,7 +46,10 @@ class _Worker(object):
     :param max_batch_size: The maximum number of items to send at a time
                            in the background thread.
     """
-    def __init__(self, exporter, grace_period=_DEFAULT_GRACE_PERIOD,
+
+    def __init__(self,
+                 exporter,
+                 grace_period=_DEFAULT_GRACE_PERIOD,
                  max_batch_size=_DEFAULT_MAX_BATCH_SIZE):
         self.exporter = exporter
         self._grace_period = grace_period
@@ -107,8 +110,7 @@ class _Worker(object):
                     logging.exception(
                         '%s failed to emit data.'
                         'Dropping %s objects from queue.',
-                        self.exporter.__class__.__name__,
-                        len(data))
+                        self.exporter.__class__.__name__, len(data))
                     pass
 
             for _ in range(len(items)):
@@ -199,7 +201,9 @@ class AsyncTransport(base.Transport):
                            in the background thread.
     """
 
-    def __init__(self, exporter, grace_period=_DEFAULT_GRACE_PERIOD,
+    def __init__(self,
+                 exporter,
+                 grace_period=_DEFAULT_GRACE_PERIOD,
                  max_batch_size=_DEFAULT_MAX_BATCH_SIZE):
         self.exporter = exporter
         self.worker = _Worker(exporter, grace_period, max_batch_size)

--- a/opencensus/common/transports/base.py
+++ b/opencensus/common/transports/base.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Module containing base class for transport."""
 
 
@@ -20,6 +19,7 @@ class Transport(object):
 
     Subclasses of :class:`Transport` must override :meth:`export`.
     """
+
     def export(self, datas):
         """Export the data."""
         raise NotImplementedError

--- a/opencensus/common/transports/sync.py
+++ b/opencensus/common/transports/sync.py
@@ -16,6 +16,7 @@ from opencensus.common.transports import base
 
 
 class SyncTransport(base.Transport):
+
     def __init__(self, exporter):
         self.exporter = exporter
 

--- a/opencensus/metrics/export/metric.py
+++ b/opencensus/metrics/export/metric.py
@@ -15,7 +15,6 @@
 from opencensus.metrics.export import metric_descriptor
 from opencensus.metrics.export import value
 
-
 DESCRIPTOR_VALUE = {
     metric_descriptor.MetricDescriptorType.GAUGE_INT64:
     value.ValueLong,

--- a/opencensus/metrics/export/metric_descriptor.py
+++ b/opencensus/metrics/export/metric_descriptor.py
@@ -23,8 +23,7 @@ class _MetricDescriptorTypeMeta(type):
 
     def __contains__(cls, item):
         return item in {
-            MetricDescriptorType.GAUGE_INT64,
-            MetricDescriptorType.GAUGE_DOUBLE,
+            MetricDescriptorType.GAUGE_INT64, MetricDescriptorType.GAUGE_DOUBLE,
             MetricDescriptorType.GAUGE_DISTRIBUTION,
             MetricDescriptorType.CUMULATIVE_INT64,
             MetricDescriptorType.CUMULATIVE_DOUBLE,

--- a/opencensus/metrics/label_key.py
+++ b/opencensus/metrics/label_key.py
@@ -22,6 +22,7 @@ class LabelKey(object):
     :type description: str
     :param description: description of the label
     """
+
     def __init__(self, key, description):
         self._key = key
         self._description = description

--- a/opencensus/metrics/label_value.py
+++ b/opencensus/metrics/label_value.py
@@ -19,6 +19,7 @@ class LabelValue(object):
     :type value: str
     :param value: the value for the label
     """
+
     def __init__(self, value=None):
         self._value = value
 

--- a/opencensus/stats/aggregation.py
+++ b/opencensus/stats/aggregation.py
@@ -17,7 +17,6 @@ import logging
 from opencensus.stats import bucket_boundaries
 from opencensus.stats import aggregation_data
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -51,6 +50,7 @@ class BaseAggregation(object):
     :param aggregation_type: represents the type of this aggregation
 
     """
+
     def __init__(self, buckets=None, aggregation_type=Type.NONE):
         self._aggregation_type = aggregation_type
         self._buckets = buckets or []
@@ -78,6 +78,7 @@ class SumAggregation(BaseAggregation):
     :param aggregation_type: represents the type of this aggregation
 
     """
+
     def __init__(self, sum=None, aggregation_type=Type.SUM):
         super(SumAggregation, self).__init__(aggregation_type=aggregation_type)
         self._sum = aggregation_data.SumAggregationDataFloat(
@@ -101,9 +102,10 @@ class CountAggregation(BaseAggregation):
     :param aggregation_type: represents the type of this aggregation
 
     """
+
     def __init__(self, count=0, aggregation_type=Type.COUNT):
-        super(CountAggregation, self).__init__(
-            aggregation_type=aggregation_type)
+        super(CountAggregation,
+              self).__init__(aggregation_type=aggregation_type)
         self._count = aggregation_data.CountAggregationData(count)
         self.aggregation_data = self._count
 
@@ -144,8 +146,7 @@ class DistributionAggregation(BaseAggregation):
                 ii += 1
             if ii:
                 logger.warning("Dropping {} negative bucket boundaries, the "
-                               "values must be strictly > 0"
-                               .format(ii))
+                               "values must be strictly > 0".format(ii))
             boundaries = boundaries[ii:]
 
         super(DistributionAggregation, self).__init__(
@@ -177,11 +178,12 @@ class LastValueAggregation(BaseAggregation):
     :param aggregation_type: represents the type of this aggregation
 
     """
+
     def __init__(self, value=0, aggregation_type=Type.LASTVALUE):
-        super(LastValueAggregation, self).__init__(
-            aggregation_type=aggregation_type)
+        super(LastValueAggregation,
+              self).__init__(aggregation_type=aggregation_type)
         self.aggregation_data = aggregation_data.LastValueAggregationData(
-                                                                value=value)
+            value=value)
         self._value = value
 
     @property

--- a/opencensus/stats/aggregation_data.py
+++ b/opencensus/stats/aggregation_data.py
@@ -16,7 +16,6 @@ import logging
 
 from opencensus.stats import bucket_boundaries
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/opencensus/stats/bucket_boundaries.py
+++ b/opencensus/stats/bucket_boundaries.py
@@ -20,6 +20,7 @@ class BucketBoundaries(object):
     :param boundaries: boundaries for the buckets in the underlying histogram
 
     """
+
     def __init__(self, boundaries=None):
         self._boundaries = list(boundaries or [])
 

--- a/opencensus/stats/exporters/base.py
+++ b/opencensus/stats/exporters/base.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Module containing base class for exporters."""
 
 

--- a/opencensus/stats/exporters/prometheus_exporter.py
+++ b/opencensus/stats/exporters/prometheus_exporter.py
@@ -44,6 +44,7 @@ class Options(object):
     :type registry: :class:`~prometheus_client.core.CollectorRegistry`
     :param registry: A Prometheus collector registry instance.
     """
+
     def __init__(self,
                  namespace='',
                  port=8000,
@@ -82,6 +83,7 @@ class Options(object):
 class Collector(object):
     """ Collector represents the Prometheus Collector object
     """
+
     def __init__(self, options=Options(), view_data={}):
         self._options = options
         self._registry = options.registry
@@ -122,9 +124,11 @@ class Collector(object):
         signature = view_signature(self.options.namespace, view)
 
         if signature not in self.registered_views:
-            desc = {'name': view_name(self.options.namespace, view),
-                    'documentation': view.description,
-                    'labels': tag_keys_to_labels(view.columns)}
+            desc = {
+                'name': view_name(self.options.namespace, view),
+                'documentation': view.description,
+                'labels': tag_keys_to_labels(view.columns)
+            }
             self.registered_views[signature] = desc
             count += 1
             self.registry.register(self)
@@ -158,45 +162,48 @@ class Collector(object):
 
         if isinstance(agg_data, aggregation_data_module.CountAggregationData):
             labels = desc['labels'] if agg_data.count_data is None else None
-            return CounterMetricFamily(name=desc['name'],
-                                       documentation=desc['documentation'],
-                                       value=float(agg_data.count_data),
-                                       labels=labels)
+            return CounterMetricFamily(
+                name=desc['name'],
+                documentation=desc['documentation'],
+                value=float(agg_data.count_data),
+                labels=labels)
         elif isinstance(agg_data,
                         aggregation_data_module.DistributionAggregationData):
 
-            assert(agg_data.bounds == sorted(agg_data.bounds))
+            assert (agg_data.bounds == sorted(agg_data.bounds))
             points = {}
             cum_count = 0
             for ii, bound in enumerate(agg_data.bounds):
                 cum_count += agg_data.counts_per_bucket[ii]
                 points[str(bound)] = cum_count
             labels = desc['labels'] if points is None else None
-            return HistogramMetricFamily(name=desc['name'],
-                                         documentation=desc['documentation'],
-                                         buckets=list(points.items()),
-                                         sum_value=agg_data.sum,
-                                         labels=labels)
+            return HistogramMetricFamily(
+                name=desc['name'],
+                documentation=desc['documentation'],
+                buckets=list(points.items()),
+                sum_value=agg_data.sum,
+                labels=labels)
 
         elif isinstance(agg_data,
                         aggregation_data_module.SumAggregationDataFloat):
             labels = desc['labels'] if agg_data.sum_data is None else None
-            return UntypedMetricFamily(name=desc['name'],
-                                       documentation=desc['documentation'],
-                                       value=agg_data.sum_data,
-                                       labels=labels)
+            return UntypedMetricFamily(
+                name=desc['name'],
+                documentation=desc['documentation'],
+                value=agg_data.sum_data,
+                labels=labels)
 
         elif isinstance(agg_data,
                         aggregation_data_module.LastValueAggregationData):
             labels = desc['labels'] if agg_data.value is None else None
-            return GaugeMetricFamily(name=desc['name'],
-                                     documentation=desc['documentation'],
-                                     value=agg_data.value,
-                                     labels=labels)
+            return GaugeMetricFamily(
+                name=desc['name'],
+                documentation=desc['documentation'],
+                value=agg_data.value,
+                labels=labels)
 
         else:
-            raise ValueError("unsupported aggregation type %s"
-                             % type(agg_data))
+            raise ValueError("unsupported aggregation type %s" % type(agg_data))
 
     def collect(self):  # pragma: NO COVER
         """Collect fetches the statistics from OpenCensus
@@ -208,8 +215,7 @@ class Collector(object):
             signature = view_signature(self.options.namespace,
                                        self.view_data[v_data].view)
             desc = self.registered_views[signature]
-            metric = self.to_metric(desc,
-                                    self.view_data[v_data].view)
+            metric = self.to_metric(desc, self.view_data[v_data].view)
             yield metric
 
     def describe(self):
@@ -223,8 +229,7 @@ class Collector(object):
             if not isinstance(v_data, str):
                 signature = view_signature(self.options.namespace, v_data.view)
                 desc = self.registered_views[signature]
-                metric = self.to_metric(desc,
-                                        self.view_data[v_data].view)
+                metric = self.to_metric(desc, self.view_data[v_data].view)
                 yield metric
 
 
@@ -250,6 +255,7 @@ class PrometheusStatsExporter(base.StatsExporter):
         :class:`~opencensus.stats.exporters.prometheus_exporters.Collector`
     :param collector: An instance of the Prometheus Collector object.
     """
+
     def __init__(self,
                  options,
                  gatherer,
@@ -313,8 +319,8 @@ class PrometheusStatsExporter(base.StatsExporter):
     def serve_http(self):
         """ serve_http serves the Prometheus endpoint.
         """
-        start_http_server(port=self.options.port,
-                          addr=str(self.options.address))
+        start_http_server(
+            port=self.options.port, addr=str(self.options.address))
 
 
 def new_stats_exporter(option):
@@ -326,9 +332,8 @@ def new_stats_exporter(option):
 
     collector = new_collector(option)
 
-    exporter = PrometheusStatsExporter(options=option,
-                                       gatherer=option.registry,
-                                       collector=collector)
+    exporter = PrometheusStatsExporter(
+        options=option, gatherer=option.registry, collector=collector)
     return exporter
 
 

--- a/opencensus/stats/exporters/stackdriver_exporter.py
+++ b/opencensus/stats/exporters/stackdriver_exporter.py
@@ -42,6 +42,7 @@ GLOBAL_RESOURCE_TYPE = 'global'
 class Options(object):
     """ Options contains options for configuring the exporter.
     """
+
     def __init__(self,
                  project_id="",
                  resource="",
@@ -109,6 +110,7 @@ class Options(object):
 class StackdriverStatsExporter(base.StatsExporter):
     """ StackdriverStatsExporter exports stats
     to the Stackdriver Monitoring."""
+
     def __init__(self,
                  options=Options(),
                  client=None,
@@ -239,7 +241,7 @@ class StackdriverStatsExporter(base.StatsExporter):
             point.interval.end_time.seconds = int(timestamp_end)
 
             secs = point.interval.end_time.seconds
-            point.interval.end_time.nanos = int((timestamp_end-secs)*10**9)
+            point.interval.end_time.nanos = int((timestamp_end - secs) * 10**9)
 
             if type(agg) is not aggregation.aggregation_data.\
                     LastValueAggregationData:  # pragma: NO COVER
@@ -295,8 +297,8 @@ class StackdriverStatsExporter(base.StatsExporter):
             if isinstance(view_measure, measure.MeasureFloat):
                 value_type = metric_desc.ValueType.DOUBLE
         else:
-            raise Exception("unsupported aggregation type: %s"
-                            % type(view_aggregation))
+            raise Exception(
+                "unsupported aggregation type: %s" % type(view_aggregation))
 
         display_name_prefix = DEFAULT_DISPLAY_NAME_PREFIX
         if self.options.metric_prefix != "":
@@ -345,8 +347,7 @@ def set_monitored_resource(series, option_resource_type):
                                     'namespace_name')
                 set_attribute_label(series, resource_labels, 'pod_id',
                                     'pod_name')
-                set_attribute_label(series, resource_labels, 'zone',
-                                    'location')
+                set_attribute_label(series, resource_labels, 'zone', 'location')
 
             elif monitored_resource.resource_type == 'gce_instance':
                 resource_type = monitored_resource.resource_type
@@ -358,15 +359,21 @@ def set_monitored_resource(series, option_resource_type):
                 resource_type = monitored_resource.resource_type
                 set_attribute_label(series, resource_labels, 'aws_account')
                 set_attribute_label(series, resource_labels, 'instance_id')
-                set_attribute_label(series, resource_labels, 'region',
-                                    label_value_prefix='aws:')
+                set_attribute_label(
+                    series,
+                    resource_labels,
+                    'region',
+                    label_value_prefix='aws:')
     else:
         resource_type = option_resource_type
     series.resource.type = resource_type
 
 
-def set_attribute_label(series, resource_labels, attribute_key,
-                        canonical_key=None, label_value_prefix=''):
+def set_attribute_label(series,
+                        resource_labels,
+                        attribute_key,
+                        canonical_key=None,
+                        label_value_prefix=''):
     """Set a label to timeseries that can be used for monitoring
     :param series: TimeSeries object based on view data
     :param resource_labels: collection of labels

--- a/opencensus/stats/measure.py
+++ b/opencensus/stats/measure.py
@@ -27,6 +27,7 @@ class BaseMeasure(object):
     :param unit: the units in which the measure values are measured
 
     """
+
     def __init__(self, name, description, unit=None):
         self._name = name
         self._description = description
@@ -50,11 +51,13 @@ class BaseMeasure(object):
 
 class MeasureInt(BaseMeasure):
     """Creates an Integer Measure"""
+
     def __init__(self, name, description, unit=None):
         super(MeasureInt, self).__init__(name, description, unit)
 
 
 class MeasureFloat(BaseMeasure):
     """Creates a Float Measure"""
+
     def __init__(self, name, description, unit=None):
         super(MeasureFloat, self).__init__(name, description, unit)

--- a/opencensus/stats/measure_to_view_map.py
+++ b/opencensus/stats/measure_to_view_map.py
@@ -92,8 +92,8 @@ class MeasureToViewMap(object):
         if registered_measure is None:
             self._registered_measures[measure.name] = measure
         self._measure_to_view_data_list_map[view.measure.name].append(
-            view_data_module.ViewData(view=view, start_time=timestamp,
-                                      end_time=timestamp))
+            view_data_module.ViewData(
+                view=view, start_time=timestamp, end_time=timestamp))
 
     def record(self, tags, measurement_map, timestamp, attachments=None):
         """records stats with a set of tags"""
@@ -108,7 +108,9 @@ class MeasureToViewMap(object):
                     view_datas.extend(view_data_list)
             for view_data in view_datas:
                 view_data.record(
-                    context=tags, value=value, timestamp=timestamp,
+                    context=tags,
+                    value=value,
+                    timestamp=timestamp,
                     attachments=attachments)
             self.export(view_datas)
 

--- a/opencensus/stats/measurement.py
+++ b/opencensus/stats/measurement.py
@@ -23,6 +23,7 @@ class Measurement(object):
     :param value: value of the measurement
 
     """
+
     def __init__(self, measure, value):
         self._measure = measure
         self._value = value
@@ -40,11 +41,13 @@ class Measurement(object):
 
 class MeasurementInt(Measurement):
     """ Creates a new Integer Measurement """
+
     def __init__(self, measure, value):
         super(MeasurementInt, self).__init__(measure, value)
 
 
 class MeasurementFloat(Measurement):
     """ Creates a new Float Measurement """
+
     def __init__(self, measure, value):
         super(MeasurementFloat, self).__init__(measure, value)

--- a/opencensus/stats/measurement_map.py
+++ b/opencensus/stats/measurement_map.py
@@ -17,7 +17,6 @@ import logging
 
 from opencensus.tags import execution_context
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -34,6 +33,7 @@ class MeasurementMap(object):
     :param attachments: the contextual information about the attachment value.
 
     """
+
     def __init__(self, measure_to_view_map, attachments=None):
         self._measurement_map = {}
         self._measure_to_view_map = measure_to_view_map
@@ -107,13 +107,12 @@ class MeasurementMap(object):
                 logger.warning("Dropping values, value to record must be "
                                "non-negative")
                 logger.info("Measure '{}' has negative value ({}), refusing "
-                            "to record measurements from {}"
-                            .format(measure.name, value, self))
+                            "to record measurements from {}".format(
+                                measure.name, value, self))
                 return
 
         self.measure_to_view_map.record(
-                tags=tag_map_tags,
-                measurement_map=self.measurement_map,
-                timestamp=datetime.utcnow().isoformat() + 'Z',
-                attachments=self.attachments
-        )
+            tags=tag_map_tags,
+            measurement_map=self.measurement_map,
+            timestamp=datetime.utcnow().isoformat() + 'Z',
+            attachments=self.attachments)

--- a/opencensus/stats/metric_utils.py
+++ b/opencensus/stats/metric_utils.py
@@ -77,7 +77,9 @@ def view_to_metric_descriptor(view):
     :param view: the view data to for which to build a metric descriptor
     """
     return metric_descriptor.MetricDescriptor(
-        view.name, view.description, view.measure.unit,
+        view.name,
+        view.description,
+        view.measure.unit,
         get_metric_type(view.measure, view.aggregation),
         # TODO: add label key description
         [label_key.LabelKey(tk, "") for tk in view.columns])

--- a/opencensus/stats/stats.py
+++ b/opencensus/stats/stats.py
@@ -20,6 +20,7 @@ class Stats(object):
     """Stats defines a View Manager and a Stats Recorder in order for the
     collection of Stats
     """
+
     def __init__(self):
         self._stats_recorder = StatsRecorder()
         self._view_manager = ViewManager()

--- a/opencensus/stats/stats_recorder.py
+++ b/opencensus/stats/stats_recorder.py
@@ -21,6 +21,7 @@ class StatsRecorder(object):
     """Stats Recorder provides methods to record stats against tags
 
     """
+
     def __init__(self):
         if execution_context.get_measure_to_view_map() == {}:
             execution_context.set_measure_to_view_map(MeasureToViewMap())

--- a/opencensus/stats/view.py
+++ b/opencensus/stats/view.py
@@ -33,6 +33,7 @@ class View(object):
     :param aggregation: the aggregation the view will support
 
     """
+
     def __init__(self, name, description, columns, measure, aggregation):
         self._name = name
         self._description = description

--- a/opencensus/stats/view_data.py
+++ b/opencensus/stats/view_data.py
@@ -29,10 +29,8 @@ class ViewData(object):
     :param end_time: the end time for this view data
 
     """
-    def __init__(self,
-                 view,
-                 start_time,
-                 end_time):
+
+    def __init__(self, view, start_time, end_time):
         self._view = view
         self._start_time = start_time
         self._end_time = end_time
@@ -81,8 +79,8 @@ class ViewData(object):
 
     def record(self, context, value, timestamp, attachments=None):
         """records the view data against context"""
-        tag_values = self.get_tag_values(tags=context.map,
-                                         columns=self.view.columns)
+        tag_values = self.get_tag_values(
+            tags=context.map, columns=self.view.columns)
         tuple_vals = tuple(tag_values)
         if tuple_vals not in self.tag_value_aggregation_data_map:
             self.tag_value_aggregation_data_map[tuple_vals] = copy.deepcopy(

--- a/opencensus/stats/view_manager.py
+++ b/opencensus/stats/view_manager.py
@@ -20,6 +20,7 @@ from datetime import datetime
 class ViewManager(object):
     """View Manager allows the registering of Views for collecting stats
     and receiving stats data as View Data"""
+
     def __init__(self):
         self.time = datetime.utcnow().isoformat() + 'Z'
         if execution_context.get_measure_to_view_map() == {}:
@@ -38,8 +39,8 @@ class ViewManager(object):
 
     def get_view(self, view_name):
         """gets the view given the view name """
-        return self.measure_to_view_map.get_view(view_name=view_name,
-                                                 timestamp=self.time)
+        return self.measure_to_view_map.get_view(
+            view_name=view_name, timestamp=self.time)
 
     def get_all_exported_views(self):
         """returns all of the exported views for the current measure to view

--- a/opencensus/tags/propagation/binary_serializer.py
+++ b/opencensus/tags/propagation/binary_serializer.py
@@ -30,6 +30,7 @@ TAG_MAP_SERIALIZED_SIZE_LIMIT = 8192
 
 
 class BinarySerializer(object):
+
     def from_byte_array(self, binary):
         if len(binary) <= 0:
             logging.warning("Input byte[] cannot be empty/")
@@ -51,8 +52,7 @@ class BinarySerializer(object):
             tag_key, tag_value = tag
             total_chars += len(tag_key)
             total_chars += len(tag_value)
-            encoded_bytes = self._encode_tag(
-                tag_key, tag_value, encoded_bytes)
+            encoded_bytes = self._encode_tag(tag_key, tag_value, encoded_bytes)
         if total_chars <= TAG_MAP_SERIALIZED_SIZE_LIMIT:
             return encoded_bytes
         else:  # pragma: NO COVER

--- a/opencensus/trace/__init__.py
+++ b/opencensus/trace/__init__.py
@@ -14,5 +14,4 @@
 
 from opencensus.trace.span import Span
 
-
 __all__ = ['Span']

--- a/opencensus/trace/attributes.py
+++ b/opencensus/trace/attributes.py
@@ -38,6 +38,7 @@ class Attributes(object):
                        to 128 bytes long. The value can be a string up to 256
                        bytes, an integer, or the Boolean values true and false.
     """
+
     def __init__(self, attributes=None):
         self.attributes = attributes or {}
 
@@ -64,8 +65,6 @@ class Attributes(object):
             if value is not None:
                 attributes_json[key] = value
 
-        result = {
-            'attributeMap': attributes_json
-        }
+        result = {'attributeMap': attributes_json}
 
         return result

--- a/opencensus/trace/attributes_helper.py
+++ b/opencensus/trace/attributes_helper.py
@@ -34,7 +34,6 @@ COMMON_ATTRIBUTES = {
     'TID': 'tid',
 }
 
-
 GRPC_ATTRIBUTES = {
     'GRPC_HOST_PORT': 'grpc.host_port',
     'GRPC_METHOD': 'grpc.method',

--- a/opencensus/trace/base_span.py
+++ b/opencensus/trace/base_span.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Module containing base class for Span."""
 
 

--- a/opencensus/trace/blank_span.py
+++ b/opencensus/trace/blank_span.py
@@ -40,21 +40,20 @@ class BlankSpan(base_span.BaseSpan):
                            the finish method in the Span class.
     """
 
-    def __init__(
-            self,
-            name=None,
-            parent_span=None,
-            attributes=None,
-            start_time=None,
-            end_time=None,
-            span_id=None,
-            stack_trace=None,
-            time_events=None,
-            links=None,
-            status=None,
-            same_process_as_parent_span=None,
-            context_tracer=None,
-            span_kind=None):
+    def __init__(self,
+                 name=None,
+                 parent_span=None,
+                 attributes=None,
+                 start_time=None,
+                 end_time=None,
+                 span_id=None,
+                 stack_trace=None,
+                 time_events=None,
+                 links=None,
+                 status=None,
+                 same_process_as_parent_span=None,
+                 context_tracer=None,
+                 span_kind=None):
         self.name = name
         self.parent_span = parent_span
         self.start_time = start_time
@@ -126,8 +125,9 @@ class BlankSpan(base_span.BaseSpan):
         :param time_event: A TimeEvent object.
         """
         if not isinstance(time_event, time_event_module.TimeEvent):
-            raise TypeError("Type Error: received {}, but requires TimeEvent.".
-                            format(type(time_event).__name__))
+            raise TypeError(
+                "Type Error: received {}, but requires TimeEvent.".format(
+                    type(time_event).__name__))
 
     def add_link(self, link):
         """No-op implementation of this method.

--- a/opencensus/trace/config_integration.py
+++ b/opencensus/trace/config_integration.py
@@ -17,9 +17,10 @@ import logging
 
 log = logging.getLogger(__name__)
 
-SUPPORTED_INTEGRATIONS = ['httplib', 'mysql', 'postgresql', 'pymysql',
-                          'requests', 'sqlalchemy', 'google_cloud_clientlibs',
-                          'threading']
+SUPPORTED_INTEGRATIONS = [
+    'httplib', 'mysql', 'postgresql', 'pymysql', 'requests', 'sqlalchemy',
+    'google_cloud_clientlibs', 'threading'
+]
 
 PATH_PREFIX = 'opencensus.trace.ext'
 
@@ -40,10 +41,8 @@ def trace_integrations(integrations, tracer=None):
             integrated.append(item)
         except Exception as e:
             log.warning(
-                'Failed to integrate module: {}, supported integrations are {}'
-                .format(
-                    item,
-                    ', '.join(str(x) for x in SUPPORTED_INTEGRATIONS)))
+                'Failed to integrate module: {}, supported integrations are {}'.
+                format(item, ', '.join(str(x) for x in SUPPORTED_INTEGRATIONS)))
             log.warning('{}'.format(e))
 
     return integrated

--- a/opencensus/trace/exporters/base.py
+++ b/opencensus/trace/exporters/base.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Module containing base class for exporters."""
 
 

--- a/opencensus/trace/exporters/file_exporter.py
+++ b/opencensus/trace/exporters/file_exporter.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Export the trace spans to a local file."""
 
 import json
@@ -41,7 +40,8 @@ class FileExporter(base.Exporter):
 
     """
 
-    def __init__(self, file_name=DEFAULT_FILENAME,
+    def __init__(self,
+                 file_name=DEFAULT_FILENAME,
                  transport=sync.SyncTransport,
                  file_mode='w+'):
         self.file_name = file_name

--- a/opencensus/trace/exporters/jaeger_exporter.py
+++ b/opencensus/trace/exporters/jaeger_exporter.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Export the spans data to Jaeger."""
 
 import logging
@@ -74,18 +73,17 @@ class JaegerExporter(base.Exporter):
                       :class:`.BackgroundThreadTransport`.
     """
 
-    def __init__(
-            self,
-            service_name='my_service',
-            host_name=None,
-            port=None,
-            username=None,
-            password=None,
-            endpoint='',
-            agent_host_name=DEFAULT_HOST_NAME,
-            agent_port=DEFAULT_AGENT_PORT,
-            agent_endpoint=DEFAULT_ENDPOINT,
-            transport=sync.SyncTransport):
+    def __init__(self,
+                 service_name='my_service',
+                 host_name=None,
+                 port=None,
+                 username=None,
+                 password=None,
+                 endpoint='',
+                 agent_host_name=DEFAULT_HOST_NAME,
+                 agent_port=DEFAULT_AGENT_PORT,
+                 agent_endpoint=DEFAULT_ENDPOINT,
+                 transport=sync.SyncTransport):
         self.transport = transport(self)
         self.service_name = service_name
         self.host_name = host_name
@@ -102,8 +100,7 @@ class JaegerExporter(base.Exporter):
     def agent_client(self):
         if self._agent_client is None:
             self._agent_client = AgentClientUDP(
-                host_name=self.agent_host_name,
-                port=self.agent_port)
+                host_name=self.agent_host_name, port=self.agent_port)
         return self._agent_client
 
     @property
@@ -114,17 +111,14 @@ class JaegerExporter(base.Exporter):
         if self.host_name is None or self.port is None:
             return None
 
-        thrift_url = 'http://{}:{}{}'.format(
-            self.host_name,
-            self.port,
-            self.endpoint or DEFAULT_ENDPOINT)
+        thrift_url = 'http://{}:{}{}'.format(self.host_name, self.port,
+                                             self.endpoint or DEFAULT_ENDPOINT)
 
         auth = None
         if self.username is not None and self.password is not None:
             auth = (self.username, self.password)
 
-        self._collector = Collector(
-            thrift_url=thrift_url, auth=auth)
+        self._collector = Collector(thrift_url=thrift_url, auth=auth)
         return self._collector
 
     def emit(self, span_datas):
@@ -181,15 +175,17 @@ class JaegerExporter(base.Exporter):
 
             status = span.status
             if status is not None:
-                tags.append(jaeger.Tag(
-                    key='status.code',
-                    vType=jaeger.TagType.LONG,
-                    vLong=status.code))
+                tags.append(
+                    jaeger.Tag(
+                        key='status.code',
+                        vType=jaeger.TagType.LONG,
+                        vLong=status.code))
 
-                tags.append(jaeger.Tag(
-                    key='status.message',
-                    vType=jaeger.TagType.STRING,
-                    vStr=status.message))
+                tags.append(
+                    jaeger.Tag(
+                        key='status.message',
+                        vType=jaeger.TagType.STRING,
+                        vStr=status.message))
 
             refs = _extract_refs_from_span(span)
             logs = _extract_logs_from_span(span)
@@ -227,11 +223,12 @@ def _extract_refs_from_span(span):
     refs = []
     for link in span.links:
         trace_id = link.trace_id
-        refs.append(jaeger.SpanRef(
-            refType=_convert_reftype_to_jaeger_reftype(link.type),
-            traceIdHigh=_convert_hex_str_to_int(trace_id[0:16]),
-            traceIdLow=_convert_hex_str_to_int(trace_id[16:32]),
-            spanId=_convert_hex_str_to_int(link.span_id)))
+        refs.append(
+            jaeger.SpanRef(
+                refType=_convert_reftype_to_jaeger_reftype(link.type),
+                traceIdHigh=_convert_hex_str_to_int(trace_id[0:16]),
+                traceIdLow=_convert_hex_str_to_int(trace_id[16:32]),
+                spanId=_convert_hex_str_to_int(link.span_id)))
     return refs
 
 
@@ -272,14 +269,15 @@ def _extract_logs_from_span(span):
         if annotation.attributes is not None:
             fields = _extract_tags(annotation.attributes.attributes)
 
-        fields.append(jaeger.Tag(
-            key='message',
-            vType=jaeger.TagType.STRING,
-            vStr=annotation.description))
+        fields.append(
+            jaeger.Tag(
+                key='message',
+                vType=jaeger.TagType.STRING,
+                vStr=annotation.description))
 
         event_timestamp = timestamp_to_microseconds(time_event.timestamp)
-        logs.append(jaeger.Log(timestamp=int(round(event_timestamp)),
-                               fields=fields))
+        logs.append(
+            jaeger.Log(timestamp=int(round(event_timestamp)), fields=fields))
     return logs
 
 
@@ -298,20 +296,11 @@ def _extract_tags(attr):
 def _convert_attribute_to_tag(key, attr):
     """Convert the attributes to jaeger tags."""
     if isinstance(attr, bool):
-        return jaeger.Tag(
-            key=key,
-            vBool=attr,
-            vType=jaeger.TagType.BOOL)
+        return jaeger.Tag(key=key, vBool=attr, vType=jaeger.TagType.BOOL)
     if isinstance(attr, str):
-        return jaeger.Tag(
-            key=key,
-            vStr=attr,
-            vType=jaeger.TagType.STRING)
+        return jaeger.Tag(key=key, vStr=attr, vType=jaeger.TagType.STRING)
     if isinstance(attr, int):
-        return jaeger.Tag(
-            key=key,
-            vLong=attr,
-            vType=jaeger.TagType.LONG)
+        return jaeger.Tag(key=key, vLong=attr, vType=jaeger.TagType.LONG)
     logging.warn('Could not serialize attribute \
             {}:{} to tag'.format(key, attr))
     return None
@@ -339,13 +328,12 @@ class Collector(base.Exporter):
                            HTTP server.
     """
 
-    def __init__(
-            self,
-            thrift_url='',
-            auth=None,
-            client=jaeger.Client,
-            transport=sync.SyncTransport,
-            http_transport=THttpClient.THttpClient):
+    def __init__(self,
+                 thrift_url='',
+                 auth=None,
+                 client=jaeger.Client,
+                 transport=sync.SyncTransport,
+                 http_transport=THttpClient.THttpClient):
         self.transport = transport(self)
         self.thrift_url = thrift_url
         self.auth = auth
@@ -417,13 +405,12 @@ class AgentClientUDP(base.Exporter):
                       :class:`.BackgroundThreadTransport`.
     """
 
-    def __init__(
-            self,
-            host_name=DEFAULT_HOST_NAME,
-            port=DEFAULT_AGENT_PORT,
-            max_packet_size=UDP_PACKET_MAX_LENGTH,
-            client=agent.Client,
-            transport=sync.SyncTransport):
+    def __init__(self,
+                 host_name=DEFAULT_HOST_NAME,
+                 port=DEFAULT_AGENT_PORT,
+                 max_packet_size=UDP_PACKET_MAX_LENGTH,
+                 client=agent.Client,
+                 transport=sync.SyncTransport):
         self.transport = transport(self)
         self.address = (host_name, port)
         self.max_packet_size = max_packet_size

--- a/opencensus/trace/exporters/logging_exporter.py
+++ b/opencensus/trace/exporters/logging_exporter.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Export the spans data to python logging."""
 
 import logging

--- a/opencensus/trace/exporters/ocagent/trace_exporter.py
+++ b/opencensus/trace/exporters/ocagent/trace_exporter.py
@@ -60,13 +60,12 @@ class TraceExporter(base.Exporter):
                       :class:`.BackgroundThreadTransport`.
     """
 
-    def __init__(
-            self,
-            service_name,
-            host_name=None,
-            endpoint=None,
-            client=None,
-            transport=sync.SyncTransport):
+    def __init__(self,
+                 service_name,
+                 host_name=None,
+                 endpoint=None,
+                 client=None,
+                 transport=sync.SyncTransport):
         self.transport = transport(self)
         self.endpoint = DEFAULT_ENDPOINT if endpoint is None else endpoint
 
@@ -80,17 +79,15 @@ class TraceExporter(base.Exporter):
         self.service_name = service_name
         self.node = common_pb2.Node(
             identifier=common_pb2.ProcessIdentifier(
-                host_name=socket.gethostname() if host_name is None
-                else host_name,
+                host_name=socket.gethostname()
+                if host_name is None else host_name,
                 pid=os.getpid(),
                 start_timestamp=utils.proto_ts_from_datetime(
-                    datetime.datetime.now())
-            ),
+                    datetime.datetime.now())),
             library_info=common_pb2.LibraryInfo(
                 language=common_pb2.LibraryInfo.Language.Value('PYTHON'),
                 exporter_version=EXPORTER_VERSION,
-                core_library_version=__version__
-            ),
+                core_library_version=__version__),
             service_info=common_pb2.ServiceInfo(name=self.service_name))
 
     def emit(self, span_datas):
@@ -143,13 +140,14 @@ class TraceExporter(base.Exporter):
         :returns: List of span export requests.
         """
 
-        pb_spans = [utils.translate_to_trace_proto(
-            span_data) for span_data in span_datas]
+        pb_spans = [
+            utils.translate_to_trace_proto(span_data)
+            for span_data in span_datas
+        ]
 
         # TODO: send node once per channel
         yield trace_service_pb2.ExportTraceServiceRequest(
-            node=self.node,
-            spans=pb_spans)
+            node=self.node, spans=pb_spans)
 
     # TODO: better support for receiving config updates
     def update_config(self, config):
@@ -188,7 +186,6 @@ class TraceExporter(base.Exporter):
 
         # TODO: send node once per channel
         request = trace_service_pb2.CurrentLibraryConfig(
-            node=self.node,
-            config=config)
+            node=self.node, config=config)
 
         yield request

--- a/opencensus/trace/exporters/ocagent/utils.py
+++ b/opencensus/trace/exporters/ocagent/utils.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Translates opencensus span data to trace proto"""
 
 from google.protobuf.internal.well_known_types import ParseError
@@ -43,13 +42,11 @@ def translate_to_trace_proto(span_data):
         start_time=proto_ts_from_datetime_str(span_data.start_time),
         end_time=proto_ts_from_datetime_str(span_data.end_time),
         status=trace_pb2.Status(
-            code=span_data.status.code,
-            message=span_data.status.message)
+            code=span_data.status.code, message=span_data.status.message)
         if span_data.status is not None else None,
         same_process_as_parent_span=BoolValue(
             value=span_data.same_process_as_parent_span)
-        if span_data.same_process_as_parent_span is not None
-        else None,
+        if span_data.same_process_as_parent_span is not None else None,
         child_span_count=UInt32Value(value=span_data.child_span_count)
         if span_data.child_span_count is not None else None)
 
@@ -57,10 +54,8 @@ def translate_to_trace_proto(span_data):
     if span_data.attributes is not None:
         for attribute_key, attribute_value \
                 in span_data.attributes.items():
-            add_proto_attribute_value(
-                pb_span.attributes,
-                attribute_key,
-                attribute_value)
+            add_proto_attribute_value(pb_span.attributes, attribute_key,
+                                      attribute_value)
 
     # time events
     if span_data.time_events is not None:
@@ -68,15 +63,13 @@ def translate_to_trace_proto(span_data):
             if span_data_event.message_event is not None:
                 pb_event = pb_span.time_events.time_event.add()
                 pb_event.time.FromJsonString(span_data_event.timestamp)
-                set_proto_message_event(
-                    pb_event.message_event,
-                    span_data_event.message_event)
+                set_proto_message_event(pb_event.message_event,
+                                        span_data_event.message_event)
             elif span_data_event.annotation is not None:
                 pb_event = pb_span.time_events.time_event.add()
                 pb_event.time.FromJsonString(span_data_event.timestamp)
-                set_proto_annotation(
-                    pb_event.annotation,
-                    span_data_event.annotation)
+                set_proto_annotation(pb_event.annotation,
+                                     span_data_event.annotation)
 
     # links
     if span_data.links is not None:
@@ -90,10 +83,8 @@ def translate_to_trace_proto(span_data):
                     link.attributes.attributes is not None:
                 for attribute_key, attribute_value \
                         in link.attributes.attributes.items():
-                    add_proto_attribute_value(
-                        pb_link.attributes,
-                        attribute_key,
-                        attribute_value)
+                    add_proto_attribute_value(pb_link.attributes, attribute_key,
+                                              attribute_value)
 
     # tracestate
     if span_data.context.tracestate is not None:
@@ -103,9 +94,7 @@ def translate_to_trace_proto(span_data):
     return pb_span
 
 
-def set_proto_message_event(
-        pb_message_event,
-        span_data_message_event):
+def set_proto_message_event(pb_message_event, span_data_message_event):
     """Sets properties on the protobuf message event.
 
     :type pb_message_event:
@@ -143,10 +132,8 @@ def set_proto_annotation(pb_annotation, span_data_annotation):
             and span_data_annotation.attributes.attributes is not None:
         for attribute_key, attribute_value in \
                 span_data_annotation.attributes.attributes.items():
-            add_proto_attribute_value(
-                pb_annotation.attributes,
-                attribute_key,
-                attribute_value)
+            add_proto_attribute_value(pb_annotation.attributes, attribute_key,
+                                      attribute_value)
 
 
 def hex_str_to_bytes_str(hex_str):
@@ -197,10 +184,7 @@ def proto_ts_from_datetime(dt):
     return ts
 
 
-def add_proto_attribute_value(
-        pb_attributes,
-        attribute_key,
-        attribute_value):
+def add_proto_attribute_value(pb_attributes, attribute_key, attribute_value):
     """Sets string, int or boolean value on protobuf
         span, link or annotation attributes.
 

--- a/opencensus/trace/exporters/print_exporter.py
+++ b/opencensus/trace/exporters/print_exporter.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Export the trace spans by printing them out."""
 
 from opencensus.trace.exporters import base

--- a/opencensus/trace/exporters/stackdriver_exporter.py
+++ b/opencensus/trace/exporters/stackdriver_exporter.py
@@ -94,30 +94,37 @@ def set_monitored_resource_attributes(span):
                                 'container_name')
             set_attribute_label(span, resource_type, resource_labels,
                                 'namespace_id', 'namespace_name')
-            set_attribute_label(span, resource_type, resource_labels,
-                                'pod_id', 'pod_name')
-            set_attribute_label(span, resource_type, resource_labels,
-                                'zone', 'location')
+            set_attribute_label(span, resource_type, resource_labels, 'pod_id',
+                                'pod_name')
+            set_attribute_label(span, resource_type, resource_labels, 'zone',
+                                'location')
 
         elif resource_type == 'gce_instance':
             set_attribute_label(span, resource_type, resource_labels,
                                 'project_id')
             set_attribute_label(span, resource_type, resource_labels,
                                 'instance_id')
-            set_attribute_label(span, resource_type, resource_labels,
-                                'zone')
+            set_attribute_label(span, resource_type, resource_labels, 'zone')
 
         elif resource_type == 'aws_ec2_instance':
             set_attribute_label(span, resource_type, resource_labels,
                                 'aws_account')
             set_attribute_label(span, resource_type, resource_labels,
                                 'instance_id')
-            set_attribute_label(span, resource_type, resource_labels,
-                                'region', label_value_prefix='aws:')
+            set_attribute_label(
+                span,
+                resource_type,
+                resource_labels,
+                'region',
+                label_value_prefix='aws:')
 
 
-def set_attribute_label(span, resource_type, resource_labels, attribute_key,
-                        canonical_key=None, label_value_prefix=''):
+def set_attribute_label(span,
+                        resource_type,
+                        resource_labels,
+                        attribute_key,
+                        canonical_key=None,
+                        label_value_prefix=''):
     """Set a label to span that can be used for tracing.
     :param span: Span object
     :param resource_type: resource type
@@ -131,9 +138,10 @@ def set_attribute_label(span, resource_type, resource_labels, attribute_key,
         if canonical_key is None:
             canonical_key = attribute_key
 
-        pair = {RESOURCE_LABEL % (resource_type, canonical_key):
-                label_value_prefix + resource_labels[attribute_key]
-                }
+        pair = {
+            RESOURCE_LABEL % (resource_type, canonical_key):
+            label_value_prefix + resource_labels[attribute_key]
+        }
         pair_attrs = Attributes(pair).format_attributes_json()\
             .get('attributeMap')
 
@@ -191,7 +199,9 @@ class StackdriverExporter(base.Exporter):
                       :class:`.BackgroundThreadTransport`.
     """
 
-    def __init__(self, client=None, project_id=None,
+    def __init__(self,
+                 client=None,
+                 project_id=None,
                  transport=sync.SyncTransport):
         # The client will handle the case when project_id is None
         if client is None:
@@ -300,22 +310,17 @@ ATTRIBUTE_MAPPING = {
     'http.client_country': '/http/client_country',
     'http.client_protocol': '/http/client_protocol',
     'http.client_region': '/http/client_region',
-
     'http.host': '/http/host',
     'http.method': '/http/method',
-
     'http.redirected_url': '/http/redirected_url',
     'http.request_size': '/http/request/size',
     'http.response_size': '/http/response/size',
-
     'http.status_code': '/http/status_code',
     'http.url': '/http/url',
     'http.user_agent': '/http/user_agent',
-
     'pid': '/pid',
     'stacktrace': '/stacktrace',
     'tid': '/tid',
-
     'grpc.host_port': '/grpc/host_port',
     'grpc.method': '/grpc/method',
 }

--- a/opencensus/trace/exporters/transports/background_thread.py
+++ b/opencensus/trace/exporters/transports/background_thread.py
@@ -48,7 +48,10 @@ class _Worker(object):
     :param max_batch_size: The maximum number of items to send at a time
                            in the background thread.
     """
-    def __init__(self, exporter, grace_period=_DEFAULT_GRACE_PERIOD,
+
+    def __init__(self,
+                 exporter,
+                 grace_period=_DEFAULT_GRACE_PERIOD,
                  max_batch_size=_DEFAULT_MAX_BATCH_SIZE):
         self.exporter = exporter
         self._grace_period = grace_period
@@ -110,8 +113,7 @@ class _Worker(object):
                     logging.exception(
                         '%s failed to emit spans.'
                         'Dropping %s spans from queue.',
-                        self.exporter.__class__.__name__,
-                        len(span_datas))
+                        self.exporter.__class__.__name__, len(span_datas))
                     pass
 
             for _ in range(len(items)):
@@ -212,7 +214,9 @@ class BackgroundThreadTransport(base.Transport):
                            in the background thread.
     """
 
-    def __init__(self, exporter, grace_period=_DEFAULT_GRACE_PERIOD,
+    def __init__(self,
+                 exporter,
+                 grace_period=_DEFAULT_GRACE_PERIOD,
                  max_batch_size=_DEFAULT_MAX_BATCH_SIZE):
         self.exporter = exporter
         self.worker = _Worker(exporter, grace_period, max_batch_size)

--- a/opencensus/trace/exporters/transports/base.py
+++ b/opencensus/trace/exporters/transports/base.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Module containing base class for transport."""
 
 
@@ -20,6 +19,7 @@ class Transport(object):
 
     Subclasses of :class:`Transport` must override :meth:`export`.
     """
+
     def export(self, span_datas):
         """Export the SpanData tuples by calling exporter.emit()."""
         raise NotImplementedError

--- a/opencensus/trace/exporters/transports/sync.py
+++ b/opencensus/trace/exporters/transports/sync.py
@@ -16,6 +16,7 @@ from opencensus.trace.exporters.transports import base
 
 
 class SyncTransport(base.Transport):
+
     def __init__(self, exporter):
         self.exporter = exporter
 

--- a/opencensus/trace/exporters/zipkin_exporter.py
+++ b/opencensus/trace/exporters/zipkin_exporter.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Export the spans data to Zipkin Collector."""
 
 import json
@@ -67,16 +66,15 @@ class ZipkinExporter(base.Exporter):
                       :class:`.BackgroundThreadTransport`.
     """
 
-    def __init__(
-            self,
-            service_name='my_service',
-            host_name=DEFAULT_HOST_NAME,
-            port=DEFAULT_PORT,
-            endpoint=DEFAULT_ENDPOINT,
-            protocol=DEFAULT_PROTOCOL,
-            transport=sync.SyncTransport,
-            ipv4=None,
-            ipv6=None):
+    def __init__(self,
+                 service_name='my_service',
+                 host_name=DEFAULT_HOST_NAME,
+                 port=DEFAULT_PORT,
+                 endpoint=DEFAULT_ENDPOINT,
+                 protocol=DEFAULT_PROTOCOL,
+                 transport=sync.SyncTransport,
+                 ipv4=None,
+                 ipv6=None):
         self.service_name = service_name
         self.host_name = host_name
         self.port = port
@@ -89,11 +87,8 @@ class ZipkinExporter(base.Exporter):
 
     @property
     def get_url(self):
-        return '{}://{}:{}{}'.format(
-            self.protocol,
-            self.host_name,
-            self.port,
-            self.endpoint)
+        return '{}://{}:{}{}'.format(self.protocol, self.host_name, self.port,
+                                     self.endpoint)
 
     def emit(self, span_datas):
         """Send SpanData tuples to Zipkin server, default using the v2 API.
@@ -113,8 +108,8 @@ class ZipkinExporter(base.Exporter):
 
             if result.status_code not in SUCCESS_STATUS_CODE:
                 logging.error(
-                    "Failed to send spans to Zipkin server! Spans are {}"
-                    .format(zipkin_spans))
+                    "Failed to send spans to Zipkin server! Spans are {}".
+                    format(zipkin_spans))
         except Exception as e:  # pragma: NO COVER
             logging.error(getattr(e, 'message', e))
 
@@ -210,7 +205,9 @@ def _extract_annotations_from_span(span):
             continue
 
         event_timestamp_mus = timestamp_to_microseconds(time_event.timestamp)
-        annotations.append({'timestamp': int(round(event_timestamp_mus)),
-                            'value': annotation.description})
+        annotations.append({
+            'timestamp': int(round(event_timestamp_mus)),
+            'value': annotation.description
+        })
 
     return annotations

--- a/opencensus/trace/ext/dbapi/trace.py
+++ b/opencensus/trace/ext/dbapi/trace.py
@@ -23,6 +23,7 @@ QUERY_WRAP_METHODS = ['execute', 'executemany']
 
 def wrap_conn(conn_func):
     """Wrap the mysql conn object with TraceConnection."""
+
     def call(*args, **kwargs):
         try:
             conn = conn_func(*args, **kwargs)
@@ -33,10 +34,12 @@ def wrap_conn(conn_func):
         except Exception:  # pragma: NO COVER
             logging.warning('Fail to wrap conn, mysql not traced.')
             return conn_func(*args, **kwargs)
+
     return call
 
 
 def wrap_cursor(cursor_func):
+
     def call(*args, **kwargs):
         try:
             cursor = cursor_func(*args, **kwargs)
@@ -48,22 +51,24 @@ def wrap_cursor(cursor_func):
         except Exception:  # pragma: NO COVER
             logging.warning('Fail to wrap cursor, mysql not traced.')
             return cursor_func(*args, **kwargs)
+
     return call
 
 
 def trace_cursor_query(query_func):
+
     def call(query, *args, **kwargs):
         _tracer = execution_context.get_opencensus_tracer()
         _span = _tracer.start_span()
         _span.name = 'mysql.query'
         _span.span_kind = span_module.SpanKind.CLIENT
         _tracer.add_attribute_to_current_span('mysql.query', query)
-        _tracer.add_attribute_to_current_span(
-            'mysql.cursor.method.name',
-            query_func.__name__)
+        _tracer.add_attribute_to_current_span('mysql.cursor.method.name',
+                                              query_func.__name__)
 
         result = query_func(query, *args, **kwargs)
 
         _tracer.end_span()
         return result
+
     return call

--- a/opencensus/trace/ext/django/config.py
+++ b/opencensus/trace/ext/django/config.py
@@ -18,11 +18,13 @@ import logging
 from django.conf import settings as django_settings
 
 DEFAULT_DJANGO_TRACER_CONFIG = {
-    'SAMPLER': 'opencensus.trace.samplers.always_on.AlwaysOnSampler',
+    'SAMPLER':
+    'opencensus.trace.samplers.always_on.AlwaysOnSampler',
     'EXPORTER':
-        'opencensus.trace.exporters.print_exporter.PrintExporter',
-    'PROPAGATOR': 'opencensus.trace.propagation.google_cloud_format.'
-                  'GoogleCloudFormatPropagator',
+    'opencensus.trace.exporters.print_exporter.PrintExporter',
+    'PROPAGATOR':
+    'opencensus.trace.propagation.google_cloud_format.'
+    'GoogleCloudFormatPropagator',
 }
 
 DEFAULT_DJANGO_TRACER_PARAMS = {
@@ -41,7 +43,6 @@ DEFAULT_DJANGO_TRACER_PARAMS = {
     'TRANSPORT': 'opencensus.trace.exporters.transports.sync.SyncTransport',
 }
 
-
 PATH_DELIMITER = '.'
 TRANSPORT = 'TRANSPORT'
 
@@ -56,15 +57,11 @@ class DjangoTraceSettings(object):
 
     def __init__(self):
         # Try to read the user settings from django settings file
-        self.settings = getattr(
-            django_settings,
-            'OPENCENSUS_TRACE',
-            DEFAULT_DJANGO_TRACER_CONFIG)
+        self.settings = getattr(django_settings, 'OPENCENSUS_TRACE',
+                                DEFAULT_DJANGO_TRACER_CONFIG)
 
-        self.params = getattr(
-            django_settings,
-            'OPENCENSUS_TRACE_PARAMS',
-            DEFAULT_DJANGO_TRACER_PARAMS)
+        self.params = getattr(django_settings, 'OPENCENSUS_TRACE_PARAMS',
+                              DEFAULT_DJANGO_TRACER_PARAMS)
 
         # Set default value for the tracer config if user not specified
         _set_default_configs(self.settings, DEFAULT_DJANGO_TRACER_CONFIG)

--- a/opencensus/trace/ext/django/middleware.py
+++ b/opencensus/trace/ext/django/middleware.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Django middleware helper to capture and trace a request."""
 import logging
 
@@ -118,8 +117,8 @@ class OpencensusMiddleware(MiddlewareMixin):
 
         # Initialize the sampler
         if self._sampler.__name__ == 'ProbabilitySampler':
-            _rate = settings.params.get(
-                SAMPLING_RATE, probability.DEFAULT_SAMPLING_RATE)
+            _rate = settings.params.get(SAMPLING_RATE,
+                                        probability.DEFAULT_SAMPLING_RATE)
             self.sampler = self._sampler(_rate)
         else:
             self.sampler = self._sampler()
@@ -130,16 +129,14 @@ class OpencensusMiddleware(MiddlewareMixin):
         if self._exporter.__name__ == 'GoogleCloudExporter':
             _project_id = settings.params.get(GCP_EXPORTER_PROJECT, None)
             self.exporter = self._exporter(
-                project_id=_project_id,
-                transport=transport)
+                project_id=_project_id, transport=transport)
         elif self._exporter.__name__ == 'ZipkinExporter':
             _service_name = self._get_service_name(settings.params)
-            _zipkin_host_name = settings.params.get(
-                ZIPKIN_EXPORTER_HOST_NAME, 'localhost')
-            _zipkin_port = settings.params.get(
-                ZIPKIN_EXPORTER_PORT, 9411)
-            _zipkin_protocol = settings.params.get(
-                ZIPKIN_EXPORTER_PROTOCOL, 'http')
+            _zipkin_host_name = settings.params.get(ZIPKIN_EXPORTER_HOST_NAME,
+                                                    'localhost')
+            _zipkin_port = settings.params.get(ZIPKIN_EXPORTER_PORT, 9411)
+            _zipkin_protocol = settings.params.get(ZIPKIN_EXPORTER_PROTOCOL,
+                                                   'http')
             self.exporter = self._exporter(
                 service_name=_service_name,
                 host_name=_zipkin_host_name,
@@ -148,8 +145,8 @@ class OpencensusMiddleware(MiddlewareMixin):
                 transport=transport)
         elif self._exporter.__name__ == 'TraceExporter':
             _service_name = self._get_service_name(settings.params)
-            _endpoint = settings.params.get(
-                OCAGENT_TRACE_EXPORTER_ENDPOINT, None)
+            _endpoint = settings.params.get(OCAGENT_TRACE_EXPORTER_ENDPOINT,
+                                            None)
             self.exporter = self._exporter(
                 service_name=_service_name,
                 endpoint=_endpoint,
@@ -157,13 +154,12 @@ class OpencensusMiddleware(MiddlewareMixin):
         elif self._exporter.__name__ == 'JaegerExporter':
             _service_name = self._get_service_name(settings.params)
             self.exporter = self._exporter(
-                service_name=_service_name,
-                transport=transport)
+                service_name=_service_name, transport=transport)
         else:
             self.exporter = self._exporter(transport=transport)
 
-        self.blacklist_hostnames = settings.params.get(
-            BLACKLIST_HOSTNAMES, None)
+        self.blacklist_hostnames = settings.params.get(BLACKLIST_HOSTNAMES,
+                                                       None)
 
         # Initialize the propagator
         self.propagator = self._propagator()
@@ -179,13 +175,10 @@ class OpencensusMiddleware(MiddlewareMixin):
             return
 
         # Add the request to thread local
-        execution_context.set_opencensus_attr(
-            REQUEST_THREAD_LOCAL_KEY,
-            request)
+        execution_context.set_opencensus_attr(REQUEST_THREAD_LOCAL_KEY, request)
 
-        execution_context.set_opencensus_attr(
-            'blacklist_hostnames',
-            self.blacklist_hostnames)
+        execution_context.set_opencensus_attr('blacklist_hostnames',
+                                              self.blacklist_hostnames)
 
         try:
             # Start tracing this request
@@ -203,20 +196,16 @@ class OpencensusMiddleware(MiddlewareMixin):
             span = tracer.start_span()
             span.span_kind = span_module.SpanKind.SERVER
             tracer.add_attribute_to_current_span(
-                attribute_key=HTTP_METHOD,
-                attribute_value=request.method)
+                attribute_key=HTTP_METHOD, attribute_value=request.method)
             tracer.add_attribute_to_current_span(
-                attribute_key=HTTP_URL,
-                attribute_value=request.path)
+                attribute_key=HTTP_URL, attribute_value=request.path)
 
             # Add the span to thread local
             # in some cases (exceptions, timeouts) currentspan in
             # response event will be one of a child spans.
             # let's keep reference to 'django' span and
             # use it in response event
-            execution_context.set_opencensus_attr(
-                SPAN_THREAD_LOCAL_KEY,
-                span)
+            execution_context.set_opencensus_attr(SPAN_THREAD_LOCAL_KEY, span)
 
         except Exception:  # pragma: NO COVER
             log.error('Failed to trace request', exc_info=True)
@@ -261,11 +250,10 @@ class OpencensusMiddleware(MiddlewareMixin):
             return response
 
     def _get_service_name(self, params):
-        _service_name = params.get(
-            SERVICE_NAME, None)
+        _service_name = params.get(SERVICE_NAME, None)
 
         if _service_name is None:
-            _service_name = params.get(
-                ZIPKIN_EXPORTER_SERVICE_NAME, 'my_service')
+            _service_name = params.get(ZIPKIN_EXPORTER_SERVICE_NAME,
+                                       'my_service')
 
         return _service_name

--- a/opencensus/trace/ext/google_cloud_clientlibs/trace.py
+++ b/opencensus/trace/ext/google_cloud_clientlibs/trace.py
@@ -23,8 +23,8 @@ from opencensus.trace import execution_context
 from opencensus.trace.ext.grpc.client_interceptor import (
     OpenCensusClientInterceptor)
 
-from opencensus.trace.ext.requests.trace import (
-    trace_integration as trace_requests)
+from opencensus.trace.ext.requests.trace import (trace_integration as
+                                                 trace_requests)
 
 log = logging.getLogger(__name__)
 
@@ -54,27 +54,18 @@ def trace_grpc(tracer=None):
     make_secure_channel_func = getattr(_helpers, MAKE_SECURE_CHANNEL)
     make_secure_channel_wrapped = wrap_make_secure_channel(
         make_secure_channel_func, tracer)
-    setattr(
-        _helpers,
-        MAKE_SECURE_CHANNEL,
-        make_secure_channel_wrapped)
+    setattr(_helpers, MAKE_SECURE_CHANNEL, make_secure_channel_wrapped)
 
     # Wrap the grpc.insecure_channel.
     insecure_channel_func = getattr(grpc, INSECURE_CHANNEL)
-    insecure_channel_wrapped = wrap_insecure_channel(
-        insecure_channel_func, tracer)
-    setattr(
-        grpc,
-        INSECURE_CHANNEL,
-        insecure_channel_wrapped)
+    insecure_channel_wrapped = wrap_insecure_channel(insecure_channel_func,
+                                                     tracer)
+    setattr(grpc, INSECURE_CHANNEL, insecure_channel_wrapped)
 
     # Wrap google.api_core.grpc_helpers.create_channel
     create_channel_func = getattr(grpc_helpers, CREATE_CHANNEL)
     create_channel_wrapped = wrap_create_channel(create_channel_func, tracer)
-    setattr(
-        grpc_helpers,
-        CREATE_CHANNEL,
-        create_channel_wrapped)
+    setattr(grpc_helpers, CREATE_CHANNEL, create_channel_wrapped)
 
 
 def trace_http(tracer=None):
@@ -84,6 +75,7 @@ def trace_http(tracer=None):
 
 def wrap_make_secure_channel(make_secure_channel_func, tracer=None):
     """Wrap the google.cloud._helpers.make_secure_channel."""
+
     def call(*args, **kwargs):
         channel = make_secure_channel_func(*args, **kwargs)
 
@@ -98,15 +90,16 @@ def wrap_make_secure_channel(make_secure_channel_func, tracer=None):
                 channel, tracer_interceptor)
             return intercepted_channel  # pragma: NO COVER
         except Exception:
-            log.warning(
-                'Failed to wrap secure channel, '
-                'clientlibs grpc calls not traced.')
+            log.warning('Failed to wrap secure channel, '
+                        'clientlibs grpc calls not traced.')
             return channel
+
     return call
 
 
 def wrap_insecure_channel(insecure_channel_func, tracer=None):
     """Wrap the grpc.insecure_channel."""
+
     def call(*args, **kwargs):
         channel = insecure_channel_func(*args, **kwargs)
 
@@ -121,15 +114,16 @@ def wrap_insecure_channel(insecure_channel_func, tracer=None):
                 channel, tracer_interceptor)
             return intercepted_channel  # pragma: NO COVER
         except Exception:
-            log.warning(
-                'Failed to wrap insecure channel, '
-                'clientlibs grpc calls not traced.')
+            log.warning('Failed to wrap insecure channel, '
+                        'clientlibs grpc calls not traced.')
             return channel
+
     return call
 
 
 def wrap_create_channel(create_channel_func, tracer=None):
     """Wrap the google.api_core.grpc_helpers.create_channel."""
+
     def call(*args, **kwargs):
         channel = create_channel_func(*args, **kwargs)
 
@@ -144,8 +138,8 @@ def wrap_create_channel(create_channel_func, tracer=None):
                 channel, tracer_interceptor)
             return intercepted_channel  # pragma: NO COVER
         except Exception:
-            log.warning(
-                'Failed to wrap create_channel, '
-                'clientlibs grpc calls not traced.')
+            log.warning('Failed to wrap create_channel, '
+                        'clientlibs grpc calls not traced.')
             return channel
+
     return call

--- a/opencensus/trace/ext/grpc/utils.py
+++ b/opencensus/trace/ext/grpc/utils.py
@@ -14,17 +14,11 @@ def add_message_event(proto_message, span, message_event_type, message_id=1):
             message_event=time_event.MessageEvent(
                 message_id,
                 type=message_event_type,
-                uncompressed_size_bytes=proto_message.ByteSize()
-            )
-        )
-    )
+                uncompressed_size_bytes=proto_message.ByteSize())))
 
 
-def wrap_iter_with_message_events(
-    request_or_response_iter,
-    span,
-    message_event_type
-):
+def wrap_iter_with_message_events(request_or_response_iter, span,
+                                  message_event_type):
     """Wraps a request or response iterator to add message events to the span
     for each proto message sent or received
     """
@@ -33,8 +27,7 @@ def wrap_iter_with_message_events(
             proto_message=message,
             span=span,
             message_event_type=message_event_type,
-            message_id=message_id
-        )
+            message_id=message_id)
         yield message
 
 

--- a/opencensus/trace/ext/postgresql/trace.py
+++ b/opencensus/trace/ext/postgresql/trace.py
@@ -47,6 +47,7 @@ def connect(*args, **kwargs):
 
 
 def trace_cursor_query(query_func):
+
     def call(query, *args, **kwargs):
         _tracer = execution_context.get_opencensus_tracer()
         if _tracer is not None:

--- a/opencensus/trace/ext/pyramid/config.py
+++ b/opencensus/trace/ext/pyramid/config.py
@@ -22,7 +22,6 @@ DEFAULT_PYRAMID_TRACER_CONFIG = {
     'PROPAGATOR': google_cloud_format.GoogleCloudFormatPropagator()
 }
 
-
 DEFAULT_PYRAMID_TRACER_PARAMS = {
     # https://cloud.google.com/appengine/docs/flexible/python/
     # how-instances-are-managed#health_checking
@@ -31,14 +30,13 @@ DEFAULT_PYRAMID_TRACER_PARAMS = {
 
 
 class PyramidTraceSettings(object):
-    def __init__(self, registry):
-        self.settings = registry.settings.get(
-            'OPENCENSUS_TRACE',
-            DEFAULT_PYRAMID_TRACER_CONFIG)
 
-        self.params = registry.settings.get(
-            'OPENCENSUS_TRACE_PARAMS',
-            DEFAULT_PYRAMID_TRACER_PARAMS)
+    def __init__(self, registry):
+        self.settings = registry.settings.get('OPENCENSUS_TRACE',
+                                              DEFAULT_PYRAMID_TRACER_CONFIG)
+
+        self.params = registry.settings.get('OPENCENSUS_TRACE_PARAMS',
+                                            DEFAULT_PYRAMID_TRACER_PARAMS)
 
         _set_default_configs(self.settings, DEFAULT_PYRAMID_TRACER_CONFIG)
 

--- a/opencensus/trace/ext/pyramid/pyramid_middleware.py
+++ b/opencensus/trace/ext/pyramid/pyramid_middleware.py
@@ -28,7 +28,6 @@ HTTP_STATUS_CODE = attributes_helper.COMMON_ATTRIBUTES['HTTP_STATUS_CODE']
 
 BLACKLIST_PATHS = 'BLACKLIST_PATHS'
 
-
 log = logging.getLogger(__name__)
 
 
@@ -88,17 +87,13 @@ class OpenCensusTweenFactory(object):
             span = tracer.start_span()
 
             # Set the span name as the name of the current module name
-            span.name = '[{}]{}'.format(
-                request.method,
-                request.path)
+            span.name = '[{}]{}'.format(request.method, request.path)
 
             span.span_kind = span_module.SpanKind.SERVER
             tracer.add_attribute_to_current_span(
-                attribute_key=HTTP_METHOD,
-                attribute_value=request.method)
+                attribute_key=HTTP_METHOD, attribute_value=request.method)
             tracer.add_attribute_to_current_span(
-                attribute_key=HTTP_URL,
-                attribute_value=request.path)
+                attribute_key=HTTP_URL, attribute_value=request.path)
         except Exception:  # pragma: NO COVER
             log.error('Failed to trace request', exc_info=True)
 
@@ -108,9 +103,8 @@ class OpenCensusTweenFactory(object):
 
         try:
             tracer = execution_context.get_opencensus_tracer()
-            tracer.add_attribute_to_current_span(
-                HTTP_STATUS_CODE,
-                str(response.status_code))
+            tracer.add_attribute_to_current_span(HTTP_STATUS_CODE,
+                                                 str(response.status_code))
 
             tracer.end_span()
             tracer.finish()

--- a/opencensus/trace/ext/requests/trace.py
+++ b/opencensus/trace/ext/requests/trace.py
@@ -54,12 +54,13 @@ def trace_integration(tracer=None):
         setattr(requests, requests_func.__name__, wrapped)
 
     # Wrap Session class
-    wrapt.wrap_function_wrapper(
-        MODULE_NAME, 'Session.request', wrap_session_request)
+    wrapt.wrap_function_wrapper(MODULE_NAME, 'Session.request',
+                                wrap_session_request)
 
 
 def wrap_requests(requests_func):
     """Wrap the requests function to trace it."""
+
     def call(url, *args, **kwargs):
         blacklist_hostnames = execution_context.get_opencensus_attr(
             'blacklist_hostnames')
@@ -82,8 +83,8 @@ def wrap_requests(requests_func):
         result = requests_func(url, *args, **kwargs)
 
         # Add the status code to attributes
-        _tracer.add_attribute_to_current_span(
-            HTTP_STATUS_CODE, str(result.status_code))
+        _tracer.add_attribute_to_current_span(HTTP_STATUS_CODE,
+                                              str(result.status_code))
 
         _tracer.end_span()
         return result
@@ -112,11 +113,9 @@ def wrap_session_request(wrapped, instance, args, kwargs):
     _span.name = '[requests]{}'.format(method)
     _span.span_kind = span_module.SpanKind.CLIENT
 
-    tracer_headers = _tracer.propagator.to_headers(
-        _tracer.span_context)
+    tracer_headers = _tracer.propagator.to_headers(_tracer.span_context)
 
-    kwargs.setdefault('headers', {}).update(
-        tracer_headers)
+    kwargs.setdefault('headers', {}).update(tracer_headers)
 
     # Add the requests url to attributes
     _tracer.add_attribute_to_current_span(HTTP_URL, url)
@@ -124,8 +123,8 @@ def wrap_session_request(wrapped, instance, args, kwargs):
     result = wrapped(*args, **kwargs)
 
     # Add the status code to attributes
-    _tracer.add_attribute_to_current_span(
-        HTTP_STATUS_CODE, str(result.status_code))
+    _tracer.add_attribute_to_current_span(HTTP_STATUS_CODE,
+                                          str(result.status_code))
 
     _tracer.end_span()
     return result

--- a/opencensus/trace/ext/sqlalchemy/trace.py
+++ b/opencensus/trace/ext/sqlalchemy/trace.py
@@ -17,7 +17,6 @@ import logging
 from sqlalchemy import engine
 from sqlalchemy import event
 
-
 from opencensus.trace import execution_context
 from opencensus.trace import span as span_module
 
@@ -43,8 +42,8 @@ def trace_engine(engine):
     event.listen(engine, 'after_cursor_execute', _after_cursor_execute)
 
 
-def _before_cursor_execute(conn, cursor, statement, parameters,
-                           context, executemany):
+def _before_cursor_execute(conn, cursor, statement, parameters, context,
+                           executemany):
     """Intercept low-level cursor execute() events before execution.
     If executemany is True, this is an executemany call, else an execute call.
 
@@ -67,8 +66,8 @@ def _before_cursor_execute(conn, cursor, statement, parameters,
     _span.span_kind = span_module.SpanKind.CLIENT
 
     # Set query statement attribute
-    _tracer.add_attribute_to_current_span(
-        '{}.query'.format(MODULE_NAME), statement)
+    _tracer.add_attribute_to_current_span('{}.query'.format(MODULE_NAME),
+                                          statement)
 
     # Set query parameters attribute
     _tracer.add_attribute_to_current_span(
@@ -76,12 +75,11 @@ def _before_cursor_execute(conn, cursor, statement, parameters,
 
     # Set query function attribute
     _tracer.add_attribute_to_current_span(
-        '{}.cursor.method.name'.format(MODULE_NAME),
-        query_func)
+        '{}.cursor.method.name'.format(MODULE_NAME), query_func)
 
 
-def _after_cursor_execute(conn, cursor, statement, parameters,
-                          context, executemany):
+def _after_cursor_execute(conn, cursor, statement, parameters, context,
+                          executemany):
     """Intercept low-level cursor execute() events after execution.
     If executemany is True, this is an executemany call, else an execute call.
 

--- a/opencensus/trace/ext/threading/trace.py
+++ b/opencensus/trace/ext/threading/trace.py
@@ -31,9 +31,8 @@ def trace_integration(tracer=None):
     log.info("Integrated module: {}".format(MODULE_NAME))
     # Wrap the threading start function
     start_func = getattr(threading.Thread, "start")
-    setattr(
-        threading.Thread, start_func.__name__, wrap_threading_start(start_func)
-    )
+    setattr(threading.Thread, start_func.__name__,
+            wrap_threading_start(start_func))
 
     # Wrap the threading run function
     run_func = getattr(threading.Thread, "run")
@@ -63,8 +62,7 @@ def wrap_threading_start(start_func):
 
     def call(self):
         self._opencensus_context = (
-            execution_context.get_opencensus_full_context()
-        )
+            execution_context.get_opencensus_full_context())
         return start_func(self)
 
     return call
@@ -76,9 +74,7 @@ def wrap_threading_run(run_func):
     """
 
     def call(self):
-        execution_context.set_opencensus_full_context(
-            *self._opencensus_context
-        )
+        execution_context.set_opencensus_full_context(*self._opencensus_context)
         return run_func(self)
 
     return call
@@ -96,16 +92,14 @@ def wrap_apply_async(apply_async_func):
         wrapped_kwargs = {}
         print(_tracer)
         wrapped_kwargs["span_context_binary"] = propagator.to_header(
-            _tracer.span_context
-        )
+            _tracer.span_context)
         wrapped_kwargs["kwds"] = kwds
         wrapped_kwargs["sampler"] = _tracer.sampler
         wrapped_kwargs["exporter"] = _tracer.exporter
         wrapped_kwargs["propagator"] = _tracer.propagator
 
         return apply_async_func(
-            self, wrapped_func, args=args, kwds=wrapped_kwargs, **kwargs
-        )
+            self, wrapped_func, args=args, kwds=wrapped_kwargs, **kwargs)
 
     return call
 
@@ -121,8 +115,7 @@ def wrap_submit(submit_func):
 
         wrapped_kwargs = {}
         wrapped_kwargs["span_context_binary"] = propagator.to_header(
-            _tracer.span_context
-        )
+            _tracer.span_context)
         wrapped_kwargs["kwds"] = kwargs
         wrapped_kwargs["sampler"] = _tracer.sampler
         wrapped_kwargs["exporter"] = _tracer.exporter

--- a/opencensus/trace/ext/utils.py
+++ b/opencensus/trace/ext/utils.py
@@ -84,12 +84,10 @@ def disable_tracing_hostname(url, blacklist_hostnames=None):
         _tracer = execution_context.get_opencensus_tracer()
         try:
             blacklist_hostnames = [
-                '{}:{}'.format(
-                    _tracer.exporter.host_name,
-                    _tracer.exporter.port
-                )
+                '{}:{}'.format(_tracer.exporter.host_name,
+                               _tracer.exporter.port)
             ]
-        except(AttributeError):
+        except (AttributeError):
             blacklist_hostnames = []
 
     return url in blacklist_hostnames

--- a/opencensus/trace/link.py
+++ b/opencensus/trace/link.py
@@ -48,6 +48,7 @@ class Link(object):
     :param attributes: A set of attributes on the link. You have have up to 32
                        attributes per link.
     """
+
     def __init__(self, trace_id, span_id, type=None, attributes=None):
         self.trace_id = trace_id
         self.span_id = span_id

--- a/opencensus/trace/propagation/binary_format.py
+++ b/opencensus/trace/propagation/binary_format.py
@@ -59,8 +59,7 @@ BINARY_FORMAT = '{big_endian}{version_id}' \
         trace_option=UNSIGNED_CHAR)
 
 Header = collections.namedtuple(
-    'Header',
-    'version_id '
+    'Header', 'version_id '
     'trace_id_field_id '
     'trace_id '
     'span_id_field_id '
@@ -92,6 +91,7 @@ class BinaryFormatPropagator(object):
             trace_option: Byte with length 1.
                 e.g. b'\x01'
     """
+
     def from_header(self, binary):
         """Generate a SpanContext object using the trace context header.
         The value of enabled parsed from header is int. Need to convert to
@@ -116,9 +116,7 @@ class BinaryFormatPropagator(object):
             logging.warning(
                 'Cannot parse the incoming binary data {}, '
                 'wrong format. Total bytes length should be {}.'.format(
-                    binary, FORMAT_LENGTH
-                )
-            )
+                    binary, FORMAT_LENGTH))
             return span_context_module.SpanContext(from_header=False)
 
         # data.trace_id is in bytes with length 16, hexlify it to hex bytes
@@ -128,10 +126,10 @@ class BinaryFormatPropagator(object):
         trace_options = TraceOptions(data.trace_option)
 
         span_context = span_context_module.SpanContext(
-                trace_id=trace_id,
-                span_id=span_id,
-                trace_options=trace_options,
-                from_header=True)
+            trace_id=trace_id,
+            span_id=span_id,
+            trace_options=trace_options,
+            from_header=True)
 
         return span_context
 
@@ -157,12 +155,7 @@ class BinaryFormatPropagator(object):
         # Convert trace_id to bytes with length 16, treat span_id as 64 bit
         # integer which is unsigned long long type and convert it to bytes with
         # length 8, trace_option is integer with length 1.
-        return struct.pack(
-            BINARY_FORMAT,
-            VERSION_ID,
-            TRACE_ID_FIELD_ID,
-            binascii.unhexlify(trace_id),
-            SPAN_ID_FIELD_ID,
-            binascii.unhexlify(span_id),
-            TRACE_OPTION_FIELD_ID,
-            trace_options)
+        return struct.pack(BINARY_FORMAT, VERSION_ID, TRACE_ID_FIELD_ID,
+                           binascii.unhexlify(trace_id), SPAN_ID_FIELD_ID,
+                           binascii.unhexlify(span_id), TRACE_OPTION_FIELD_ID,
+                           trace_options)

--- a/opencensus/trace/propagation/google_cloud_format.py
+++ b/opencensus/trace/propagation/google_cloud_format.py
@@ -31,6 +31,7 @@ class GoogleCloudFormatPropagator(object):
     format header. Later we will add implementation for supporting other
     format like binary format and zipkin, opencensus format.
     """
+
     def from_header(self, header):
         """Generate a SpanContext object using the trace context header.
         The value of enabled parsed from header is int. Need to convert to
@@ -50,8 +51,8 @@ class GoogleCloudFormatPropagator(object):
             match = re.search(_TRACE_CONTEXT_HEADER_RE, header)
         except TypeError:
             logging.warning(
-                'Header should be str, got {}. Cannot parse the header.'
-                .format(header.__class__.__name__))
+                'Header should be str, got {}. Cannot parse the header.'.format(
+                    header.__class__.__name__))
             raise
 
         if match:
@@ -70,8 +71,8 @@ class GoogleCloudFormatPropagator(object):
             return span_context
         else:
             logging.warning(
-                'Cannot parse the header {}, generate a new context instead.'
-                .format(header))
+                'Cannot parse the header {}, generate a new context instead.'.
+                format(header))
             return SpanContext()
 
     def from_headers(self, headers):
@@ -105,10 +106,7 @@ class GoogleCloudFormatPropagator(object):
         span_id = span_context.span_id
         trace_options = span_context.trace_options.trace_options_byte
 
-        header = '{}/{};o={}'.format(
-            trace_id,
-            span_id,
-            int(trace_options))
+        header = '{}/{};o={}'.format(trace_id, span_id, int(trace_options))
         return header
 
     def to_headers(self, span_context):

--- a/opencensus/trace/propagation/text_format.py
+++ b/opencensus/trace/propagation/text_format.py
@@ -28,6 +28,7 @@ class TextFormatPropagator(object):
     information from a carrier which is a dict to form a SpanContext. And
     generating a dict using the provided SpanContext.
     """
+
     def from_carrier(self, carrier):
         """Generate a SpanContext object using the information in the carrier.
 

--- a/opencensus/trace/propagation/trace_context_http_header_format.py
+++ b/opencensus/trace/propagation/trace_context_http_header_format.py
@@ -101,11 +101,8 @@ class TraceContextPropagator(object):
         trace_options = '01' if trace_options else '00'
 
         headers = {
-            _TRACEPARENT_HEADER_NAME: '00-{}-{}-{}'.format(
-                trace_id,
-                span_id,
-                trace_options
-            ),
+            _TRACEPARENT_HEADER_NAME:
+            '00-{}-{}-{}'.format(trace_id, span_id, trace_options),
         }
         tracestate = span_context.tracestate
         if tracestate:

--- a/opencensus/trace/propagation/tracestate_string_format.py
+++ b/opencensus/trace/propagation/tracestate_string_format.py
@@ -25,6 +25,7 @@ _MEMBER_FORMAT_RE = re.compile(_MEMBER_FORMAT)
 
 
 class TracestateStringFormatter(object):
+
     def from_string(self, string):
         tracestate = Tracestate()
         for member in re.split(_DELIMITER_FORMAT_RE, string):
@@ -38,7 +39,5 @@ class TracestateStringFormatter(object):
         return tracestate
 
     def to_string(self, tracestate):
-        return ','.join(map(
-            lambda key: key + '=' + tracestate[key],
-            tracestate
-        ))
+        return ','.join(
+            map(lambda key: key + '=' + tracestate[key], tracestate))

--- a/opencensus/trace/samplers/__init__.py
+++ b/opencensus/trace/samplers/__init__.py
@@ -17,6 +17,6 @@ from opencensus.trace.samplers.always_on import AlwaysOnSampler
 from opencensus.trace.samplers.base import Sampler
 from opencensus.trace.samplers.probability import ProbabilitySampler
 
-
-__all__ = ['Sampler', 'AlwaysOnSampler', 'AlwaysOffSampler',
-           'ProbabilitySampler']
+__all__ = [
+    'Sampler', 'AlwaysOnSampler', 'AlwaysOffSampler', 'ProbabilitySampler'
+]

--- a/opencensus/trace/samplers/base.py
+++ b/opencensus/trace/samplers/base.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Module containing base class for samplers."""
 
 

--- a/opencensus/trace/samplers/probability.py
+++ b/opencensus/trace/samplers/probability.py
@@ -25,6 +25,7 @@ class ProbabilitySampler(Sampler):
     :type rate: float
     :param rate: The rate of sampling.
     """
+
     def __init__(self, rate=None):
         if rate is None:
             rate = DEFAULT_SAMPLING_RATE

--- a/opencensus/trace/span.py
+++ b/opencensus/trace/span.py
@@ -99,21 +99,20 @@ class Span(base_span.BaseSpan):
                         `opencensus.trace.span.SpanKind`)
     """
 
-    def __init__(
-            self,
-            name,
-            parent_span=None,
-            attributes=None,
-            start_time=None,
-            end_time=None,
-            span_id=None,
-            stack_trace=None,
-            time_events=None,
-            links=None,
-            status=None,
-            same_process_as_parent_span=None,
-            context_tracer=None,
-            span_kind=SpanKind.UNSPECIFIED):
+    def __init__(self,
+                 name,
+                 parent_span=None,
+                 attributes=None,
+                 start_time=None,
+                 end_time=None,
+                 span_id=None,
+                 stack_trace=None,
+                 time_events=None,
+                 links=None,
+                 status=None,
+                 same_process_as_parent_span=None,
+                 context_tracer=None,
+                 span_kind=SpanKind.UNSPECIFIED):
         self.name = name
         self.parent_span = parent_span
         self.start_time = start_time
@@ -196,8 +195,10 @@ class Span(base_span.BaseSpan):
         :param attrs: keyworded arguments e.g. failed=True, name='Caching'
         """
         at = attributes.Attributes(attrs)
-        self.add_time_event(time_event_module.TimeEvent(datetime.utcnow(),
-                            time_event_module.Annotation(description, at)))
+        self.add_time_event(
+            time_event_module.TimeEvent(
+                datetime.utcnow(), time_event_module.Annotation(
+                    description, at)))
 
     def add_time_event(self, time_event):
         """Add a TimeEvent.
@@ -208,8 +209,9 @@ class Span(base_span.BaseSpan):
         if isinstance(time_event, time_event_module.TimeEvent):
             self.time_events.append(time_event)
         else:
-            raise TypeError("Type Error: received {}, but requires TimeEvent.".
-                            format(type(time_event).__name__))
+            raise TypeError(
+                "Type Error: received {}, but requires TimeEvent.".format(
+                    type(time_event).__name__))
 
     def add_link(self, link):
         """Add a Link.
@@ -220,8 +222,9 @@ class Span(base_span.BaseSpan):
         if isinstance(link, link_module.Link):
             self.links.append(link)
         else:
-            raise TypeError("Type Error: received {}, but requires Link.".
-                            format(type(link).__name__))
+            raise TypeError(
+                "Type Error: received {}, but requires Link.".format(
+                    type(link).__name__))
 
     def start(self):
         """Set the start time for a span."""
@@ -289,14 +292,15 @@ def format_span_json(span):
 
     if span.time_events:
         span_json['timeEvents'] = {
-            'timeEvent': [time_event.format_time_event_json()
-                          for time_event in span.time_events]
+            'timeEvent': [
+                time_event.format_time_event_json()
+                for time_event in span.time_events
+            ]
         }
 
     if span.links:
         span_json['links'] = {
-            'link': [
-                link.format_link_json() for link in span.links]
+            'link': [link.format_link_json() for link in span.links]
         }
 
     if span.status is not None:

--- a/opencensus/trace/span_context.py
+++ b/opencensus/trace/span_context.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """SpanContext encapsulates the current context within the request's trace."""
 
 import logging
@@ -53,13 +52,13 @@ class SpanContext(object):
     :param from_header: (Optional) Indicates whether the trace context is
                         generated from request header.
     """
-    def __init__(
-            self,
-            trace_id=None,
-            span_id=None,
-            trace_options=None,
-            tracestate=None,
-            from_header=False):
+
+    def __init__(self,
+                 trace_id=None,
+                 span_id=None,
+                 trace_options=None,
+                 tracestate=None,
+                 from_header=False):
         if trace_id is None:
             trace_id = generate_trace_id()
 
@@ -113,9 +112,8 @@ class SpanContext(object):
         if match:
             return span_id
         else:
-            logging.warning(
-                'Span_id {} does not the match the '
-                'required format'.format(span_id))
+            logging.warning('Span_id {} does not the match the '
+                            'required format'.format(span_id))
             self.from_header = False
             return None
 
@@ -133,9 +131,8 @@ class SpanContext(object):
         assert isinstance(trace_id, str)
 
         if trace_id is _INVALID_TRACE_ID:
-            logging.warning(
-                'Trace_id {} is invalid (cannot be all zero), '
-                'generating a new one.'.format(trace_id))
+            logging.warning('Trace_id {} is invalid (cannot be all zero), '
+                            'generating a new one.'.format(trace_id))
             self.from_header = False
             return generate_trace_id()
 

--- a/opencensus/trace/span_data.py
+++ b/opencensus/trace/span_data.py
@@ -126,14 +126,15 @@ def _format_legacy_span_json(span_data):
 
     if span_data.time_events:
         span_json['timeEvents'] = {
-            'timeEvent': [time_event.format_time_event_json()
-                          for time_event in span_data.time_events]
+            'timeEvent': [
+                time_event.format_time_event_json()
+                for time_event in span_data.time_events
+            ]
         }
 
     if span_data.links:
         span_json['links'] = {
-            'link': [
-                link.format_link_json() for link in span_data.links]
+            'link': [link.format_link_json() for link in span_data.links]
         }
 
     if span_data.status is not None:

--- a/opencensus/trace/stack_trace.py
+++ b/opencensus/trace/stack_trace.py
@@ -65,15 +65,9 @@ class StackFrame(object):
     :param source_version: The version of the deployed source code
                            (up to 128 bytes).
     """
-    def __init__(self,
-                 func_name,
-                 original_func_name,
-                 file_name,
-                 line_num,
-                 col_num,
-                 load_module,
-                 build_id,
-                 source_version):
+
+    def __init__(self, func_name, original_func_name, file_name, line_num,
+                 col_num, load_module, build_id, source_version):
         self.func_name = func_name
         self.original_func_name = original_func_name
         self.file_name = file_name
@@ -86,8 +80,7 @@ class StackFrame(object):
     def format_stack_frame_json(self):
         """Convert StackFrame object to json format."""
         stack_frame_json = {}
-        stack_frame_json['function_name'] = _get_truncatable_str(
-            self.func_name)
+        stack_frame_json['function_name'] = _get_truncatable_str(self.func_name)
         stack_frame_json['original_function_name'] = _get_truncatable_str(
             self.original_func_name)
         stack_frame_json['file_name'] = _get_truncatable_str(self.file_name)
@@ -115,6 +108,7 @@ class StackTrace(object):
                                 bandwidth for duplicate stack traces within a
                                 single trace.
     """
+
     def __init__(self, stack_frames=None, stack_trace_hash_id=None):
         if stack_frames is None:
             stack_frames = []
@@ -134,8 +128,7 @@ class StackTrace(object):
     def from_traceback(cls, tb):
         """Initializes a StackTrace from a python traceback instance"""
         stack_trace = cls(
-            stack_trace_hash_id=generate_hash_id_from_traceback(tb)
-        )
+            stack_trace_hash_id=generate_hash_id_from_traceback(tb))
         # use the add_stack_frame so that json formatting is applied
         for tb_frame_info in traceback.extract_tb(tb):
             filename, line_num, fn_name, _ = tb_frame_info
@@ -148,9 +141,7 @@ class StackTrace(object):
                     col_num=0,  # I don't think this is available in python
                     load_module=filename,
                     build_id=BUILD_ID,
-                    source_version=SOURCE_VERSION
-                )
-            )
+                    source_version=SOURCE_VERSION))
         return stack_trace
 
     def add_stack_frame(self, stack_frame):

--- a/opencensus/trace/status.py
+++ b/opencensus/trace/status.py
@@ -39,6 +39,7 @@ class Status(object):
                     See: https://cloud.google.com/trace/docs/reference/v2/
                          rest/v2/Status#FIELDS.details
     """
+
     def __init__(self, code, message, details=None):
         self.code = code
         self.message = message
@@ -58,7 +59,4 @@ class Status(object):
 
     @classmethod
     def from_exception(cls, exc):
-        return cls(
-            code=code_pb2.UNKNOWN,
-            message=str(exc)
-        )
+        return cls(code=code_pb2.UNKNOWN, message=str(exc))

--- a/opencensus/trace/time_event.py
+++ b/opencensus/trace/time_event.py
@@ -40,6 +40,7 @@ class Annotation(object):
     :param attributes: A set of attributes on the annotation.
                        You can have up to 4 attributes per Annotation.
     """
+
     def __init__(self, description, attributes=None):
         self.description = description
         self.attributes = attributes
@@ -76,7 +77,11 @@ class MessageEvent(object):
                                   size as uncompressed.
 
     """
-    def __init__(self, id, type=None, uncompressed_size_bytes=None,
+
+    def __init__(self,
+                 id,
+                 type=None,
+                 uncompressed_size_bytes=None,
                  compressed_size_bytes=None):
         if type is None:
             type = Type.TYPE_UNSPECIFIED
@@ -125,6 +130,7 @@ class TimeEvent(object):
     :param message_event: An event describing a message sent/received between
                           spans.
     """
+
     def __init__(self, timestamp, annotation=None, message_event=None):
         self.timestamp = timestamp.isoformat() + 'Z'
 

--- a/opencensus/trace/tracer.py
+++ b/opencensus/trace/tracer.py
@@ -40,12 +40,12 @@ class Tracer(object):
                      :class:`.Loggingexporter`, :class:`.Zipkinexporter`,
                      :class:`.GoogleCloudexporter`
     """
-    def __init__(
-            self,
-            span_context=None,
-            sampler=None,
-            exporter=None,
-            propagator=None):
+
+    def __init__(self,
+                 span_context=None,
+                 sampler=None,
+                 exporter=None,
+                 propagator=None):
         if span_context is None:
             span_context = SpanContext()
 
@@ -83,8 +83,7 @@ class Tracer(object):
         if sampled:
             self.span_context.trace_options.set_enabled(True)
             return context_tracer.ContextTracer(
-                exporter=self.exporter,
-                span_context=self.span_context)
+                exporter=self.exporter, span_context=self.span_context)
         else:
             return noop_tracer.NoopTracer()
 
@@ -129,8 +128,8 @@ class Tracer(object):
         :type attribute_value:str
         :param attribute_value: Attribute value.
         """
-        self.tracer.add_attribute_to_current_span(
-            attribute_key, attribute_value)
+        self.tracer.add_attribute_to_current_span(attribute_key,
+                                                  attribute_value)
 
     def trace_decorator(self):
         """Decorator to trace a function."""

--- a/opencensus/trace/tracers/base.py
+++ b/opencensus/trace/tracers/base.py
@@ -18,6 +18,7 @@ class Tracer(object):
 
     Subclasses of :class:`Tracer` must implement the below methods.
     """
+
     def finish(self):
         """End the spans and send to reporters."""
         raise NotImplementedError
@@ -67,6 +68,7 @@ class NullContextManager(object):
     """Empty object as a helper for faking Trace and Span when tracing is
     disabled.
     """
+
     def __init__(self, span_id=None, context_tracer=None):
         self.name = None
         self.span_id = span_id

--- a/opencensus/trace/tracers/context_tracer.py
+++ b/opencensus/trace/tracers/context_tracer.py
@@ -86,9 +86,7 @@ class ContextTracer(base.Tracer):
                 span_id=self.span_context.span_id)
 
         span = trace_span.Span(
-            name,
-            parent_span=parent_span,
-            context_tracer=self)
+            name, parent_span=parent_span, context_tracer=self)
         with self._spans_list_condition:
             self._spans_list.append(span)
         self.span_context.span_id = span.span_id
@@ -158,8 +156,8 @@ class ContextTracer(base.Tracer):
                 name=span.name,
                 context=self.span_context,
                 span_id=span.span_id,
-                parent_span_id=span.parent_span.span_id if
-                span.parent_span else None,
+                parent_span_id=span.parent_span.span_id
+                if span.parent_span else None,
                 attributes=span.attributes,
                 start_time=span.start_time,
                 end_time=span.end_time,
@@ -169,10 +167,7 @@ class ContextTracer(base.Tracer):
                 links=span.links,
                 status=span.status,
                 same_process_as_parent_span=span.same_process_as_parent_span,
-                span_kind=span.span_kind
-
-            )
-            for span in span_tree
+                span_kind=span.span_kind) for span in span_tree
         ]
 
         return span_datas

--- a/opencensus/trace/tracers/noop_tracer.py
+++ b/opencensus/trace/tracers/noop_tracer.py
@@ -26,8 +26,7 @@ class NoopTracer(base.Tracer):
     def __init__(self):
 
         self.span_context = SpanContext(
-            trace_options=trace_options.TraceOptions(0)
-        )
+            trace_options=trace_options.TraceOptions(0))
 
     def finish(self):
         """End spans and send to reporter."""

--- a/opencensus/trace/tracestate.py
+++ b/opencensus/trace/tracestate.py
@@ -27,6 +27,7 @@ _VALUE_VALIDATION_RE = re.compile('^' + _VALUE_FORMAT + '$')
 
 
 class Tracestate(OrderedDict):
+
     def __setitem__(self, key, value):
         if not isinstance(key, str):
             raise ValueError('key must be an instance of str')

--- a/opencensus/trace/utils.py
+++ b/opencensus/trace/utils.py
@@ -27,8 +27,8 @@ def _get_truncatable_str(str_to_convert):
     """Truncate a string if exceed limit and record the truncated bytes
     count.
     """
-    truncated, truncated_byte_count = check_str_length(
-        str_to_convert, MAX_LENGTH)
+    truncated, truncated_byte_count = check_str_length(str_to_convert,
+                                                       MAX_LENGTH)
 
     result = {
         'value': truncated,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/tests/system/stats/prometheus/prometheus_stats_test.py
+++ b/tests/system/stats/prometheus/prometheus_stats_test.py
@@ -38,16 +38,15 @@ class TestPrometheusStats(unittest.TestCase):
         VIDEO_SIZE_VIEW_NAME = "my.org/views/video_size"
         VIDEO_SIZE_DISTRIBUTION = aggregation_module.CountAggregation(
             256.0 * MiB)
-        VIDEO_SIZE_VIEW = view_module.View(VIDEO_SIZE_VIEW_NAME,
-                                           "processed video size over time",
-                                           [FRONTEND_KEY],
-                                           VIDEO_SIZE_MEASURE,
-                                           VIDEO_SIZE_DISTRIBUTION)
+        VIDEO_SIZE_VIEW = view_module.View(
+            VIDEO_SIZE_VIEW_NAME, "processed video size over time",
+            [FRONTEND_KEY], VIDEO_SIZE_MEASURE, VIDEO_SIZE_DISTRIBUTION)
         stats = stats_module.Stats()
         view_manager = stats.view_manager
         stats_recorder = stats.stats_recorder
 
-        exporter = prometheus.new_stats_exporter(prometheus.Options(namespace="opencensus", port=9303))
+        exporter = prometheus.new_stats_exporter(
+            prometheus.Options(namespace="opencensus", port=9303))
         view_manager.register_exporter(exporter)
 
         view_manager.register_view(VIDEO_SIZE_VIEW)
@@ -63,10 +62,13 @@ class TestPrometheusStats(unittest.TestCase):
 
         if sys.version_info > (3, 0):
             import urllib.request
-            contents = urllib.request.urlopen("http://localhost:9303/metrics").read()
+            contents = urllib.request.urlopen(
+                "http://localhost:9303/metrics").read()
         else:
             import urllib2
             contents = urllib2.urlopen("http://localhost:9303/metrics").read()
 
-        self.assertIn(b'# TYPE opencensus_my.org/views/video_size counter', contents)
-        self.assertIn(b'opencensus_my.org/views/video_size 268435456.0', contents)
+        self.assertIn(b'# TYPE opencensus_my.org/views/video_size counter',
+                      contents)
+        self.assertIn(b'opencensus_my.org/views/video_size 268435456.0',
+                      contents)

--- a/tests/system/stats/stackdriver/stackdriver_stats_test.py
+++ b/tests/system/stats/stackdriver/stackdriver_stats_test.py
@@ -35,6 +35,7 @@ PROJECT = os.environ.get('GCLOUD_PROJECT_PYTHON')
 RETRY_WAIT_PERIOD = 10000  # Wait 10 seconds between each retry
 RETRY_MAX_ATTEMPT = 10  # Retry 10 times
 
+
 class TestBasicStats(unittest.TestCase):
 
     def test_stats_record_sync(self):
@@ -52,21 +53,20 @@ class TestBasicStats(unittest.TestCase):
             measure_name, measure_description, "By")
         VIDEO_SIZE_VIEW_NAME = view_name
         VIDEO_SIZE_DISTRIBUTION = aggregation_module.DistributionAggregation(
-                                    [0.0, 16.0 * MiB, 256.0 * MiB])
-        VIDEO_SIZE_VIEW = view_module.View(VIDEO_SIZE_VIEW_NAME,
-                                        view_description,
-                                        [FRONTEND_KEY],
-                                        VIDEO_SIZE_MEASURE,
-                                        VIDEO_SIZE_DISTRIBUTION)
+            [0.0, 16.0 * MiB, 256.0 * MiB])
+        VIDEO_SIZE_VIEW = view_module.View(
+            VIDEO_SIZE_VIEW_NAME, view_description, [FRONTEND_KEY],
+            VIDEO_SIZE_MEASURE, VIDEO_SIZE_DISTRIBUTION)
 
         stats = stats_module.Stats()
         view_manager = stats.view_manager
         stats_recorder = stats.stats_recorder
 
         client = monitoring_v3.MetricServiceClient()
-        exporter = stackdriver.StackdriverStatsExporter(options=stackdriver.Options(project_id=PROJECT),
-                                                        client=client,
-                                                        transport=sync.SyncTransport)
+        exporter = stackdriver.StackdriverStatsExporter(
+            options=stackdriver.Options(project_id=PROJECT),
+            client=client,
+            transport=sync.SyncTransport)
         view_manager.register_exporter(exporter)
 
         # Register view.
@@ -88,12 +88,16 @@ class TestBasicStats(unittest.TestCase):
         # Sleep for [0, 10] milliseconds to fake wait.
         time.sleep(random.randint(1, 10) / 1000.0)
 
-        @retry(wait_fixed=RETRY_WAIT_PERIOD, stop_max_attempt_number=RETRY_MAX_ATTEMPT)
+        @retry(
+            wait_fixed=RETRY_WAIT_PERIOD,
+            stop_max_attempt_number=RETRY_MAX_ATTEMPT)
         def get_metric_descriptors(self, exporter, view_description):
             name = exporter.client.project_path(PROJECT)
-            list_metrics_descriptors = exporter.client.list_metric_descriptors(name)
-            element = next((element for element in list_metrics_descriptors if element.description == view_description), None)
-        
+            list_metrics_descriptors = exporter.client.list_metric_descriptors(
+                name)
+            element = next((element for element in list_metrics_descriptors
+                            if element.description == view_description), None)
+
             self.assertIsNotNone(element)
             self.assertEqual(element.description, view_description)
             self.assertEqual(element.unit, "By")
@@ -115,18 +119,17 @@ class TestBasicStats(unittest.TestCase):
             measure_name, measure_description, "By")
         VIDEO_SIZE_VIEW_NAME_ASYNC = view_name
         VIDEO_SIZE_DISTRIBUTION_ASYNC = aggregation_module.DistributionAggregation(
-                                    [0.0, 16.0 * MiB, 256.0 * MiB])
-        VIDEO_SIZE_VIEW_ASYNC = view_module.View(VIDEO_SIZE_VIEW_NAME_ASYNC,
-                                        view_description,
-                                        [FRONTEND_KEY_ASYNC],
-                                        VIDEO_SIZE_MEASURE_ASYNC,
-                                        VIDEO_SIZE_DISTRIBUTION_ASYNC)
+            [0.0, 16.0 * MiB, 256.0 * MiB])
+        VIDEO_SIZE_VIEW_ASYNC = view_module.View(
+            VIDEO_SIZE_VIEW_NAME_ASYNC, view_description, [FRONTEND_KEY_ASYNC],
+            VIDEO_SIZE_MEASURE_ASYNC, VIDEO_SIZE_DISTRIBUTION_ASYNC)
 
         stats = stats_module.Stats()
         view_manager = stats.view_manager
         stats_recorder = stats.stats_recorder
 
-        exporter = stackdriver.new_stats_exporter(stackdriver.Options(project_id=PROJECT))
+        exporter = stackdriver.new_stats_exporter(
+            stackdriver.Options(project_id=PROJECT))
         view_manager.register_exporter(exporter)
 
         # Register view.
@@ -145,11 +148,15 @@ class TestBasicStats(unittest.TestCase):
 
         measure_map.record(tag_map)
 
-        @retry(wait_fixed=RETRY_WAIT_PERIOD, stop_max_attempt_number=RETRY_MAX_ATTEMPT)
+        @retry(
+            wait_fixed=RETRY_WAIT_PERIOD,
+            stop_max_attempt_number=RETRY_MAX_ATTEMPT)
         def get_metric_descriptors(self, exporter, view_description):
             name = exporter.client.project_path(PROJECT)
-            list_metrics_descriptors = exporter.client.list_metric_descriptors(name)
-            element = next((element for element in list_metrics_descriptors if element.description == view_description), None)
+            list_metrics_descriptors = exporter.client.list_metric_descriptors(
+                name)
+            element = next((element for element in list_metrics_descriptors
+                            if element.description == view_description), None)
             self.assertIsNotNone(element)
             self.assertEqual(element.description, view_description)
             self.assertEqual(element.unit, "By")

--- a/tests/system/trace/basic_trace/basic_trace_system_test.py
+++ b/tests/system/trace/basic_trace/basic_trace_system_test.py
@@ -46,8 +46,7 @@ class TestBasicTrace(unittest.TestCase):
             span_context=span_context,
             sampler=sampler,
             exporter=exporter,
-            propagator=propagator
-        )
+            propagator=propagator)
 
         with tracer.span(name='root_span') as root:
             func_to_trace()

--- a/tests/system/trace/django/app/settings.py
+++ b/tests/system/trace/django/app/settings.py
@@ -11,14 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Django settings for test app."""
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 
 import django
-
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = 'secret_key_for_test'
@@ -83,15 +81,20 @@ TEMPLATES = [
 ]
 
 OPENCENSUS_TRACE = {
-    'SAMPLER': 'opencensus.trace.samplers.always_on.AlwaysOnSampler',
-    'EXPORTER': 'opencensus.trace.exporters.stackdriver_exporter.StackdriverExporter',
-    'PROPAGATOR': 'opencensus.trace.propagation.google_cloud_format.'
-                  'GoogleCloudFormatPropagator',
+    'SAMPLER':
+    'opencensus.trace.samplers.always_on.AlwaysOnSampler',
+    'EXPORTER':
+    'opencensus.trace.exporters.stackdriver_exporter.StackdriverExporter',
+    'PROPAGATOR':
+    'opencensus.trace.propagation.google_cloud_format.'
+    'GoogleCloudFormatPropagator',
 }
 
 OPENCENSUS_TRACE_PARAMS = {
     'SAMPLING_RATE': 0.5,
-    'BLACKLIST_PATHS': ['_ah/health',],
+    'BLACKLIST_PATHS': [
+        '_ah/health',
+    ],
     'TRANSPORT': 'opencensus.trace.exporters.transports.sync.SyncTransport',
 }
 
@@ -107,7 +110,6 @@ USE_I18N = True
 USE_L10N = True
 
 USE_TZ = True
-
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.8/howto/static-files/

--- a/tests/system/trace/django/app/urls.py
+++ b/tests/system/trace/django/app/urls.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """project_name URL Configuration
 
 The `urlpatterns` list routes URLs to views. For more information please see:
@@ -31,7 +30,6 @@ from django.conf.urls import include, url
 from django.contrib import admin
 
 import app.views
-
 
 urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),

--- a/tests/system/trace/django/app/views.py
+++ b/tests/system/trace/django/app/views.py
@@ -50,8 +50,7 @@ def greetings(request):
         if form.is_valid():
             first_name = form.cleaned_data['fname']
             last_name = form.cleaned_data['lname']
-            return HttpResponse(
-                "Hello, {} {}".format(first_name, last_name))
+            return HttpResponse("Hello, {} {}".format(first_name, last_name))
         else:
             return render(request, 'home.html')
 
@@ -61,9 +60,7 @@ def greetings(request):
 def mysql_trace(request):
     try:
         conn = mysql.connector.connect(
-            host=DB_HOST,
-            user='root',
-            password=MYSQL_PASSWORD)
+            host=DB_HOST, user='root', password=MYSQL_PASSWORD)
         cursor = conn.cursor()
 
         query = 'SELECT 2*3'
@@ -108,8 +105,8 @@ def postgresql_trace(request):
 def sqlalchemy_mysql_trace(request):
     try:
         engine = sqlalchemy.create_engine(
-            'mysql+mysqlconnector://{}:{}@{}'.format(
-                'root', MYSQL_PASSWORD, DB_HOST))
+            'mysql+mysqlconnector://{}:{}@{}'.format('root', MYSQL_PASSWORD,
+                                                     DB_HOST))
         conn = engine.connect()
 
         query = 'SELECT 2*3'
@@ -130,10 +127,8 @@ def sqlalchemy_mysql_trace(request):
 
 def sqlalchemy_postgresql_trace(request):
     try:
-        engine = sqlalchemy.create_engine(
-            'postgresql://{}:{}@{}/{}'.format(
-                'postgres', POSTGRES_PASSWORD,
-                DB_HOST, 'postgres'))
+        engine = sqlalchemy.create_engine('postgresql://{}:{}@{}/{}'.format(
+            'postgres', POSTGRES_PASSWORD, DB_HOST, 'postgres'))
         conn = engine.connect()
 
         query = 'SELECT 2*3'

--- a/tests/system/trace/django/django_system_test.py
+++ b/tests/system/trace/django/django_system_test.py
@@ -56,10 +56,7 @@ def run_application():
     cmd = 'python tests/system/trace/django/manage.py runserver {}'.format(
         HOST_PORT)
     process = subprocess.Popen(
-        cmd,
-        stdout=subprocess.PIPE,
-        shell=True,
-        preexec_fn=os.setsid)
+        cmd, stdout=subprocess.PIPE, shell=True, preexec_fn=os.setsid)
     return process
 
 
@@ -80,8 +77,8 @@ class TestDjangoTrace(unittest.TestCase):
         self.process = run_application()
 
         self.headers_trace = {
-            'x-cloud-trace-context': '{}/{};o={}'.format(
-                self.trace_id, self.span_id, 1)
+            'x-cloud-trace-context':
+            '{}/{};o={}'.format(self.trace_id, self.span_id, 1)
         }
 
         # Wait the application to start
@@ -95,11 +92,11 @@ class TestDjangoTrace(unittest.TestCase):
         os.killpg(os.getpgid(self.process.pid), signal.SIGTERM)
 
     def test_django_request_trace(self):
-        requests.get(
-            BASE_URL,
-            headers=self.headers_trace)
+        requests.get(BASE_URL, headers=self.headers_trace)
 
-        @retry(wait_fixed=RETRY_WAIT_PERIOD, stop_max_attempt_number=RETRY_MAX_ATTEMPT)
+        @retry(
+            wait_fixed=RETRY_WAIT_PERIOD,
+            stop_max_attempt_number=RETRY_MAX_ATTEMPT)
         def test_with_retry(self):
             trace = self.client.get_trace(trace_id=self.trace_id)
             spans = trace.get('spans')
@@ -115,11 +112,11 @@ class TestDjangoTrace(unittest.TestCase):
         test_with_retry(self)
 
     def test_mysql_trace(self):
-        requests.get(
-            '{}mysql'.format(BASE_URL),
-            headers=self.headers_trace)
+        requests.get('{}mysql'.format(BASE_URL), headers=self.headers_trace)
 
-        @retry(wait_fixed=RETRY_WAIT_PERIOD, stop_max_attempt_number=RETRY_MAX_ATTEMPT)
+        @retry(
+            wait_fixed=RETRY_WAIT_PERIOD,
+            stop_max_attempt_number=RETRY_MAX_ATTEMPT)
         def test_with_retry(self):
             trace = self.client.get_trace(trace_id=self.trace_id)
             spans = trace.get('spans')
@@ -139,8 +136,8 @@ class TestDjangoTrace(unittest.TestCase):
                     request_succeeded = True
 
                 if span.get('name') == '[mysql.query]SELECT 2*3':
-                    self.assertEqual(labels.get(
-                        'mysql.cursor.method.name'), 'execute')
+                    self.assertEqual(
+                        labels.get('mysql.cursor.method.name'), 'execute')
                     self.assertEqual(labels.get('mysql.query'), 'SELECT 2*3')
 
             self.assertTrue(request_succeeded)
@@ -149,10 +146,11 @@ class TestDjangoTrace(unittest.TestCase):
 
     def test_postgresql_trace(self):
         requests.get(
-            '{}postgresql'.format(BASE_URL),
-            headers=self.headers_trace)
+            '{}postgresql'.format(BASE_URL), headers=self.headers_trace)
 
-        @retry(wait_fixed=RETRY_WAIT_PERIOD, stop_max_attempt_number=RETRY_MAX_ATTEMPT)
+        @retry(
+            wait_fixed=RETRY_WAIT_PERIOD,
+            stop_max_attempt_number=RETRY_MAX_ATTEMPT)
         def test_with_retry(self):
             trace = self.client.get_trace(trace_id=self.trace_id)
             spans = trace.get('spans')
@@ -172,10 +170,10 @@ class TestDjangoTrace(unittest.TestCase):
                     request_succeeded = True
 
                 if span.get('name') == '[postgresql.query]SELECT 2*3':
-                    self.assertEqual(labels.get(
-                        'postgresql.cursor.method.name'), 'execute')
-                    self.assertEqual(labels.get(
-                        'postgresql.query'), 'SELECT 2*3')
+                    self.assertEqual(
+                        labels.get('postgresql.cursor.method.name'), 'execute')
+                    self.assertEqual(
+                        labels.get('postgresql.query'), 'SELECT 2*3')
 
             self.assertTrue(request_succeeded)
 
@@ -183,10 +181,11 @@ class TestDjangoTrace(unittest.TestCase):
 
     def test_sqlalchemy_mysql_trace(self):
         requests.get(
-            '{}sqlalchemy_mysql'.format(BASE_URL),
-            headers=self.headers_trace)
+            '{}sqlalchemy_mysql'.format(BASE_URL), headers=self.headers_trace)
 
-        @retry(wait_fixed=RETRY_WAIT_PERIOD, stop_max_attempt_number=RETRY_MAX_ATTEMPT)
+        @retry(
+            wait_fixed=RETRY_WAIT_PERIOD,
+            stop_max_attempt_number=RETRY_MAX_ATTEMPT)
         def test_with_retry(self):
             trace = self.client.get_trace(trace_id=self.trace_id)
             spans = trace.get('spans')
@@ -212,7 +211,9 @@ class TestDjangoTrace(unittest.TestCase):
             '{}sqlalchemy_postgresql'.format(BASE_URL),
             headers=self.headers_trace)
 
-        @retry(wait_fixed=RETRY_WAIT_PERIOD, stop_max_attempt_number=RETRY_MAX_ATTEMPT)
+        @retry(
+            wait_fixed=RETRY_WAIT_PERIOD,
+            stop_max_attempt_number=RETRY_MAX_ATTEMPT)
         def test_with_retry(self):
             trace = self.client.get_trace(trace_id=self.trace_id)
             spans = trace.get('spans')

--- a/tests/system/trace/flask/flask_system_test.py
+++ b/tests/system/trace/flask/flask_system_test.py
@@ -54,10 +54,7 @@ def run_application():
     """Start running the flask application."""
     cmd = 'python tests/system/trace/flask/main.py'
     process = subprocess.Popen(
-        cmd,
-        stdout=subprocess.PIPE,
-        shell=True,
-        preexec_fn=os.setsid)
+        cmd, stdout=subprocess.PIPE, shell=True, preexec_fn=os.setsid)
     return process
 
 
@@ -78,8 +75,8 @@ class TestFlaskTrace(unittest.TestCase):
         self.process = run_application()
 
         self.headers_trace = {
-            'X-Cloud-Trace-Context': '{}/{};o={}'.format(
-                self.trace_id, self.span_id, 1)
+            'X-Cloud-Trace-Context':
+            '{}/{};o={}'.format(self.trace_id, self.span_id, 1)
         }
 
         # Wait the application to start
@@ -93,11 +90,11 @@ class TestFlaskTrace(unittest.TestCase):
         os.killpg(os.getpgid(self.process.pid), signal.SIGTERM)
 
     def test_flask_request_trace(self):
-        requests.get(
-            BASE_URL,
-            headers=self.headers_trace)
+        requests.get(BASE_URL, headers=self.headers_trace)
 
-        @retry(wait_fixed=RETRY_WAIT_PERIOD, stop_max_attempt_number=RETRY_MAX_ATTEMPT)
+        @retry(
+            wait_fixed=RETRY_WAIT_PERIOD,
+            stop_max_attempt_number=RETRY_MAX_ATTEMPT)
         def test_with_retry(self):
             trace = self.client.get_trace(trace_id=self.trace_id)
             spans = trace.get('spans')
@@ -113,11 +110,11 @@ class TestFlaskTrace(unittest.TestCase):
         test_with_retry(self)
 
     def test_mysql_trace(self):
-        requests.get(
-            '{}mysql'.format(BASE_URL),
-            headers=self.headers_trace)
+        requests.get('{}mysql'.format(BASE_URL), headers=self.headers_trace)
 
-        @retry(wait_fixed=RETRY_WAIT_PERIOD, stop_max_attempt_number=RETRY_MAX_ATTEMPT)
+        @retry(
+            wait_fixed=RETRY_WAIT_PERIOD,
+            stop_max_attempt_number=RETRY_MAX_ATTEMPT)
         def test_with_retry(self):
             trace = self.client.get_trace(trace_id=self.trace_id)
             spans = trace.get('spans')
@@ -137,8 +134,8 @@ class TestFlaskTrace(unittest.TestCase):
                     request_succeeded = True
 
                 if span.get('name') == '[mysql.query]SELECT 2*3':
-                    self.assertEqual(labels.get(
-                        'mysql.cursor.method.name'), 'execute')
+                    self.assertEqual(
+                        labels.get('mysql.cursor.method.name'), 'execute')
                     self.assertEqual(labels.get('mysql.query'), 'SELECT 2*3')
 
             self.assertTrue(request_succeeded)
@@ -147,10 +144,11 @@ class TestFlaskTrace(unittest.TestCase):
 
     def test_postgresql_trace(self):
         requests.get(
-            '{}postgresql'.format(BASE_URL),
-            headers=self.headers_trace)
+            '{}postgresql'.format(BASE_URL), headers=self.headers_trace)
 
-        @retry(wait_fixed=RETRY_WAIT_PERIOD, stop_max_attempt_number=RETRY_MAX_ATTEMPT)
+        @retry(
+            wait_fixed=RETRY_WAIT_PERIOD,
+            stop_max_attempt_number=RETRY_MAX_ATTEMPT)
         def test_with_retry(self):
             trace = self.client.get_trace(trace_id=self.trace_id)
             spans = trace.get('spans')
@@ -170,10 +168,10 @@ class TestFlaskTrace(unittest.TestCase):
                     request_succeeded = True
 
                 if span.get('name') == '[postgresql.query]SELECT 2*3':
-                    self.assertEqual(labels.get(
-                        'postgresql.cursor.method.name'), 'execute')
-                    self.assertEqual(labels.get(
-                        'postgresql.query'), 'SELECT 2*3')
+                    self.assertEqual(
+                        labels.get('postgresql.cursor.method.name'), 'execute')
+                    self.assertEqual(
+                        labels.get('postgresql.query'), 'SELECT 2*3')
 
             self.assertTrue(request_succeeded)
 
@@ -181,10 +179,11 @@ class TestFlaskTrace(unittest.TestCase):
 
     def test_sqlalchemy_mysql_trace(self):
         requests.get(
-            '{}sqlalchemy-mysql'.format(BASE_URL),
-            headers=self.headers_trace)
+            '{}sqlalchemy-mysql'.format(BASE_URL), headers=self.headers_trace)
 
-        @retry(wait_fixed=RETRY_WAIT_PERIOD, stop_max_attempt_number=RETRY_MAX_ATTEMPT)
+        @retry(
+            wait_fixed=RETRY_WAIT_PERIOD,
+            stop_max_attempt_number=RETRY_MAX_ATTEMPT)
         def test_with_retry(self):
             trace = self.client.get_trace(trace_id=self.trace_id)
             spans = trace.get('spans')
@@ -210,7 +209,9 @@ class TestFlaskTrace(unittest.TestCase):
             '{}sqlalchemy-postgresql'.format(BASE_URL),
             headers=self.headers_trace)
 
-        @retry(wait_fixed=RETRY_WAIT_PERIOD, stop_max_attempt_number=RETRY_MAX_ATTEMPT)
+        @retry(
+            wait_fixed=RETRY_WAIT_PERIOD,
+            stop_max_attempt_number=RETRY_MAX_ATTEMPT)
         def test_with_retry(self):
             trace = self.client.get_trace(trace_id=self.trace_id)
             spans = trace.get('spans')

--- a/tests/system/trace/flask/main.py
+++ b/tests/system/trace/flask/main.py
@@ -58,9 +58,7 @@ def hello():
 def mysql_query():
     try:
         conn = mysql.connector.connect(
-            host=DB_HOST,
-            user='root',
-            password=MYSQL_PASSWORD)
+            host=DB_HOST, user='root', password=MYSQL_PASSWORD)
         cursor = conn.cursor()
 
         query = 'SELECT 2*3'
@@ -113,8 +111,8 @@ def postgresql_query():
 def sqlalchemy_mysql_query():
     try:
         engine = sqlalchemy.create_engine(
-            'mysql+mysqlconnector://{}:{}@{}'.format(
-                'root', MYSQL_PASSWORD, DB_HOST))
+            'mysql+mysqlconnector://{}:{}@{}'.format('root', MYSQL_PASSWORD,
+                                                     DB_HOST))
         conn = engine.connect()
 
         query = 'SELECT 2*3'
@@ -136,10 +134,8 @@ def sqlalchemy_mysql_query():
 @app.route('/sqlalchemy-postgresql')
 def sqlalchemy_postgresql_query():
     try:
-        engine = sqlalchemy.create_engine(
-            'postgresql://{}:{}@{}/{}'.format(
-                'postgres', POSTGRES_PASSWORD,
-                DB_HOST, 'postgres'))
+        engine = sqlalchemy.create_engine('postgresql://{}:{}@{}/{}'.format(
+            'postgres', POSTGRES_PASSWORD, DB_HOST, 'postgres'))
         conn = engine.connect()
 
         query = 'SELECT 2*3'

--- a/tests/unit/common/monitored_resource_util/test_aws_identity_doc_utils.py
+++ b/tests/unit/common/monitored_resource_util/test_aws_identity_doc_utils.py
@@ -34,9 +34,7 @@ class TestAwsIdentityDocumentUtils(unittest.TestCase):
             'pendingTime': '2016-11-19T16:32:11Z',
             'accountId': '123456789012',
             'region': 'us-west-2',
-            'marketplaceProductCodes': [
-                "1abc2defghijklm3nopqrs4tu"
-            ],
+            'marketplaceProductCodes': ["1abc2defghijklm3nopqrs4tu"],
             'instanceType': 't2.micro',
             'version': '2017-09-30',
             'architecture': 'x86_64',
@@ -61,7 +59,6 @@ class TestAwsIdentityDocumentUtils(unittest.TestCase):
 
         self.assertEquals(labels_list, expected_labels)
 
-
     @mock.patch('opencensus.common.monitored_resource_util.'
                 'aws_identity_doc_utils.get_request')
     def test_get_aws_metadata_none_fields(self, http_request_mock):
@@ -72,9 +69,7 @@ class TestAwsIdentityDocumentUtils(unittest.TestCase):
             'pendingTime': '2016-11-19T16:32:11Z',
             'accountId': '123456789012',
             'region': 'us-west-2',
-            'marketplaceProductCodes': [
-                "1abc2defghijklm3nopqrs4tu"
-            ],
+            'marketplaceProductCodes': ["1abc2defghijklm3nopqrs4tu"],
             'instanceType': 't2.micro',
             'version': '2017-09-30',
             'architecture': 'x86_64',
@@ -91,10 +86,7 @@ class TestAwsIdentityDocumentUtils(unittest.TestCase):
 
         self.assertEquals(len(labels_list), 2)
 
-        expected_labels = {
-            'aws_account': '123456789012',
-            'region': 'us-west-2'
-        }
+        expected_labels = {'aws_account': '123456789012', 'region': 'us-west-2'}
 
         self.assertEquals(labels_list, expected_labels)
 

--- a/tests/unit/common/monitored_resource_util/test_gcp_metadata_config.py
+++ b/tests/unit/common/monitored_resource_util/test_gcp_metadata_config.py
@@ -60,6 +60,7 @@ class TestGcpMetadataConfig(unittest.TestCase):
         """
         At least in python 3 binary strings are returned from urllib
         """
+
         def assign_attribute_value(*args, **kwargs):
             attribute_uri = args[0].split('/')[-1]
             if attribute_uri == 'id':
@@ -88,12 +89,14 @@ class TestGcpMetadataConfig(unittest.TestCase):
 
         self.assertEquals(labels_list, expected_labels)
 
-    @mock.patch.dict(os.environ,
-                     {'KUBERNETES_SERVICE_HOST': '127.0.0.1',
-                      'CONTAINER_NAME': 'container',
-                      'NAMESPACE': 'namespace',
-                      'HOSTNAME': 'localhost'}, clear=True
-                     )
+    @mock.patch.dict(
+        os.environ, {
+            'KUBERNETES_SERVICE_HOST': '127.0.0.1',
+            'CONTAINER_NAME': 'container',
+            'NAMESPACE': 'namespace',
+            'HOSTNAME': 'localhost'
+        },
+        clear=True)
     @mock.patch('opencensus.common.monitored_resource_util.'
                 'gcp_metadata_config.get_request')
     def test_get_gke_metadata(self, http_request_mock):
@@ -132,11 +135,13 @@ class TestGcpMetadataConfig(unittest.TestCase):
 
         self.assertEquals(labels_list, expected_labels)
 
-    @mock.patch.dict(os.environ,
-                     {'KUBERNETES_SERVICE_HOST': '127.0.0.1',
-                      'NAMESPACE': 'namespace',
-                      'HOSTNAME': 'localhost'}, clear=True
-                     )
+    @mock.patch.dict(
+        os.environ, {
+            'KUBERNETES_SERVICE_HOST': '127.0.0.1',
+            'NAMESPACE': 'namespace',
+            'HOSTNAME': 'localhost'
+        },
+        clear=True)
     @mock.patch('opencensus.common.monitored_resource_util.'
                 'gcp_metadata_config.get_request')
     def test_get_gke_metadata_container_empty(self, http_request_mock):

--- a/tests/unit/common/monitored_resource_util/test_monitored_resource.py
+++ b/tests/unit/common/monitored_resource_util/test_monitored_resource.py
@@ -21,7 +21,9 @@ from opencensus.common.monitored_resource_util.monitored_resource import AwsMoni
 
 class TestMonitoredResource(unittest.TestCase):
 
-    @mock.patch('opencensus.common.monitored_resource_util.monitored_resource.GcpMetadataConfig')
+    @mock.patch(
+        'opencensus.common.monitored_resource_util.monitored_resource.GcpMetadataConfig'
+    )
     def test_GcpGceMonitoredResource(self, gcp_metadata_mock):
         mocked_labels = {
             'instance_id': 'my-instance',
@@ -35,7 +37,9 @@ class TestMonitoredResource(unittest.TestCase):
         self.assertEquals(resource.resource_type, 'gce_instance')
         self.assertEquals(resource.get_resource_labels(), mocked_labels)
 
-    @mock.patch('opencensus.common.monitored_resource_util.monitored_resource.GcpMetadataConfig')
+    @mock.patch(
+        'opencensus.common.monitored_resource_util.monitored_resource.GcpMetadataConfig'
+    )
     def test_GcpGkeMonitoredResource(self, gcp_metadata_mock):
 
         mocked_labels = {
@@ -54,7 +58,9 @@ class TestMonitoredResource(unittest.TestCase):
         self.assertEquals(resource.resource_type, 'gke_container')
         self.assertEquals(resource.get_resource_labels(), mocked_labels)
 
-    @mock.patch('opencensus.common.monitored_resource_util.monitored_resource.AwsIdentityDocumentUtils')
+    @mock.patch(
+        'opencensus.common.monitored_resource_util.monitored_resource.AwsIdentityDocumentUtils'
+    )
     def test_AwsMonitoredResource(self, aws_metadata_mock):
 
         mocked_labels = {

--- a/tests/unit/common/monitored_resource_util/test_monitored_resource_util.py
+++ b/tests/unit/common/monitored_resource_util/test_monitored_resource_util.py
@@ -24,7 +24,8 @@ from opencensus.common.monitored_resource_util.monitored_resource import AwsMoni
 class TestMonitoredResourceUtil(unittest.TestCase):
 
     def test_gke_environment(self):
-        patch = mock.patch.dict(os.environ, {'KUBERNETES_SERVICE_HOST': '127.0.0.1'})
+        patch = mock.patch.dict(os.environ,
+                                {'KUBERNETES_SERVICE_HOST': '127.0.0.1'})
 
         with patch:
             monitored_resource = MonitoredResourceUtil.get_instance()
@@ -33,10 +34,11 @@ class TestMonitoredResourceUtil(unittest.TestCase):
             self.assertIsInstance(monitored_resource, GcpGkeMonitoredResource)
 
     def test_gce_environment(self):
-        patch = mock.patch('opencensus.common.monitored_resource_util.'
-                           'gcp_metadata_config.GcpMetadataConfig.'
-                           'is_running_on_gcp',
-                           return_value=True)
+        patch = mock.patch(
+            'opencensus.common.monitored_resource_util.'
+            'gcp_metadata_config.GcpMetadataConfig.'
+            'is_running_on_gcp',
+            return_value=True)
         with patch:
             monitored_resource = MonitoredResourceUtil.get_instance()
 

--- a/tests/unit/common/test_http_handler.py
+++ b/tests/unit/common/test_http_handler.py
@@ -43,9 +43,7 @@ class TestHttpHandler(unittest.TestCase):
             'pendingTime': '2016-11-19T16:32:11Z',
             'accountId': '12345678901',
             'region': 'us-west-2',
-            'marketplaceProductCodes': [
-                "1abc2defghijklm3nopqrs4tu"
-            ],
+            'marketplaceProductCodes': ["1abc2defghijklm3nopqrs4tu"],
             'instanceType': 't2.micro',
             'version': '2017-09-30',
             'architecture': 'x86_64',
@@ -67,9 +65,7 @@ class TestHttpHandler(unittest.TestCase):
             'pendingTime': '2016-11-19T16:32:11Z',
             'accountId': '123456789012',
             'region': 'us-west-2',
-            'marketplaceProductCodes': [
-                "1abc2defghijklm3nopqrs4tu"
-            ],
+            'marketplaceProductCodes': ["1abc2defghijklm3nopqrs4tu"],
             'instanceType': 't2.micro',
             'version': '2017-09-30',
             'architecture': 'x86_64',
@@ -82,27 +78,36 @@ class TestHttpHandler(unittest.TestCase):
         self.assertEqual(urlopen_mock.call_count, 1)
 
     def test_urlopen_requests_on_urlerror(self):
+
         def raise_urlerror(req, timeout):
             raise URLError('URL Error message')
 
-        with mock.patch('opencensus.common.http_handler.urlopen') as urlopen_mock:
+        with mock.patch(
+                'opencensus.common.http_handler.urlopen') as urlopen_mock:
             urlopen_mock.side_effect = raise_urlerror
             self.assertIsNone(get_request(self.TEST_URL))
 
     def test_urlopen_requests_on_httperror(self):
+
         def raise_httperror(req, timeout):
             raise HTTPError(
-                url='http://127.0.0.1', code=400,
-                msg='Bad request', hdrs=None, fp=None)
+                url='http://127.0.0.1',
+                code=400,
+                msg='Bad request',
+                hdrs=None,
+                fp=None)
 
-        with mock.patch('opencensus.common.http_handler.urlopen') as urlopen_mock:
+        with mock.patch(
+                'opencensus.common.http_handler.urlopen') as urlopen_mock:
             urlopen_mock.side_effect = raise_httperror
             self.assertIsNone(get_request(self.TEST_URL))
 
     def test_urlopen_requests_on_sockettimeout(self):
+
         def raise_sockettimeout(req, timeout):
             raise socket.timeout('URL Timeout message')
 
-        with mock.patch('opencensus.common.http_handler.urlopen') as urlopen_mock:
+        with mock.patch(
+                'opencensus.common.http_handler.urlopen') as urlopen_mock:
             urlopen_mock.side_effect = raise_sockettimeout
             self.assertIsNone(get_request(self.TEST_URL))

--- a/tests/unit/common/transports/test_async.py
+++ b/tests/unit/common/transports/test_async.py
@@ -18,7 +18,6 @@ import mock
 
 from opencensus.common.transports import async_
 
-
 # Don't let workers wait between exports in testing
 wait_period_patch = mock.patch(
     'opencensus.common.transports.async_._WAIT_PERIOD', 0)
@@ -40,8 +39,8 @@ class Test_Worker(unittest.TestCase):
         grace_period = 10
         max_batch_size = 20
 
-        worker = async_._Worker(exporter, grace_period=grace_period,
-                                max_batch_size=max_batch_size)
+        worker = async_._Worker(
+            exporter, grace_period=grace_period, max_batch_size=max_batch_size)
 
         self.assertEqual(worker.exporter, exporter)
         self.assertEqual(worker._grace_period, grace_period)
@@ -59,8 +58,7 @@ class Test_Worker(unittest.TestCase):
         self.assertIsNotNone(worker._thread)
         self.assertTrue(worker._thread.daemon)
         self.assertEqual(worker._thread._target, worker._thread_main)
-        self.assertEqual(
-            worker._thread._name, async_._WORKER_THREAD_NAME)
+        self.assertEqual(worker._thread._name, async_._WORKER_THREAD_NAME)
         mock_atexit.assert_called_once_with(worker._export_pending_data)
 
         cur_thread = worker._thread
@@ -76,8 +74,7 @@ class Test_Worker(unittest.TestCase):
         worker.stop()
 
         self.assertEqual(worker._queue.qsize(), 1)
-        self.assertEqual(
-            worker._queue.get(), async_._WORKER_TERMINATOR)
+        self.assertEqual(worker._queue.get(), async_._WORKER_TERMINATOR)
         self.assertFalse(worker.is_alive)
         self.assertIsNone(worker._thread)
 
@@ -123,7 +120,7 @@ class Test_Worker(unittest.TestCase):
         trace1 = {
             'traceId': 'test1',
             'spans': [{}, {}],
-            }
+        }
         trace2 = {
             'traceId': 'test2',
             'spans': [{}],
@@ -177,6 +174,7 @@ class Test_Worker(unittest.TestCase):
     def test__thread_main_terminate_before_finish(self):
 
         class Exporter(object):
+
             def __init__(self):
                 self.exported = []
 
@@ -211,6 +209,7 @@ class Test_Worker(unittest.TestCase):
     def test__thread_main_alive_on_emit_failed(self, mock):
 
         class Exporter(object):
+
             def __init__(self):
                 self.exported = []
 
@@ -262,8 +261,7 @@ class TestAsyncTransport(unittest.TestCase):
 
     def test_constructor(self):
         patch_worker = mock.patch(
-            'opencensus.common.transports.async_._Worker',
-            autospec=True)
+            'opencensus.common.transports.async_._Worker', autospec=True)
         exporter = mock.Mock()
 
         with patch_worker:
@@ -274,8 +272,7 @@ class TestAsyncTransport(unittest.TestCase):
 
     def test_export(self):
         patch_worker = mock.patch(
-            'opencensus.common.transports.async_._Worker',
-            autospec=True)
+            'opencensus.common.transports.async_._Worker', autospec=True)
         exporter = mock.Mock()
 
         with patch_worker:
@@ -292,8 +289,7 @@ class TestAsyncTransport(unittest.TestCase):
 
     def test_flush(self):
         patch_worker = mock.patch(
-            'opencensus.common.transports.async_._Worker',
-            autospec=True)
+            'opencensus.common.transports.async_._Worker', autospec=True)
         exporter = mock.Mock()
 
         with patch_worker:

--- a/tests/unit/common/transports/test_common_base_transport.py
+++ b/tests/unit/common/transports/test_common_base_transport.py
@@ -14,6 +14,7 @@
 
 import unittest
 
+
 class TestCommonBaseTransport(unittest.TestCase):
 
     def test_export_abstract(self):

--- a/tests/unit/common/transports/test_sync.py
+++ b/tests/unit/common/transports/test_sync.py
@@ -16,6 +16,7 @@ import unittest
 import mock
 from opencensus.common.transports import sync
 
+
 class TestSyncTransport(unittest.TestCase):
 
     def test_constructor(self):

--- a/tests/unit/metrics/export/test_metric.py
+++ b/tests/unit/metrics/export/test_metric.py
@@ -25,6 +25,7 @@ from opencensus.metrics.export import time_series
 
 
 class TestMetric(unittest.TestCase):
+
     def test_init(self):
 
         # Check for required arg errors
@@ -37,10 +38,13 @@ class TestMetric(unittest.TestCase):
         mock_time_series.check_points_type.return_value = True
 
         mock_descriptor = Mock(spec=metric_descriptor.MetricDescriptor)
-        mock_descriptor.type = (metric_descriptor
-                                .MetricDescriptorType.GAUGE_INT64)
+        mock_descriptor.type = (
+            metric_descriptor.MetricDescriptorType.GAUGE_INT64)
 
-        mm = metric.Metric(mock_descriptor, [mock_time_series],)
+        mm = metric.Metric(
+            mock_descriptor,
+            [mock_time_series],
+        )
         self.assertEqual(mm.time_series, [mock_time_series])
         self.assertEqual(mm.descriptor, mock_descriptor)
 
@@ -54,14 +58,14 @@ class TestMetric(unittest.TestCase):
         mock_time_series2.check_points_type.return_value = False
 
         for value_type in (
-            metric_descriptor.MetricDescriptorType.GAUGE_INT64,
-            metric_descriptor.MetricDescriptorType.CUMULATIVE_INT64,
-            metric_descriptor.MetricDescriptorType.GAUGE_DOUBLE,
-            metric_descriptor.MetricDescriptorType.CUMULATIVE_DOUBLE,
-            metric_descriptor.MetricDescriptorType.GAUGE_DISTRIBUTION,
-            metric_descriptor.MetricDescriptorType.CUMULATIVE_DISTRIBUTION,
-            metric_descriptor.MetricDescriptorType.SUMMARY,
-            10  # unspecified type
+                metric_descriptor.MetricDescriptorType.GAUGE_INT64,
+                metric_descriptor.MetricDescriptorType.CUMULATIVE_INT64,
+                metric_descriptor.MetricDescriptorType.GAUGE_DOUBLE,
+                metric_descriptor.MetricDescriptorType.CUMULATIVE_DOUBLE,
+                metric_descriptor.MetricDescriptorType.GAUGE_DISTRIBUTION,
+                metric_descriptor.MetricDescriptorType.CUMULATIVE_DISTRIBUTION,
+                metric_descriptor.MetricDescriptorType.SUMMARY,
+                10  # unspecified type
         ):
             with self.assertRaises(ValueError):
                 mock_descriptor.type = value_type
@@ -77,21 +81,18 @@ class TestMetric(unittest.TestCase):
 
         mock_descriptor_gauge = Mock(spec=metric_descriptor.MetricDescriptor)
         mock_descriptor_gauge.type = (
-            metric_descriptor.MetricDescriptorType.GAUGE_INT64
-        )
-        mock_descriptor_cumulative = (
-            Mock(spec=metric_descriptor.MetricDescriptor)
-        )
+            metric_descriptor.MetricDescriptorType.GAUGE_INT64)
+        mock_descriptor_cumulative = (Mock(
+            spec=metric_descriptor.MetricDescriptor))
         mock_descriptor_cumulative.type = (
-            metric_descriptor.MetricDescriptorType.CUMULATIVE_INT64
-        )
+            metric_descriptor.MetricDescriptorType.CUMULATIVE_INT64)
 
-        (metric.Metric(mock_descriptor_gauge, [mock_ts])
-         ._check_start_timestamp())
-        (metric.Metric(mock_descriptor_cumulative, [mock_ts])
-         ._check_start_timestamp())
-        (metric.Metric(mock_descriptor_gauge, [mock_ts_no_start])
-         ._check_start_timestamp())
+        (metric.Metric(mock_descriptor_gauge,
+                       [mock_ts])._check_start_timestamp())
+        (metric.Metric(mock_descriptor_cumulative,
+                       [mock_ts])._check_start_timestamp())
+        (metric.Metric(mock_descriptor_gauge,
+                       [mock_ts_no_start])._check_start_timestamp())
         with self.assertRaises(ValueError):
             metric.Metric(mock_descriptor_cumulative,
                           [mock_ts_no_start])._check_start_timestamp()

--- a/tests/unit/metrics/export/test_metric_descriptor.py
+++ b/tests/unit/metrics/export/test_metric_descriptor.py
@@ -29,6 +29,7 @@ LABEL_KEYS = (LABEL_KEY1, LABEL_KEY2)
 
 
 class TestMetricDescriptor(unittest.TestCase):
+
     def test_init(self):
         metric_descriptor = MetricDescriptor(NAME, DESCRIPTION, UNIT,
                                              MetricDescriptorType.GAUGE_DOUBLE,
@@ -43,7 +44,7 @@ class TestMetricDescriptor(unittest.TestCase):
 
     def test_bogus_type(self):
         with self.assertRaises(ValueError):
-            MetricDescriptor(NAME, DESCRIPTION, UNIT, 0, (LABEL_KEY1, ))
+            MetricDescriptor(NAME, DESCRIPTION, UNIT, 0, (LABEL_KEY1,))
 
     def test_null_label_keys(self):
         with self.assertRaises(ValueError):
@@ -53,7 +54,7 @@ class TestMetricDescriptor(unittest.TestCase):
     def test_null_label_key_values(self):
         with self.assertRaises(ValueError):
             MetricDescriptor(NAME, DESCRIPTION, UNIT,
-                             MetricDescriptorType.GAUGE_DOUBLE, (None, ))
+                             MetricDescriptorType.GAUGE_DOUBLE, (None,))
 
     def test_to_type_class(self):
         self.assertEqual(

--- a/tests/unit/metrics/export/test_point.py
+++ b/tests/unit/metrics/export/test_point.py
@@ -19,6 +19,7 @@ from opencensus.metrics.export import value as value_module
 
 
 class TestPoint(unittest.TestCase):
+
     def setUp(self):
         self.double_value = value_module.Value.double_value(55.5)
         self.long_value = value_module.Value.long_value(9876543210)

--- a/tests/unit/metrics/export/test_summary.py
+++ b/tests/unit/metrics/export/test_summary.py
@@ -19,6 +19,7 @@ from opencensus.metrics.export import summary as summary_module
 
 
 class TestSummary(unittest.TestCase):
+
     def setUp(self):
         value_at_percentile = [summary_module.ValueAtPercentile(99.5, 10.2)]
         self.snapshot = summary_module.Snapshot(10, 87.07, value_at_percentile)
@@ -52,14 +53,14 @@ class TestSummary(unittest.TestCase):
 
 
 class TestSnapshot(unittest.TestCase):
+
     def setUp(self):
         self.value_at_percentile = [
             summary_module.ValueAtPercentile(99.5, 10.2)
         ]
 
         # Invalid value_at_percentile
-        self.value_at_percentile1 = summary_module.ValueAtPercentile(
-            99.5, 10.2)
+        self.value_at_percentile1 = summary_module.ValueAtPercentile(99.5, 10.2)
 
     def test_constructor(self):
         snapshot = summary_module.Snapshot(10, 87.07, self.value_at_percentile)
@@ -101,8 +102,7 @@ class TestSnapshot(unittest.TestCase):
         summary_module.Snapshot(0, 0, self.value_at_percentile)
 
     def test_constructor_with_none_count_sum(self):
-        snapshot = summary_module.Snapshot(None, None,
-                                           self.value_at_percentile)
+        snapshot = summary_module.Snapshot(None, None, self.value_at_percentile)
 
         self.assertIsNotNone(snapshot)
         self.assertIsNone(snapshot.count)
@@ -112,6 +112,7 @@ class TestSnapshot(unittest.TestCase):
 
 
 class TestValueAtPercentile(unittest.TestCase):
+
     def test_constructor(self):
         value_at_percentile = summary_module.ValueAtPercentile(99.5, 10.2)
 

--- a/tests/unit/metrics/export/test_time_series.py
+++ b/tests/unit/metrics/export/test_time_series.py
@@ -26,19 +26,15 @@ START_TIMESTAMP = '2018-10-09T22:33:44.012345Z'
 LABEL_VALUE1 = label_value.LabelValue('value one')
 LABEL_VALUE2 = label_value.LabelValue('价值二')
 LABEL_VALUES = (LABEL_VALUE1, LABEL_VALUE2)
-POINTS = (point.Point(
-    value.Value.long_value(1), "2018-10-09T23:33:44.012345Z"),
-          point.Point(
-              value.Value.long_value(2), "2018-10-10T00:33:44.012345Z"),
-          point.Point(
-              value.Value.long_value(3), "2018-10-10T01:33:44.012345Z"),
-          point.Point(
-              value.Value.long_value(4), "2018-10-10T02:33:44.012345Z"),
-          point.Point(
-              value.Value.long_value(5), "2018-10-10T03:33:44.012345Z"))
+POINTS = (point.Point(value.Value.long_value(1), "2018-10-09T23:33:44.012345Z"),
+          point.Point(value.Value.long_value(2), "2018-10-10T00:33:44.012345Z"),
+          point.Point(value.Value.long_value(3), "2018-10-10T01:33:44.012345Z"),
+          point.Point(value.Value.long_value(4), "2018-10-10T02:33:44.012345Z"),
+          point.Point(value.Value.long_value(5), "2018-10-10T03:33:44.012345Z"))
 
 
 class TestTimeSeries(unittest.TestCase):
+
     def test_init(self):
         ts = time_series.TimeSeries(LABEL_VALUES, POINTS, START_TIMESTAMP)
 
@@ -64,7 +60,7 @@ class TestTimeSeries(unittest.TestCase):
                 metric_descriptor.MetricDescriptorType.GAUGE_INT64))
 
         bad_points = POINTS + (point.Point(
-            value.Value.double_value(6.0), "2018-10-10T04:33:44.012345Z"), )
+            value.Value.double_value(6.0), "2018-10-10T04:33:44.012345Z"),)
         bad_time_series = time_series.TimeSeries(LABEL_VALUES, bad_points,
                                                  START_TIMESTAMP)
 

--- a/tests/unit/metrics/export/test_value.py
+++ b/tests/unit/metrics/export/test_value.py
@@ -19,6 +19,7 @@ from opencensus.metrics.export import value as value_module
 
 
 class TestValue(unittest.TestCase):
+
     def test_create_double_value(self):
         double_value = value_module.Value.double_value(-34.56)
 
@@ -53,6 +54,7 @@ BUCKETS = [value_module.Bucket(10, None) for ii in range(10)]
 
 
 class TestValueDistribution(unittest.TestCase):
+
     def test_init(self):
         distribution = value_module.ValueDistribution(
             VD_COUNT, VD_SUM, VD_SUM_OF_SQUARED_DEVIATION, BUCKET_BOUNDS,
@@ -77,9 +79,8 @@ class TestValueDistribution(unittest.TestCase):
     def test_init_bad_args(self):
 
         with self.assertRaises(ValueError):
-            value_module.ValueDistribution(-1, VD_SUM,
-                                           VD_SUM_OF_SQUARED_DEVIATION,
-                                           BUCKET_BOUNDS, BUCKETS)
+            value_module.ValueDistribution(
+                -1, VD_SUM, VD_SUM_OF_SQUARED_DEVIATION, BUCKET_BOUNDS, BUCKETS)
 
         with self.assertRaises(ValueError):
             value_module.ValueDistribution(
@@ -118,15 +119,16 @@ EX_ATTACHMENTS = {'attach': 'ments'}
 
 
 class TestExemplar(unittest.TestCase):
+
     def test_init(self):
-        exemplar = value_module.Exemplar(EX_VALUE, EX_TIMESTAMP,
-                                         EX_ATTACHMENTS)
+        exemplar = value_module.Exemplar(EX_VALUE, EX_TIMESTAMP, EX_ATTACHMENTS)
         self.assertEqual(exemplar.value, EX_VALUE)
         self.assertEqual(exemplar.timestamp, EX_TIMESTAMP)
         self.assertEqual(exemplar.attachments, EX_ATTACHMENTS)
 
 
 class TestBucket(unittest.TestCase):
+
     def setUp(self):
         self.exemplar = value_module.Exemplar(EX_VALUE, EX_TIMESTAMP,
                                               EX_ATTACHMENTS)

--- a/tests/unit/metrics/test_label_value.py
+++ b/tests/unit/metrics/test_label_value.py
@@ -19,6 +19,7 @@ from opencensus.metrics import label_value as label_value_module
 
 
 class TestLabelValue(unittest.TestCase):
+
     def test_constructor(self):
         value = 'value1'
         label_value = label_value_module.LabelValue(value)

--- a/tests/unit/stats/exporter/test_base_stats.py
+++ b/tests/unit/stats/exporter/test_base_stats.py
@@ -16,18 +16,19 @@ import unittest
 import mock
 from opencensus.stats.exporters import base
 
+
 class TestBaseStats(unittest.TestCase):
 
-	def test_emit(self):
-		exp = base.StatsExporter()
-		view_data = []
+    def test_emit(self):
+        exp = base.StatsExporter()
+        view_data = []
 
-		with self.assertRaises(NotImplementedError):
-			exp.emit(view_data)
+        with self.assertRaises(NotImplementedError):
+            exp.emit(view_data)
 
-	def test_register_view(self):
-		exp = base.StatsExporter()
-		view = mock.Mock()
+    def test_register_view(self):
+        exp = base.StatsExporter()
+        view = mock.Mock()
 
-		with self.assertRaises(NotImplementedError):
-			exp.on_register_view(view)
+        with self.assertRaises(NotImplementedError):
+            exp.on_register_view(view)

--- a/tests/unit/stats/exporter/test_prometheus_stats.py
+++ b/tests/unit/stats/exporter/test_prometheus_stats.py
@@ -26,7 +26,6 @@ from opencensus.tags import tag_key as tag_key_module
 from opencensus.tags import tag_map as tag_map_module
 from opencensus.tags import tag_value as tag_value_module
 
-
 MiB = 1 << 20
 FRONTEND_KEY = tag_key_module.TagKey("my.org/keys/frontend")
 FRONTEND_KEY_FLOAT = tag_key_module.TagKey("my.org/keys/frontend-FLOAT")
@@ -64,6 +63,7 @@ REGISTERED_VIEW2 = {
 
 
 class TestOptionsPrometheus(unittest.TestCase):
+
     def test_options_constructor(self):
         option = prometheus.Options("test1")
         self.assertEqual(option.namespace, "test1")
@@ -78,6 +78,7 @@ class TestOptionsPrometheus(unittest.TestCase):
 
 
 class TestCollectorPrometheus(unittest.TestCase):
+
     def test_collector_constructor(self):
         options = prometheus.Options("test1")
         self.assertEqual(options.namespace, "test1")
@@ -217,8 +218,7 @@ class TestCollectorPrometheus(unittest.TestCase):
         options = prometheus.Options("test2", 8001, "localhost", registry)
         collector = prometheus.Collector(options=options, view_data=view_data)
         collector.register_view(view)
-        desc = collector.registered_views[
-            'test2_new_view-my.org/keys/frontend']
+        desc = collector.registered_views['test2_new_view-my.org/keys/frontend']
         collector.to_metric(desc=desc, view=view)
 
         registry = mock.Mock()
@@ -236,6 +236,7 @@ class TestCollectorPrometheus(unittest.TestCase):
 
 
 class TestPrometheusStatsExporter(unittest.TestCase):
+
     def test_exporter_constructor_no_namespace(self):
         with self.assertRaisesRegexp(ValueError,
                                      'Namespace can not be empty string.'):

--- a/tests/unit/stats/exporter/test_stackdriver_stats.py
+++ b/tests/unit/stats/exporter/test_stackdriver_stats.py
@@ -50,11 +50,13 @@ VIDEO_SIZE_VIEW = view_module.View(
 
 
 class _Client(object):
+
     def __init__(self, client_info=None):
         self.client_info = client_info
 
 
 class TestOptions(unittest.TestCase):
+
     def test_options_blank(self):
         option = stackdriver.Options()
 
@@ -78,6 +80,7 @@ class TestOptions(unittest.TestCase):
 
 
 class TestStackdriverStatsExporter(unittest.TestCase):
+
     def test_constructor(self):
         exporter = stackdriver.StackdriverStatsExporter()
 
@@ -156,8 +159,7 @@ class TestStackdriverStatsExporter(unittest.TestCase):
         default_labels = {'key1': 'value1'}
         patch_client = mock.patch(
             ('opencensus.stats.exporters.stackdriver_exporter'
-             '.monitoring_v3.MetricServiceClient'),
-            _Client)
+             '.monitoring_v3.MetricServiceClient'), _Client)
 
         with patch_client:
             exporter_created = stackdriver.new_stats_exporter(
@@ -184,8 +186,8 @@ class TestStackdriverStatsExporter(unittest.TestCase):
 
     def test_namespacedviews(self):
         view_name = "view-1"
-        expected_view_name_namespaced = ("custom.googleapis.com/opencensus/{}"
-                                         .format(view_name))
+        expected_view_name_namespaced = (
+            "custom.googleapis.com/opencensus/{}".format(view_name))
         view_name_namespaced = stackdriver.namespaced_view_name(view_name, "")
         self.assertEqual(expected_view_name_namespaced, view_name_namespaced)
 
@@ -461,8 +463,7 @@ class TestStackdriverStatsExporter(unittest.TestCase):
                           'my-instance')
         self.assertEquals(time_series.resource.labels['aws_account'],
                           'my-project')
-        self.assertEquals(time_series.resource.labels['region'],
-                          'aws:us-east1')
+        self.assertEquals(time_series.resource.labels['region'], 'aws:us-east1')
 
         # check for out of box monitored resource
         monitor_resource_mock.return_value = mock.Mock()
@@ -643,8 +644,8 @@ class TestStackdriverStatsExporter(unittest.TestCase):
         view_name_sum_int = "view-sum-int"
         agg_sum = aggregation_module.SumAggregation(sum=2)
         view_sum_int = view_module.View(
-            view_name_sum_int, "processed video size over time",
-            [FRONTEND_KEY], VIDEO_SIZE_MEASURE, agg_sum)
+            view_name_sum_int, "processed video size over time", [FRONTEND_KEY],
+            VIDEO_SIZE_MEASURE, agg_sum)
         exporter = stackdriver.StackdriverStatsExporter(
             options=option, client=client)
         desc = exporter.create_metric_descriptor(view_sum_int)

--- a/tests/unit/stats/test_aggregation.py
+++ b/tests/unit/stats/test_aggregation.py
@@ -19,6 +19,7 @@ from opencensus.stats import aggregation as aggregation_module
 
 
 class TestBaseAggregation(unittest.TestCase):
+
     def test_constructor_defaults(self):
         base_aggregation = aggregation_module.BaseAggregation()
 
@@ -37,6 +38,7 @@ class TestBaseAggregation(unittest.TestCase):
 
 
 class TestSumAggregation(unittest.TestCase):
+
     def test_constructor_defaults(self):
         sum_aggregation = aggregation_module.SumAggregation()
 
@@ -55,6 +57,7 @@ class TestSumAggregation(unittest.TestCase):
 
 
 class TestCountAggregation(unittest.TestCase):
+
     def test_constructor_defaults(self):
         count_aggregation = aggregation_module.CountAggregation()
 
@@ -73,6 +76,7 @@ class TestCountAggregation(unittest.TestCase):
 
 
 class TestLastValueAggregation(unittest.TestCase):
+
     def test_constructor_defaults(self):
         last_value_aggregation = aggregation_module.LastValueAggregation()
 
@@ -91,6 +95,7 @@ class TestLastValueAggregation(unittest.TestCase):
 
 
 class TestDistributionAggregation(unittest.TestCase):
+
     def test_constructor_defaults(self):
         distribution_aggregation = aggregation_module.DistributionAggregation()
 
@@ -105,8 +110,7 @@ class TestDistributionAggregation(unittest.TestCase):
         distribution_aggregation = aggregation_module.DistributionAggregation(
             boundaries=boundaries, distribution=distribution)
 
-        self.assertEqual([1, 2],
-                         distribution_aggregation.boundaries.boundaries)
+        self.assertEqual([1, 2], distribution_aggregation.boundaries.boundaries)
         self.assertEqual([0, 1, 2], distribution_aggregation.distribution)
         self.assertEqual(aggregation_module.Type.DISTRIBUTION,
                          distribution_aggregation.aggregation_type)

--- a/tests/unit/stats/test_aggregation_data.py
+++ b/tests/unit/stats/test_aggregation_data.py
@@ -21,6 +21,7 @@ from opencensus.stats import aggregation_data as aggregation_data_module
 
 
 class TestBaseAggregationData(unittest.TestCase):
+
     def test_constructor(self):
         aggregation_data = 0
         base_aggregation_data = aggregation_data_module.BaseAggregationData(
@@ -30,6 +31,7 @@ class TestBaseAggregationData(unittest.TestCase):
 
 
 class TestSumAggregationData(unittest.TestCase):
+
     def test_constructor(self):
         sum_data = 1
         sum_aggregation_data = aggregation_data_module.SumAggregationDataFloat(
@@ -48,6 +50,7 @@ class TestSumAggregationData(unittest.TestCase):
 
 
 class TestCountAggregationData(unittest.TestCase):
+
     def test_constructor(self):
         count_data = 0
         count_aggregation_data = aggregation_data_module.CountAggregationData(
@@ -65,6 +68,7 @@ class TestCountAggregationData(unittest.TestCase):
 
 
 class TestLastValueAggregationData(unittest.TestCase):
+
     def test_constructor(self):
         value_data = 0
         last_value_aggregation_data =\
@@ -82,6 +86,7 @@ class TestLastValueAggregationData(unittest.TestCase):
 
 
 class TestDistributionAggregationData(unittest.TestCase):
+
     def test_constructor(self):
         mean_data = 1
         count_data = 0
@@ -182,10 +187,8 @@ class TestDistributionAggregationData(unittest.TestCase):
     def test_constructor_with_exemplar(self):
         timestamp = time.time()
         attachments = {"One": "one", "Two": "two"}
-        exemplar_1 = aggregation_data_module.Exemplar(4, timestamp,
-                                                      attachments)
-        exemplar_2 = aggregation_data_module.Exemplar(5, timestamp,
-                                                      attachments)
+        exemplar_1 = aggregation_data_module.Exemplar(4, timestamp, attachments)
+        exemplar_2 = aggregation_data_module.Exemplar(5, timestamp, attachments)
         mean_data = 1
         count_data = 0
         _min = 0
@@ -358,8 +361,7 @@ class TestDistributionAggregationData(unittest.TestCase):
         value = 3
         timestamp = time.time()
         attachments = {"One": "one", "Two": "two"}
-        exemplar_1 = aggregation_data_module.Exemplar(4, timestamp,
-                                                      attachments)
+        exemplar_1 = aggregation_data_module.Exemplar(4, timestamp, attachments)
 
         dist_agg_data = aggregation_data_module.DistributionAggregationData(
             mean_data=mean_data,

--- a/tests/unit/stats/test_bucket_boundaries.py
+++ b/tests/unit/stats/test_bucket_boundaries.py
@@ -24,24 +24,27 @@ class TestBucketBoundaries(unittest.TestCase):
         self.assertEqual([], bucket_boundaries.boundaries)
 
     def test_constructor_explicit(self):
-        boundaries = [1/4]
-        bucket_boundaries = bucket_boundaries_module.BucketBoundaries(boundaries=boundaries)
+        boundaries = [1 / 4]
+        bucket_boundaries = bucket_boundaries_module.BucketBoundaries(
+            boundaries=boundaries)
         self.assertTrue(bucket_boundaries.is_valid_boundaries(boundaries))
         self.assertEqual(boundaries, bucket_boundaries.boundaries)
 
     def test_is_valid_boundaries(self):
-        boundaries = [0, 1/4, 1/2]
-        bucket_boundaries = bucket_boundaries_module.BucketBoundaries(boundaries=boundaries)
-        self.assertTrue(bucket_boundaries.is_valid_boundaries(boundaries=boundaries))
+        boundaries = [0, 1 / 4, 1 / 2]
+        bucket_boundaries = bucket_boundaries_module.BucketBoundaries(
+            boundaries=boundaries)
+        self.assertTrue(
+            bucket_boundaries.is_valid_boundaries(boundaries=boundaries))
 
         boundaries = [2, 1, 0]
         bucket_boundaries = bucket_boundaries_module.BucketBoundaries(
             boundaries=boundaries)
-        self.assertFalse(bucket_boundaries.is_valid_boundaries(
-            boundaries=boundaries))
+        self.assertFalse(
+            bucket_boundaries.is_valid_boundaries(boundaries=boundaries))
 
         boundaries = None
         bucket_boundaries = bucket_boundaries_module.BucketBoundaries(
-            boundaries=boundaries
-        )
-        self.assertFalse(bucket_boundaries.is_valid_boundaries(boundaries=boundaries))
+            boundaries=boundaries)
+        self.assertFalse(
+            bucket_boundaries.is_valid_boundaries(boundaries=boundaries))

--- a/tests/unit/stats/test_measure.py
+++ b/tests/unit/stats/test_measure.py
@@ -32,7 +32,8 @@ class TestBaseMeasure(unittest.TestCase):
         description = "testMeasure"
         unit = "testUnit"
 
-        measure = measure_module.BaseMeasure(name=name, description=description, unit=unit)
+        measure = measure_module.BaseMeasure(
+            name=name, description=description, unit=unit)
 
         self.assertEqual("testName", measure.name)
         self.assertEqual("testMeasure", measure.description)
@@ -54,7 +55,8 @@ class TestMeasureInt(unittest.TestCase):
         description = "testMeasure"
         unit = "testUnit"
 
-        measure = measure_module.MeasureInt(name=name, description=description, unit=unit)
+        measure = measure_module.MeasureInt(
+            name=name, description=description, unit=unit)
 
         self.assertEqual("testName", measure.name)
         self.assertEqual("testMeasure", measure.description)
@@ -67,7 +69,8 @@ class TestMeasureFloat(unittest.TestCase):
         name = "testName"
         description = "testMeasure"
 
-        measure = measure_module.MeasureFloat(name=name, description=description)
+        measure = measure_module.MeasureFloat(
+            name=name, description=description)
 
         self.assertEqual(None, measure.unit)
 
@@ -76,7 +79,8 @@ class TestMeasureFloat(unittest.TestCase):
         description = "testMeasure"
         unit = "testUnit"
 
-        measure = measure_module.MeasureFloat(name=name, description=description, unit=unit)
+        measure = measure_module.MeasureFloat(
+            name=name, description=description, unit=unit)
 
         self.assertEqual("testName", measure.name)
         self.assertEqual("testMeasure", measure.description)

--- a/tests/unit/stats/test_measure_to_view_map.py
+++ b/tests/unit/stats/test_measure_to_view_map.py
@@ -24,6 +24,7 @@ from opencensus.stats.view_data import ViewData
 
 
 class TestMeasureToViewMap(unittest.TestCase):
+
     @staticmethod
     def _get_target_class():
         return measure_to_view_map_module.MeasureToViewMap
@@ -34,8 +35,7 @@ class TestMeasureToViewMap(unittest.TestCase):
     def test_constructor(self):
         measure_to_view_map = measure_to_view_map_module.MeasureToViewMap()
 
-        self.assertEqual({},
-                         measure_to_view_map._measure_to_view_data_list_map)
+        self.assertEqual({}, measure_to_view_map._measure_to_view_data_list_map)
         self.assertEqual({}, measure_to_view_map._registered_views)
         self.assertEqual({}, measure_to_view_map._registered_measures)
         self.assertEqual(set(), measure_to_view_map.exported_views)
@@ -130,12 +130,11 @@ class TestMeasureToViewMap(unittest.TestCase):
         measure_to_view_map._registered_measures = {}
         measure_to_view_map.register_view(view=view, timestamp=timestamp)
         self.assertIsNone(measure_to_view_map.exported_views)
-        self.assertEqual(measure_to_view_map._registered_views[view.name],
-                         view)
-        self.assertEqual(
-            measure_to_view_map._registered_measures[measure.name], measure)
-        self.assertIsNotNone(measure_to_view_map.
-                             _measure_to_view_data_list_map[view.measure.name])
+        self.assertEqual(measure_to_view_map._registered_views[view.name], view)
+        self.assertEqual(measure_to_view_map._registered_measures[measure.name],
+                         measure)
+        self.assertIsNotNone(measure_to_view_map._measure_to_view_data_list_map[
+            view.measure.name])
 
         # Registers a view with an existing measure.
         view2 = View(
@@ -147,8 +146,8 @@ class TestMeasureToViewMap(unittest.TestCase):
         test_with_registered_measures = measure_to_view_map.register_view(
             view=view2, timestamp=timestamp)
         self.assertIsNone(test_with_registered_measures)
-        self.assertEqual(
-            measure_to_view_map._registered_measures[measure.name], measure)
+        self.assertEqual(measure_to_view_map._registered_measures[measure.name],
+                         measure)
 
         # Registers a view with a measure that has the same name as an existing
         # measure, but with different schema. measure2 and view3 should be
@@ -173,15 +172,15 @@ class TestMeasureToViewMap(unittest.TestCase):
         # view is already registered, measure will not be registered again.
         self.assertIsNone(
             measure_to_view_map._registered_measures.get(measure.name))
-        self.assertIsNotNone(measure_to_view_map.
-                             _measure_to_view_data_list_map[view.measure.name])
+        self.assertIsNotNone(measure_to_view_map._measure_to_view_data_list_map[
+            view.measure.name])
 
         measure_to_view_map._registered_views = {name: view}
         test_result_1 = measure_to_view_map.register_view(
             view=view, timestamp=timestamp)
         self.assertIsNone(test_result_1)
-        self.assertIsNotNone(measure_to_view_map.
-                             _measure_to_view_data_list_map[view.measure.name])
+        self.assertIsNotNone(measure_to_view_map._measure_to_view_data_list_map[
+            view.measure.name])
 
     def test_register_view_with_exporter(self):
         exporter = mock.Mock()
@@ -203,12 +202,11 @@ class TestMeasureToViewMap(unittest.TestCase):
         measure_to_view_map._registered_measures = {}
         measure_to_view_map.register_view(view=view, timestamp=timestamp)
         self.assertIsNone(measure_to_view_map.exported_views)
-        self.assertEqual(measure_to_view_map._registered_views[view.name],
-                         view)
-        self.assertEqual(
-            measure_to_view_map._registered_measures[measure.name], measure)
-        self.assertIsNotNone(measure_to_view_map.
-                             _measure_to_view_data_list_map[view.measure.name])
+        self.assertEqual(measure_to_view_map._registered_views[view.name], view)
+        self.assertEqual(measure_to_view_map._registered_measures[measure.name],
+                         measure)
+        self.assertIsNotNone(measure_to_view_map._measure_to_view_data_list_map[
+            view.measure.name])
 
     def test_record(self):
         measure_name = "test_measure"
@@ -221,11 +219,12 @@ class TestMeasureToViewMap(unittest.TestCase):
         view_columns = ["testTag1", "testColumn2"]
         view_measure = measure
         view_aggregation = mock.Mock()
-        View(name=view_name,
-             description=view_description,
-             columns=view_columns,
-             measure=view_measure,
-             aggregation=view_aggregation)
+        View(
+            name=view_name,
+            description=view_description,
+            columns=view_columns,
+            measure=view_measure,
+            aggregation=view_aggregation)
 
         measure_value = 5
         tags = {"testTag1": "testTag1Value"}
@@ -240,8 +239,7 @@ class TestMeasureToViewMap(unittest.TestCase):
             timestamp=timestamp,
             attachments=None)
         self.assertNotEqual(
-            measure,
-            measure_to_view_map._registered_measures.get(measure.name))
+            measure, measure_to_view_map._registered_measures.get(measure.name))
         self.assertIsNone(record)
 
         measure_to_view_map._registered_measures = {measure.name: measure}
@@ -252,8 +250,7 @@ class TestMeasureToViewMap(unittest.TestCase):
             timestamp=timestamp,
             attachments=None)
         self.assertEqual(
-            measure,
-            measure_to_view_map._registered_measures.get(measure.name))
+            measure, measure_to_view_map._registered_measures.get(measure.name))
         self.assertIsNone(record)
 
         measure_to_view_map._measure_to_view_data_list_map = {
@@ -265,8 +262,7 @@ class TestMeasureToViewMap(unittest.TestCase):
             timestamp=timestamp,
             attachments=None)
         self.assertEqual(
-            measure,
-            measure_to_view_map._registered_measures.get(measure.name))
+            measure, measure_to_view_map._registered_measures.get(measure.name))
         self.assertTrue(
             measure.name in measure_to_view_map._measure_to_view_data_list_map)
 
@@ -288,8 +284,7 @@ class TestMeasureToViewMap(unittest.TestCase):
         measure_to_view_map.record(
             tags=mock.Mock(), stats=mock.Mock(), timestamp=mock.Mock())
         self.assertEqual(
-            measure,
-            measure_to_view_map._registered_measures.get(measure.name))
+            measure, measure_to_view_map._registered_measures.get(measure.name))
         self.assertIsNotNone(measure_to_view_map.view_datas)
         self.assertTrue(measure_to_view_map_mock.record.called)
 
@@ -349,8 +344,7 @@ class TestMeasureToViewMap(unittest.TestCase):
         record = measure_to_view_map.record(
             tags=tags, measurement_map=measurement_map, timestamp=timestamp)
         self.assertNotEqual(
-            measure,
-            measure_to_view_map._registered_measures.get(measure.name))
+            measure, measure_to_view_map._registered_measures.get(measure.name))
         self.assertIsNone(record)
 
     def test_export(self):

--- a/tests/unit/stats/test_measurement.py
+++ b/tests/unit/stats/test_measurement.py
@@ -23,7 +23,8 @@ class TestMeasurement(unittest.TestCase):
         measure = "testMeasure"
         value = 0
 
-        measurement = measurement_module.Measurement(measure=measure, value=value)
+        measurement = measurement_module.Measurement(
+            measure=measure, value=value)
 
         self.assertEqual("testMeasure", measurement.measure)
         self.assertEqual(0, measurement.value)
@@ -35,7 +36,8 @@ class TestMeasurementInt(unittest.TestCase):
         measure = "testIntMeasure"
         value = 10
 
-        measurement = measurement_module.MeasurementInt(measure=measure, value=value)
+        measurement = measurement_module.MeasurementInt(
+            measure=measure, value=value)
 
         self.assertEqual("testIntMeasure", measurement.measure)
         self.assertEqual(10, measurement.value)
@@ -47,7 +49,8 @@ class TestMeasurementFloat(unittest.TestCase):
         measure = "testFloatMeasure"
         value = 10.00
 
-        measurement = measurement_module.MeasurementFloat(measure=measure, value=value)
+        measurement = measurement_module.MeasurementFloat(
+            measure=measure, value=value)
 
         self.assertEqual("testFloatMeasure", measurement.measure)
         self.assertEqual(10.00, measurement.value)

--- a/tests/unit/stats/test_measurement_map.py
+++ b/tests/unit/stats/test_measurement_map.py
@@ -18,7 +18,6 @@ import unittest
 from opencensus.stats import measurement_map as measurement_map_module
 from opencensus.tags import execution_context
 
-
 logger_patch = mock.patch('opencensus.stats.measurement_map.logger')
 
 
@@ -59,7 +58,9 @@ class TestMeasurementMap(unittest.TestCase):
         test_value = 'testValue'
         measurement_map = measurement_map_module.MeasurementMap(
             measure_to_view_map=measure_to_view_map, attachments={})
-        with self.assertRaisesRegexp(TypeError, 'attachment key should not be empty and should be a string'):
+        with self.assertRaisesRegexp(
+                TypeError,
+                'attachment key should not be empty and should be a string'):
             measurement_map.measure_put_attachment(test_key, test_value)
 
     def test_put_attachment_none_value(self):
@@ -68,7 +69,9 @@ class TestMeasurementMap(unittest.TestCase):
         test_value = None
         measurement_map = measurement_map_module.MeasurementMap(
             measure_to_view_map=measure_to_view_map, attachments={})
-        with self.assertRaisesRegexp(TypeError, 'attachment value should not be empty and should be a string'):
+        with self.assertRaisesRegexp(
+                TypeError,
+                'attachment value should not be empty and should be a string'):
             measurement_map.measure_put_attachment(test_key, test_value)
 
     def test_put_attachment_int_key(self):
@@ -77,7 +80,9 @@ class TestMeasurementMap(unittest.TestCase):
         test_value = 'testValue'
         measurement_map = measurement_map_module.MeasurementMap(
             measure_to_view_map=measure_to_view_map, attachments={})
-        with self.assertRaisesRegexp(TypeError, 'attachment key should not be empty and should be a string'):
+        with self.assertRaisesRegexp(
+                TypeError,
+                'attachment key should not be empty and should be a string'):
             measurement_map.measure_put_attachment(test_key, test_value)
 
     def test_put_attachment_int_value(self):
@@ -86,7 +91,9 @@ class TestMeasurementMap(unittest.TestCase):
         test_value = 42
         measurement_map = measurement_map_module.MeasurementMap(
             measure_to_view_map=measure_to_view_map, attachments={})
-        with self.assertRaisesRegexp(TypeError, 'attachment value should not be empty and should be a string'):
+        with self.assertRaisesRegexp(
+                TypeError,
+                'attachment value should not be empty and should be a string'):
             measurement_map.measure_put_attachment(test_key, test_value)
 
     def test_put_attachment(self):

--- a/tests/unit/stats/test_metric_utils.py
+++ b/tests/unit/stats/test_metric_utils.py
@@ -27,6 +27,7 @@ from opencensus.stats import view
 
 
 class TestMetricUtils(unittest.TestCase):
+
     def test_get_metric_type(self):
         measure_int = mock.Mock(spec=measure.MeasureInt)
         measure_float = mock.Mock(spec=measure.MeasureFloat)

--- a/tests/unit/stats/test_stats_recorder.py
+++ b/tests/unit/stats/test_stats_recorder.py
@@ -37,4 +37,7 @@ class TestStatsRecorder(unittest.TestCase):
         stats_recorder = stats_recorder_module.StatsRecorder()
         measurement_map = stats_recorder.new_measurement_map()
 
-        self.assertEqual(measurement_map.measurement_map, MeasurementMap(measure_to_view_map=measure_to_view_map).measurement_map)
+        self.assertEqual(
+            measurement_map.measurement_map,
+            MeasurementMap(
+                measure_to_view_map=measure_to_view_map).measurement_map)

--- a/tests/unit/stats/test_view.py
+++ b/tests/unit/stats/test_view.py
@@ -26,7 +26,12 @@ class TestView(unittest.TestCase):
         measure = mock.Mock()
         aggregation = mock.Mock()
 
-        view = view_module.View(name=name, description=description, columns=columns, measure=measure, aggregation=aggregation)
+        view = view_module.View(
+            name=name,
+            description=description,
+            columns=columns,
+            measure=measure,
+            aggregation=aggregation)
 
         self.assertEqual("testName", view.name)
         self.assertEqual("testMeasure", view.description)

--- a/tests/unit/stats/test_view_data.py
+++ b/tests/unit/stats/test_view_data.py
@@ -22,6 +22,7 @@ from opencensus.stats import view as view_module
 
 
 class TestViewData(unittest.TestCase):
+
     def test_constructor(self):
         view = mock.Mock()
         start_time = datetime.utcnow()
@@ -97,8 +98,7 @@ class TestViewData(unittest.TestCase):
         self.assertIsNotNone(
             view_data.tag_value_aggregation_data_map[tuple_vals])
         self.assertIsNotNone(
-            view_data.tag_value_aggregation_data_map.get(tuple_vals).add(
-                value))
+            view_data.tag_value_aggregation_data_map.get(tuple_vals).add(value))
 
         view_data.record(context=context, value=value, timestamp=time)
         tag_values.append('val2')

--- a/tests/unit/stats/test_view_manager.py
+++ b/tests/unit/stats/test_view_manager.py
@@ -20,6 +20,7 @@ from opencensus.stats.measure_to_view_map import MeasureToViewMap
 
 
 class TestViewManager(unittest.TestCase):
+
     def test_constructor(self):
         execution_context.clear()
         self.assertEqual({}, execution_context.get_measure_to_view_map())
@@ -55,9 +56,9 @@ class TestViewManager(unittest.TestCase):
         execution_context.set_measure_to_view_map(MeasureToViewMap())
         view_manager = view_manager_module.ViewManager()
         view_manager.register_exporter(exporter)
-        count_registered_exporters = len(view_manager.measure_to_view_map.exporters)
+        count_registered_exporters = len(
+            view_manager.measure_to_view_map.exporters)
         self.assertEqual(1, count_registered_exporters)
-
 
     def test_unregister_exporter(self):
         exporter = mock.Mock()
@@ -65,11 +66,13 @@ class TestViewManager(unittest.TestCase):
         execution_context.set_measure_to_view_map(MeasureToViewMap())
         view_manager = view_manager_module.ViewManager()
         view_manager.register_exporter(exporter)
-        count_registered_exporters = len(view_manager.measure_to_view_map.exporters)
+        count_registered_exporters = len(
+            view_manager.measure_to_view_map.exporters)
         self.assertEqual(1, count_registered_exporters)
 
         view_manager.unregister_exporter(exporter)
-        count_registered_exporters = len(view_manager.measure_to_view_map.exporters)
+        count_registered_exporters = len(
+            view_manager.measure_to_view_map.exporters)
         self.assertEqual(0, count_registered_exporters)
 
     def test_get_view(self):

--- a/tests/unit/tags/propagation/test_binary_serializer.py
+++ b/tests/unit/tags/propagation/test_binary_serializer.py
@@ -19,6 +19,7 @@ from opencensus.tags.propagation import binary_serializer
 
 
 class TestBinarySerializer(unittest.TestCase):
+
     def test_from_byte_array_input_empty(self):
         binary = bytearray(b'')
         propagator = binary_serializer.BinarySerializer()
@@ -45,10 +46,12 @@ class TestBinarySerializer(unittest.TestCase):
     def test_to_byte_array(self):
         from opencensus.tags.tag_map import TagMap
 
-        tags = [Tag(TagKey('key1'), TagValue('val1')),
-                Tag(TagKey('key2'), TagValue('val2')),
-                Tag(TagKey('key3'), TagValue('val3')),
-                Tag(TagKey('key4'), TagValue('val4'))]
+        tags = [
+            Tag(TagKey('key1'), TagValue('val1')),
+            Tag(TagKey('key2'), TagValue('val2')),
+            Tag(TagKey('key3'), TagValue('val3')),
+            Tag(TagKey('key4'), TagValue('val4'))
+        ]
         tag_context = TagMap(tags=tags)
         propagator = binary_serializer.BinarySerializer()
         binary = propagator.to_byte_array(tag_context)
@@ -66,7 +69,6 @@ class TestBinarySerializer(unittest.TestCase):
                            b'\x00\x04key3\x04val3')
         buffer = memoryview(binary)
         tag_context = propagator._parse_tags(buffer)
-        expected_dict = OrderedDict(
-            [('key1', 'val1')])
+        expected_dict = OrderedDict([('key1', 'val1')])
 
         self.assertEqual(frozenset(tag_context.map), frozenset(expected_dict))

--- a/tests/unit/tags/test_tag_map.py
+++ b/tests/unit/tags/test_tag_map.py
@@ -26,8 +26,10 @@ class TestTagMap(unittest.TestCase):
         self.assertEqual(tag_map.map, {})
 
     def test_constructor_explicit(self):
-        tags_list = [Tag(TagKey('key1'), TagValue('value1')),
-                     Tag(TagKey('key2'), TagValue('value2'))]
+        tags_list = [
+            Tag(TagKey('key1'), TagValue('value1')),
+            Tag(TagKey('key2'), TagValue('value2'))
+        ]
         tag_map = TagMap(tags=tags_list)
         self.assertEqual(tag_map.map, dict(tags_list))
 
@@ -42,7 +44,8 @@ class TestTagMap(unittest.TestCase):
         tag_map.insert(key=test_key, value=test_value)
         self.assertEqual({test_key: test_value}, tag_map.map)
 
-        self.assertRaises(ValueError, tag_map.insert, key='Æ!01kr', value=test_value)
+        self.assertRaises(
+            ValueError, tag_map.insert, key='Æ!01kr', value=test_value)
 
     def test_delete(self):
         key = TagKey('key1')

--- a/tests/unit/trace/exporters/ocagent/test_trace_exporter.py
+++ b/tests/unit/trace/exporters/ocagent/test_trace_exporter.py
@@ -25,39 +25,32 @@ from opencensus.trace import span_data as span_data_module
 from opencensus.trace.exporters.gen.opencensus.trace.v1 import trace_config_pb2
 from opencensus.trace.exporters.ocagent.trace_exporter import TraceExporter
 
-
 SERVICE_NAME = 'my-service'
 
 
 class TestTraceExporter(unittest.TestCase):
 
     def test_constructor(self):
-        exporter = TraceExporter(
-            service_name=SERVICE_NAME)
+        exporter = TraceExporter(service_name=SERVICE_NAME)
 
         self.assertEqual(exporter.endpoint, 'localhost:55678')
 
     def test_constructor_with_endpoint(self):
         expected_endpoint = '0.0.0.0:50000'
         exporter = TraceExporter(
-            service_name=SERVICE_NAME,
-            endpoint=expected_endpoint)
+            service_name=SERVICE_NAME, endpoint=expected_endpoint)
 
         self.assertEqual(exporter.endpoint, expected_endpoint)
 
     def test_constructor_with_client(self):
         client = mock.Mock()
         exporter = TraceExporter(
-            service_name=SERVICE_NAME,
-            client=client,
-            transport=MockTransport)
+            service_name=SERVICE_NAME, client=client, transport=MockTransport)
 
         self.assertEqual(exporter.client, client)
 
     def test_constructor_node_host(self):
-        exporter = TraceExporter(
-            service_name=SERVICE_NAME,
-            host_name='my host')
+        exporter = TraceExporter(service_name=SERVICE_NAME, host_name='my host')
 
         self.assertEqual(exporter.node.service_info.name, SERVICE_NAME)
         self.assertEqual(exporter.node.library_info.language, 8)
@@ -71,8 +64,7 @@ class TestTraceExporter(unittest.TestCase):
         self.assertGreater(exporter.node.identifier.start_timestamp.seconds, 0)
 
     def test_constructor_node(self):
-        exporter = TraceExporter(
-            service_name=SERVICE_NAME)
+        exporter = TraceExporter(service_name=SERVICE_NAME)
 
         self.assertEqual(exporter.node.service_info.name, SERVICE_NAME)
         self.assertEqual(exporter.node.library_info.language, 8)
@@ -89,8 +81,7 @@ class TestTraceExporter(unittest.TestCase):
 
     def test_export(self):
         exporter = TraceExporter(
-            service_name=SERVICE_NAME,
-            transport=MockTransport)
+            service_name=SERVICE_NAME, transport=MockTransport)
         exporter.export({})
 
         self.assertTrue(exporter.transport.export_called)
@@ -99,9 +90,7 @@ class TestTraceExporter(unittest.TestCase):
         client = mock.Mock()
         client.Export.return_value = iter([1])
         exporter = TraceExporter(
-            service_name=SERVICE_NAME,
-            client=client,
-            transport=MockTransport)
+            service_name=SERVICE_NAME, client=client, transport=MockTransport)
 
         exporter.emit({})
 
@@ -111,9 +100,7 @@ class TestTraceExporter(unittest.TestCase):
         client = mock.Mock()
         client.Export.side_effect = grpc.RpcError()
         exporter = TraceExporter(
-            service_name=SERVICE_NAME,
-            client=client,
-            transport=MockTransport)
+            service_name=SERVICE_NAME, client=client, transport=MockTransport)
 
         # does not throw
         exporter.emit({})
@@ -163,8 +150,7 @@ class TestTraceExporter(unittest.TestCase):
         ]
 
         exporter = TraceExporter(
-            service_name=SERVICE_NAME,
-            transport=MockTransport)
+            service_name=SERVICE_NAME, transport=MockTransport)
         export_requests = list(exporter.generate_span_requests(span_datas))
 
         self.assertEqual(len(export_requests), 1)
@@ -173,14 +159,18 @@ class TestTraceExporter(unittest.TestCase):
 
         self.assertEqual(export_requests[0].spans[0].name.value, 'name0')
         self.assertEqual(export_requests[0].spans[1].name.value, 'name1')
-        self.assertEqual(hex_encoder(export_requests[0].spans[0].trace_id)[
-                         0], b'0e0c63257de34c92bf9efcd03927272e')
-        self.assertEqual(hex_encoder(export_requests[0].spans[0].span_id)[
-                         0], b'0e0c63257de34c92')
-        self.assertEqual(hex_encoder(export_requests[0].spans[1].trace_id)[
-                         0], b'1e0c63257de34c92bf9efcd03927272e')
-        self.assertEqual(hex_encoder(export_requests[0].spans[1].span_id)[
-                         0], b'1e0c63257de34c92')
+        self.assertEqual(
+            hex_encoder(export_requests[0].spans[0].trace_id)[0],
+            b'0e0c63257de34c92bf9efcd03927272e')
+        self.assertEqual(
+            hex_encoder(export_requests[0].spans[0].span_id)[0],
+            b'0e0c63257de34c92')
+        self.assertEqual(
+            hex_encoder(export_requests[0].spans[1].trace_id)[0],
+            b'1e0c63257de34c92bf9efcd03927272e')
+        self.assertEqual(
+            hex_encoder(export_requests[0].spans[1].span_id)[0],
+            b'1e0c63257de34c92')
 
     def test_basic_spans_emit(self):
         hex_encoder = codecs.getencoder('hex')
@@ -222,9 +212,7 @@ class TestTraceExporter(unittest.TestCase):
             span_kind=0)
 
         exporter = TraceExporter(
-            service_name=SERVICE_NAME,
-            client=client,
-            transport=MockTransport)
+            service_name=SERVICE_NAME, client=client, transport=MockTransport)
 
         exporter.emit([span_data0])
 
@@ -233,8 +221,9 @@ class TestTraceExporter(unittest.TestCase):
 
         pb_span0 = actual_request0.spans[0]
         self.assertEqual(pb_span0.name.value, "name0")
-        self.assertEqual(hex_encoder(pb_span0.trace_id)[
-                         0], b'0e0c63257de34c92bf9efcd03927272e')
+        self.assertEqual(
+            hex_encoder(pb_span0.trace_id)[0],
+            b'0e0c63257de34c92bf9efcd03927272e')
         self.assertEqual(hex_encoder(pb_span0.span_id)[0], b'0e0c63257de34c92')
 
         exporter.emit([span_data1])
@@ -244,8 +233,9 @@ class TestTraceExporter(unittest.TestCase):
         self.assertEqual(actual_request1.node, exporter.node)
         pb_span1 = actual_request1.spans[0]
         self.assertEqual(pb_span1.name.value, "name1")
-        self.assertEqual(hex_encoder(pb_span1.trace_id)[
-                         0], b'1e0c63257de34c92bf9efcd03927272e')
+        self.assertEqual(
+            hex_encoder(pb_span1.trace_id)[0],
+            b'1e0c63257de34c92bf9efcd03927272e')
         self.assertEqual(hex_encoder(pb_span1.span_id)[0], b'1e0c63257de34c92')
 
     def test_span_emit_exception(self):
@@ -269,9 +259,7 @@ class TestTraceExporter(unittest.TestCase):
             span_kind=0)
 
         exporter = TraceExporter(
-            service_name=SERVICE_NAME,
-            client=client,
-            transport=MockTransport)
+            service_name=SERVICE_NAME, client=client, transport=MockTransport)
 
         client.Export.side_effect = grpc.RpcError()
 
@@ -289,14 +277,11 @@ class TestTraceExporter(unittest.TestCase):
     def test_config_generator(self):
 
         config = trace_config_pb2.TraceConfig(
-            constant_sampler=trace_config_pb2.ConstantSampler(
-                decision=True))
+            constant_sampler=trace_config_pb2.ConstantSampler(decision=True))
         exporter = TraceExporter(
-            service_name=SERVICE_NAME,
-            transport=MockTransport)
+            service_name=SERVICE_NAME, transport=MockTransport)
 
-        config_requests = list(exporter.generate_config_request(
-            config))
+        config_requests = list(exporter.generate_config_request(config))
 
         self.assertEqual(len(config_requests), 1)
         self.assertEqual(config_requests[0].node, exporter.node)
@@ -306,13 +291,10 @@ class TestTraceExporter(unittest.TestCase):
         client = mock.Mock()
 
         config = trace_config_pb2.TraceConfig(
-            constant_sampler=trace_config_pb2.ConstantSampler(
-                decision=True))
+            constant_sampler=trace_config_pb2.ConstantSampler(decision=True))
 
         exporter = TraceExporter(
-            service_name=SERVICE_NAME,
-            client=client,
-            transport=MockTransport)
+            service_name=SERVICE_NAME, client=client, transport=MockTransport)
 
         client.Config.side_effect = grpc.RpcError()
         with self.assertRaises(grpc.RpcError):
@@ -330,17 +312,14 @@ class TestTraceExporter(unittest.TestCase):
         client = mock.Mock()
 
         client_config = trace_config_pb2.TraceConfig(
-            constant_sampler=trace_config_pb2.ConstantSampler(
-                decision=True))
+            constant_sampler=trace_config_pb2.ConstantSampler(decision=True))
 
         agent_config = trace_config_pb2.TraceConfig(
             probability_sampler=trace_config_pb2.ProbabilitySampler(
                 samplingProbability=0.1))
 
         exporter = TraceExporter(
-            service_name=SERVICE_NAME,
-            client=client,
-            transport=MockTransport)
+            service_name=SERVICE_NAME, client=client, transport=MockTransport)
 
         client.Config.return_value = iter([agent_config])
         actual_response = exporter.update_config(client_config)
@@ -349,6 +328,7 @@ class TestTraceExporter(unittest.TestCase):
 
 
 class MockTransport(object):
+
     def __init__(self, exporter=None):
         self.export_called = False
         self.exporter = exporter

--- a/tests/unit/trace/exporters/ocagent/test_trace_exporter_utils.py
+++ b/tests/unit/trace/exporters/ocagent/test_trace_exporter_utils.py
@@ -32,6 +32,7 @@ from opencensus.trace.exporters.gen.opencensus.trace.v1 import trace_pb2
 
 
 class TestTraceExporterUtils(unittest.TestCase):
+
     def test_basic_span_translation(self):
         hex_encoder = codecs.getencoder('hex')
 
@@ -41,8 +42,11 @@ class TestTraceExporterUtils(unittest.TestCase):
                 trace_id='6e0c63257de34c92bf9efcd03927272e'),
             span_id='6e0c63257de34c92',
             parent_span_id='6e0c63257de34c93',
-            attributes={'test_str_key': 'test_str_value',
-                        'test_int_key': 1, 'test_bool_key': False},
+            attributes={
+                'test_str_key': 'test_str_value',
+                'test_int_key': 1,
+                'test_bool_key': False
+            },
             start_time='2017-08-15T18:02:26.071158Z',
             end_time='2017-08-15T18:02:36.071158Z',
             child_span_count=None,
@@ -56,21 +60,25 @@ class TestTraceExporterUtils(unittest.TestCase):
         pb_span = utils.translate_to_trace_proto(span_data)
 
         self.assertEqual(pb_span.name.value, "name")
-        self.assertEqual(hex_encoder(pb_span.trace_id)[
-                         0], b'6e0c63257de34c92bf9efcd03927272e')
+        self.assertEqual(
+            hex_encoder(pb_span.trace_id)[0],
+            b'6e0c63257de34c92bf9efcd03927272e')
         self.assertEqual(hex_encoder(pb_span.span_id)[0], b'6e0c63257de34c92')
-        self.assertEqual(hex_encoder(pb_span.parent_span_id)
-                         [0], b'6e0c63257de34c93')
+        self.assertEqual(
+            hex_encoder(pb_span.parent_span_id)[0], b'6e0c63257de34c93')
         self.assertEqual(pb_span.kind, 0)
 
         self.assertEqual(len(pb_span.attributes.attribute_map), 3)
-        self.assertEqual(pb_span.attributes.attribute_map['test_str_key'],
-                         trace_pb2.AttributeValue(string_value=trace_pb2.TruncatableString(value='test_str_value')))
+        self.assertEqual(
+            pb_span.attributes.attribute_map['test_str_key'],
+            trace_pb2.AttributeValue(
+                string_value=trace_pb2.TruncatableString(
+                    value='test_str_value')))
 
-        self.assertEqual(
-            pb_span.attributes.attribute_map['test_int_key'], trace_pb2.AttributeValue(int_value=1))
-        self.assertEqual(
-            pb_span.attributes.attribute_map['test_bool_key'], trace_pb2.AttributeValue(bool_value=False))
+        self.assertEqual(pb_span.attributes.attribute_map['test_int_key'],
+                         trace_pb2.AttributeValue(int_value=1))
+        self.assertEqual(pb_span.attributes.attribute_map['test_bool_key'],
+                         trace_pb2.AttributeValue(bool_value=False))
 
         self.assertEqual(pb_span.start_time.ToJsonString(),
                          '2017-08-15T18:02:26.071158Z')
@@ -170,17 +178,24 @@ class TestTraceExporterUtils(unittest.TestCase):
                 trace_id='6e0c63257de34c92bf9efcd03927272e'),
             span_id='6e0c63257de34c92',
             links=[
-                link_module.Link(trace_id='0e0c63257de34c92bf9efcd03927272e',
-                                 span_id='0e0c63257de34c92',
-                                 type=link_module.Type.TYPE_UNSPECIFIED,
-                                 attributes=attributes_module.Attributes(
-                                     attributes={'test_str_key': 'test_str_value', 'test_int_key': 1, 'test_bool_key': False})),
-                link_module.Link(trace_id='1e0c63257de34c92bf9efcd03927272e',
-                                 span_id='1e0c63257de34c92',
-                                 type=link_module.Type.CHILD_LINKED_SPAN),
-                link_module.Link(trace_id='2e0c63257de34c92bf9efcd03927272e',
-                                 span_id='2e0c63257de34c92',
-                                 type=link_module.Type.PARENT_LINKED_SPAN)
+                link_module.Link(
+                    trace_id='0e0c63257de34c92bf9efcd03927272e',
+                    span_id='0e0c63257de34c92',
+                    type=link_module.Type.TYPE_UNSPECIFIED,
+                    attributes=attributes_module.Attributes(
+                        attributes={
+                            'test_str_key': 'test_str_value',
+                            'test_int_key': 1,
+                            'test_bool_key': False
+                        })),
+                link_module.Link(
+                    trace_id='1e0c63257de34c92bf9efcd03927272e',
+                    span_id='1e0c63257de34c92',
+                    type=link_module.Type.CHILD_LINKED_SPAN),
+                link_module.Link(
+                    trace_id='2e0c63257de34c92bf9efcd03927272e',
+                    span_id='2e0c63257de34c92',
+                    type=link_module.Type.PARENT_LINKED_SPAN)
             ],
             span_kind=span_module.SpanKind.SERVER,
             status=None,
@@ -197,38 +212,43 @@ class TestTraceExporterUtils(unittest.TestCase):
         pb_span = utils.translate_to_trace_proto(span_data)
 
         self.assertEqual(len(pb_span.links.link), 3)
-        self.assertEqual(hex_encoder(pb_span.links.link[0].trace_id)[
-                         0], b'0e0c63257de34c92bf9efcd03927272e')
-        self.assertEqual(hex_encoder(pb_span.links.link[1].trace_id)[
-                         0], b'1e0c63257de34c92bf9efcd03927272e')
-        self.assertEqual(hex_encoder(pb_span.links.link[2].trace_id)[
-                         0], b'2e0c63257de34c92bf9efcd03927272e')
+        self.assertEqual(
+            hex_encoder(pb_span.links.link[0].trace_id)[0],
+            b'0e0c63257de34c92bf9efcd03927272e')
+        self.assertEqual(
+            hex_encoder(pb_span.links.link[1].trace_id)[0],
+            b'1e0c63257de34c92bf9efcd03927272e')
+        self.assertEqual(
+            hex_encoder(pb_span.links.link[2].trace_id)[0],
+            b'2e0c63257de34c92bf9efcd03927272e')
 
-        self.assertEqual(hex_encoder(pb_span.links.link[0].span_id)[
-                         0], b'0e0c63257de34c92')
-        self.assertEqual(hex_encoder(pb_span.links.link[1].span_id)[
-                         0], b'1e0c63257de34c92')
-        self.assertEqual(hex_encoder(pb_span.links.link[2].span_id)[
-                         0], b'2e0c63257de34c92')
+        self.assertEqual(
+            hex_encoder(pb_span.links.link[0].span_id)[0], b'0e0c63257de34c92')
+        self.assertEqual(
+            hex_encoder(pb_span.links.link[1].span_id)[0], b'1e0c63257de34c92')
+        self.assertEqual(
+            hex_encoder(pb_span.links.link[2].span_id)[0], b'2e0c63257de34c92')
 
         self.assertEqual(pb_span.links.link[0].type, 0)
         self.assertEqual(pb_span.links.link[1].type, 1)
         self.assertEqual(pb_span.links.link[2].type, 2)
 
-        self.assertEqual(
-            len(pb_span.links.link[0].attributes.attribute_map), 3)
-        self.assertEqual(
-            len(pb_span.links.link[1].attributes.attribute_map), 0)
-        self.assertEqual(
-            len(pb_span.links.link[2].attributes.attribute_map), 0)
-
-        self.assertEqual(pb_span.links.link[0].attributes.attribute_map['test_str_key'],
-                         trace_pb2.AttributeValue(string_value=trace_pb2.TruncatableString(value='test_str_value')))
+        self.assertEqual(len(pb_span.links.link[0].attributes.attribute_map), 3)
+        self.assertEqual(len(pb_span.links.link[1].attributes.attribute_map), 0)
+        self.assertEqual(len(pb_span.links.link[2].attributes.attribute_map), 0)
 
         self.assertEqual(
-            pb_span.links.link[0].attributes.attribute_map['test_int_key'], trace_pb2.AttributeValue(int_value=1))
+            pb_span.links.link[0].attributes.attribute_map['test_str_key'],
+            trace_pb2.AttributeValue(
+                string_value=trace_pb2.TruncatableString(
+                    value='test_str_value')))
+
         self.assertEqual(
-            pb_span.links.link[0].attributes.attribute_map['test_bool_key'], trace_pb2.AttributeValue(bool_value=False))
+            pb_span.links.link[0].attributes.attribute_map['test_int_key'],
+            trace_pb2.AttributeValue(int_value=1))
+        self.assertEqual(
+            pb_span.links.link[0].attributes.attribute_map['test_bool_key'],
+            trace_pb2.AttributeValue(bool_value=False))
 
     def test_translate_time_events(self):
 
@@ -248,9 +268,15 @@ class TestTraceExporterUtils(unittest.TestCase):
                     annotation=time_event_module.Annotation(
                         description="hi there0",
                         attributes=attributes_module.Attributes(
-                            attributes={'test_str_key': 'test_str_value', 'test_int_key': 1, 'test_bool_key': False}))),
+                            attributes={
+                                'test_str_key': 'test_str_value',
+                                'test_int_key': 1,
+                                'test_bool_key': False
+                            }))),
                 time_event_module.TimeEvent(
-                    timestamp=annotation1_ts, annotation=time_event_module.Annotation(description="hi there1")),
+                    timestamp=annotation1_ts,
+                    annotation=time_event_module.Annotation(
+                        description="hi there1")),
                 time_event_module.TimeEvent(
                     timestamp=message0_ts,
                     message_event=time_event_module.MessageEvent(
@@ -260,16 +286,18 @@ class TestTraceExporterUtils(unittest.TestCase):
                         compressed_size_bytes=1)),
                 time_event_module.TimeEvent(
                     timestamp=message1_ts,
-                    message_event=time_event_module.MessageEvent(id=1,
-                                                                 type=time_event_module.Type.RECEIVED,
-                                                                 uncompressed_size_bytes=20,
-                                                                 compressed_size_bytes=2)),
+                    message_event=time_event_module.MessageEvent(
+                        id=1,
+                        type=time_event_module.Type.RECEIVED,
+                        uncompressed_size_bytes=20,
+                        compressed_size_bytes=2)),
                 time_event_module.TimeEvent(
                     timestamp=message2_ts,
-                    message_event=time_event_module.MessageEvent(id=2,
-                                                                 type=time_event_module.Type.TYPE_UNSPECIFIED,
-                                                                 uncompressed_size_bytes=30,
-                                                                 compressed_size_bytes=3))
+                    message_event=time_event_module.MessageEvent(
+                        id=2,
+                        type=time_event_module.Type.TYPE_UNSPECIFIED,
+                        uncompressed_size_bytes=30,
+                        compressed_size_bytes=3))
             ],
             span_kind=span_module.SpanKind.SERVER,
             status=None,
@@ -304,13 +332,18 @@ class TestTraceExporterUtils(unittest.TestCase):
         self.assertEqual(len(event0.annotation.attributes.attribute_map), 3)
         self.assertEqual(len(event1.annotation.attributes.attribute_map), 0)
 
-        self.assertEqual(event0.annotation.attributes.attribute_map['test_str_key'],
-                         trace_pb2.AttributeValue(string_value=trace_pb2.TruncatableString(value='test_str_value')))
+        self.assertEqual(
+            event0.annotation.attributes.attribute_map['test_str_key'],
+            trace_pb2.AttributeValue(
+                string_value=trace_pb2.TruncatableString(
+                    value='test_str_value')))
 
         self.assertEqual(
-            event0.annotation.attributes.attribute_map['test_int_key'], trace_pb2.AttributeValue(int_value=1))
+            event0.annotation.attributes.attribute_map['test_int_key'],
+            trace_pb2.AttributeValue(int_value=1))
         self.assertEqual(
-            event0.annotation.attributes.attribute_map['test_bool_key'], trace_pb2.AttributeValue(bool_value=False))
+            event0.annotation.attributes.attribute_map['test_bool_key'],
+            trace_pb2.AttributeValue(bool_value=False))
 
         self.assertEqual(event2.message_event.id, 0)
         self.assertEqual(event3.message_event.id, 1)
@@ -336,8 +369,7 @@ class TestTraceExporterUtils(unittest.TestCase):
             context=span_context_module.SpanContext(
                 trace_id='6e0c63257de34c92bf9efcd03927272e'),
             span_id='6e0c63257de34c92',
-            time_events=[
-                time_event_module.TimeEvent(timestamp=ts)],
+            time_events=[time_event_module.TimeEvent(timestamp=ts)],
             span_kind=span_module.SpanKind.SERVER,
             status=None,
             start_time=None,
@@ -363,7 +395,8 @@ class TestTraceExporterUtils(unittest.TestCase):
 
         client_span_data = span_data_module.SpanData(
             context=span_context_module.SpanContext(
-                trace_id='6e0c63257de34c92bf9efcd03927272e', tracestate=tracestate),
+                trace_id='6e0c63257de34c92bf9efcd03927272e',
+                tracestate=tracestate),
             span_id='6e0c63257de34c92',
             start_time='2017-08-15T18:02:26.071158Z',
             end_time='2017-08-15T18:02:36.071158Z',
@@ -392,26 +425,28 @@ class TestTraceExporterUtils(unittest.TestCase):
         pb_span = trace_pb2.Span()
 
         utils.add_proto_attribute_value(pb_span.attributes, 'int_key', 42)
-        utils.add_proto_attribute_value(
-            pb_span.attributes, 'bool_key', True)
-        utils.add_proto_attribute_value(
-            pb_span.attributes, 'string_key', 'value')
-        utils.add_proto_attribute_value(
-            pb_span.attributes, 'unicode_key', u'uvalue')
-        utils.add_proto_attribute_value(
-            pb_span.attributes, 'dict_key', {"a": "b"})
+        utils.add_proto_attribute_value(pb_span.attributes, 'bool_key', True)
+        utils.add_proto_attribute_value(pb_span.attributes, 'string_key',
+                                        'value')
+        utils.add_proto_attribute_value(pb_span.attributes, 'unicode_key',
+                                        u'uvalue')
+        utils.add_proto_attribute_value(pb_span.attributes, 'dict_key',
+                                        {"a": "b"})
 
         self.assertEqual(len(pb_span.attributes.attribute_map), 5)
-        self.assertEqual(
-            pb_span.attributes.attribute_map['int_key'].int_value, 42)
+        self.assertEqual(pb_span.attributes.attribute_map['int_key'].int_value,
+                         42)
         self.assertEqual(
             pb_span.attributes.attribute_map['bool_key'].bool_value, True)
         self.assertEqual(
-            pb_span.attributes.attribute_map['string_key'].string_value.value, 'value')
+            pb_span.attributes.attribute_map['string_key'].string_value.value,
+            'value')
         self.assertEqual(
-            pb_span.attributes.attribute_map['unicode_key'].string_value.value, 'uvalue')
+            pb_span.attributes.attribute_map['unicode_key'].string_value.value,
+            'uvalue')
         self.assertEqual(
-            pb_span.attributes.attribute_map['dict_key'].string_value.value, "{'a': 'b'}")
+            pb_span.attributes.attribute_map['dict_key'].string_value.value,
+            "{'a': 'b'}")
 
     def test_set_proto_event(self):
         pb_span = trace_pb2.Span()
@@ -437,18 +472,27 @@ class TestTraceExporterUtils(unittest.TestCase):
         annotation = time_event_module.Annotation(
             description="hi there",
             attributes=attributes_module.Attributes(
-                        attributes={'test_str_key': 'test_str_value', 'test_int_key': 1, 'test_bool_key': False}))
+                attributes={
+                    'test_str_key': 'test_str_value',
+                    'test_int_key': 1,
+                    'test_bool_key': False
+                }))
 
         utils.set_proto_annotation(pb_event.annotation, annotation)
 
         self.assertEqual(pb_event.annotation.description.value, "hi there")
         self.assertEqual(len(pb_event.annotation.attributes.attribute_map), 3)
-        self.assertEqual(pb_event.annotation.attributes.attribute_map['test_str_key'],
-                         trace_pb2.AttributeValue(string_value=trace_pb2.TruncatableString(value='test_str_value')))
         self.assertEqual(
-            pb_event.annotation.attributes.attribute_map['test_int_key'], trace_pb2.AttributeValue(int_value=1))
+            pb_event.annotation.attributes.attribute_map['test_str_key'],
+            trace_pb2.AttributeValue(
+                string_value=trace_pb2.TruncatableString(
+                    value='test_str_value')))
         self.assertEqual(
-            pb_event.annotation.attributes.attribute_map['test_bool_key'], trace_pb2.AttributeValue(bool_value=False))
+            pb_event.annotation.attributes.attribute_map['test_int_key'],
+            trace_pb2.AttributeValue(int_value=1))
+        self.assertEqual(
+            pb_event.annotation.attributes.attribute_map['test_bool_key'],
+            trace_pb2.AttributeValue(bool_value=False))
 
     def test_set_annotation_without_attributes(self):
         pb_span = trace_pb2.Span()
@@ -495,10 +539,9 @@ class TestTraceExporterUtils(unittest.TestCase):
     def test_hex_str_to_proto_bytes_conversion(self):
         hex_encoder = codecs.getencoder('hex')
 
-        proto_bytes = utils.hex_str_to_bytes_str(
-            '00010203040506070a0b0c0d0eff')
-        self.assertEqual(hex_encoder(proto_bytes)[0],
-                         b'00010203040506070a0b0c0d0eff')
+        proto_bytes = utils.hex_str_to_bytes_str('00010203040506070a0b0c0d0eff')
+        self.assertEqual(
+            hex_encoder(proto_bytes)[0], b'00010203040506070a0b0c0d0eff')
 
     def test_datetime_to_proto_ts_conversion_none(self):
         proto_ts = utils.proto_ts_from_datetime(None)

--- a/tests/unit/trace/exporters/test_jaeger_exporter.py
+++ b/tests/unit/trace/exporters/test_jaeger_exporter.py
@@ -16,13 +16,14 @@ import unittest
 
 import mock
 
-from opencensus.trace import (attributes, link, span_context, span_data,
-                              status, time_event)
+from opencensus.trace import (attributes, link, span_context, span_data, status,
+                              time_event)
 from opencensus.trace.exporters import jaeger_exporter
 from opencensus.trace.exporters.gen.jaeger import jaeger
 
 
 class TestJaegerExporter(unittest.TestCase):
+
     def test_constructor_default(self):
         service_name = 'my_service'
         host_name = 'localhost'
@@ -174,7 +175,7 @@ class TestJaegerExporter(unittest.TestCase):
         self.maxDiff = None
         trace_id_high = '6e0c63257de34c92'
         trace_id_low = 'bf9efcd03927272e'
-        trace_id= trace_id_high + trace_id_low
+        trace_id = trace_id_high + trace_id_low
         span_id = '6e0c63257de34c92'
         parent_span_id = '1111111111111111'
 
@@ -213,8 +214,7 @@ class TestJaegerExporter(unittest.TestCase):
             time_event.TimeEvent(
                 timestamp=time,
                 annotation=time_event.Annotation(
-                    description='First Annotation',
-                    attributes=None)),
+                    description='First Annotation', attributes=None)),
             time_event.TimeEvent(
                 timestamp=time,
                 message_event=time_event.MessageEvent(
@@ -312,8 +312,7 @@ class TestJaegerExporter(unittest.TestCase):
                 flags=1,
                 tags=[
                     jaeger.Tag(
-                        key='key_bool', vType=jaeger.TagType.BOOL,
-                        vBool=False),
+                        key='key_bool', vType=jaeger.TagType.BOOL, vBool=False),
                     jaeger.Tag(
                         key='key_string',
                         vType=jaeger.TagType.STRING,
@@ -321,8 +320,7 @@ class TestJaegerExporter(unittest.TestCase):
                     jaeger.Tag(
                         key='key_int', vType=jaeger.TagType.LONG, vLong=3),
                     jaeger.Tag(
-                        key='status.code',
-                        vType=jaeger.TagType.LONG,
+                        key='status.code', vType=jaeger.TagType.LONG,
                         vLong=200),
                     jaeger.Tag(
                         key='status.message',
@@ -381,8 +379,7 @@ class TestJaegerExporter(unittest.TestCase):
                                 vType=jaeger.TagType.STRING,
                                 vStr='First Annotation')
                         ])
-                ]
-            ),
+                ]),
             jaeger.Span(
                 operationName="test3",
                 traceIdHigh=7929822056569588882,
@@ -391,8 +388,7 @@ class TestJaegerExporter(unittest.TestCase):
                 parentSpanId=0,
                 startTime=1502820146071158,
                 duration=10000000,
-                logs=[]
-            )
+                logs=[])
         ]
 
         spans_json = [span.format_span_json() for span in spans]
@@ -438,11 +434,13 @@ class TestJaegerExporter(unittest.TestCase):
 
 
 class MockBatch(object):
+
     def write(self, iprot):
         return None
 
 
 class MockTransport(object):
+
     def __init__(self, exporter=None, uri_or_host=None):
         self.export_called = False
         self.headers_set = False
@@ -468,6 +466,7 @@ class MockTransport(object):
 
 
 class MockClient(object):
+
     def __init__(self, iprot=None):
         self.emit_called = False
         self.iprot = iprot

--- a/tests/unit/trace/exporters/test_logging_exporter.py
+++ b/tests/unit/trace/exporters/test_logging_exporter.py
@@ -62,8 +62,7 @@ class TestLoggingExporter(unittest.TestCase):
         exporter.emit(span_datas)
 
         logger.info.assert_called_once_with(
-            span_data_module.format_legacy_trace_json(span_datas)
-        )
+            span_data_module.format_legacy_trace_json(span_datas))
 
     def test_export(self):
         exporter = logging_exporter.LoggingExporter(transport=MockTransport)
@@ -80,6 +79,7 @@ class TestLoggingExporter(unittest.TestCase):
 
 
 class MockTransport(object):
+
     def __init__(self, exporter=None):
         self.export_called = False
         self.exporter = exporter
@@ -89,6 +89,7 @@ class MockTransport(object):
 
 
 class _Handler(object):
+
     def __init__(self, level):
         self.level = level
 

--- a/tests/unit/trace/exporters/test_print_exporter.py
+++ b/tests/unit/trace/exporters/test_print_exporter.py
@@ -40,6 +40,7 @@ class TestPrintExporter(unittest.TestCase):
 
 
 class MockTransport(object):
+
     def __init__(self, exporter=None):
         self.export_called = False
         self.exporter = exporter

--- a/tests/unit/trace/exporters/test_stackdriver_exporter.py
+++ b/tests/unit/trace/exporters/test_stackdriver_exporter.py
@@ -23,6 +23,7 @@ from opencensus.trace.exporters import stackdriver_exporter
 
 
 class _Client(object):
+
     def __init__(self, project=None):
         if project is None:
             project = 'PROJECT'
@@ -50,9 +51,7 @@ class TestStackdriverExporter(unittest.TestCase):
         transport = mock.Mock()
 
         exporter = stackdriver_exporter.StackdriverExporter(
-            client=client,
-            project_id=project_id,
-            transport=transport)
+            client=client, project_id=project_id, transport=transport)
 
         self.assertIs(exporter.client, client)
         self.assertEqual(exporter.project_id, project_id)
@@ -62,9 +61,7 @@ class TestStackdriverExporter(unittest.TestCase):
         project_id = 'PROJECT'
         client.project = project_id
         exporter = stackdriver_exporter.StackdriverExporter(
-            client=client,
-            project_id=project_id,
-            transport=MockTransport)
+            client=client, project_id=project_id, transport=MockTransport)
         exporter.export({})
 
         self.assertTrue(exporter.transport.export_called)
@@ -94,38 +91,44 @@ class TestStackdriverExporter(unittest.TestCase):
         ]
 
         stackdriver_spans = {
-            'spans': [
-                {
-                    'status': None,
-                    'childSpanCount': None,
-                    'links': None,
-                    'startTime': None,
-                    'spanId': '1111',
-                    'attributes': {
-                        'attributeMap': {
-                            'g.co/agent': {
-                                'string_value': {
-                                    'truncated_byte_count': 0,
-                                    'value': 'opencensus-python [{}]'.format(
-                                        __version__
-                                    )
-                                }
+            'spans': [{
+                'status':
+                None,
+                'childSpanCount':
+                None,
+                'links':
+                None,
+                'startTime':
+                None,
+                'spanId':
+                '1111',
+                'attributes': {
+                    'attributeMap': {
+                        'g.co/agent': {
+                            'string_value': {
+                                'truncated_byte_count':
+                                0,
+                                'value':
+                                'opencensus-python [{}]'.format(__version__)
                             }
                         }
-                    },
-                    'stackTrace': None,
-                    'displayName': {
-                        'truncated_byte_count': 0,
-                        'value': 'span'
-                    },
-                    'name': 'projects/PROJECT/traces/{}/spans/1111'.format(
-                        trace_id
-                    ),
-                    'timeEvents': None,
-                    'endTime': None,
-                    'sameProcessAsParentSpan': None
-                }
-            ]
+                    }
+                },
+                'stackTrace':
+                None,
+                'displayName': {
+                    'truncated_byte_count': 0,
+                    'value': 'span'
+                },
+                'name':
+                'projects/PROJECT/traces/{}/spans/1111'.format(trace_id),
+                'timeEvents':
+                None,
+                'endTime':
+                None,
+                'sameProcessAsParentSpan':
+                None
+            }]
         }
 
         client = mock.Mock()
@@ -133,8 +136,7 @@ class TestStackdriverExporter(unittest.TestCase):
         client.project = project_id
 
         exporter = stackdriver_exporter.StackdriverExporter(
-            client=client,
-            project_id=project_id)
+            client=client, project_id=project_id)
 
         exporter.emit(span_datas)
 
@@ -171,77 +173,84 @@ class TestStackdriverExporter(unittest.TestCase):
         start_time = 'test start time'
         end_time = 'test end time'
         trace = {
-            'spans': [
-                {
-                    'displayName': {
-                        'value': span_name,
-                        'truncated_byte_count': 0
-                    },
-                    'spanId': span_id,
-                    'startTime': start_time,
-                    'endTime': end_time,
-                    'parentSpanId': parent_span_id,
-                    'attributes': attributes,
-                    'someRandomKey': 'this should not be included in result',
-                    'childSpanCount': 0
-                }
-            ],
-            'traceId': trace_id
+            'spans': [{
+                'displayName': {
+                    'value': span_name,
+                    'truncated_byte_count': 0
+                },
+                'spanId': span_id,
+                'startTime': start_time,
+                'endTime': end_time,
+                'parentSpanId': parent_span_id,
+                'attributes': attributes,
+                'someRandomKey': 'this should not be included in result',
+                'childSpanCount': 0
+            }],
+            'traceId':
+            trace_id
         }
 
         client = mock.Mock()
         client.project = project_id
         exporter = stackdriver_exporter.StackdriverExporter(
-            client=client,
-            project_id=project_id)
+            client=client, project_id=project_id)
 
         spans = exporter.translate_to_stackdriver(trace)
 
         expected_traces = {
-            'spans': [
-                {
-                    'name': 'projects/{}/traces/{}/spans/{}'.format(
-                        project_id, trace_id, span_id),
-                    'displayName': {
-                        'value': span_name,
-                        'truncated_byte_count': 0
-                    },
-                    'attributes': {
-                        'attributeMap': {
-                            'g.co/agent': {
-                                'string_value': {
-                                    'truncated_byte_count': 0,
-                                    'value': 'opencensus-python [{}]'.format(
-                                        __version__
-                                    )
-                                }
-                            },
-                            'key': {
-                                'string_value': {
-                                    'truncated_byte_count': 0,
-                                    'value': 'value'
-                                }
-                            },
-                            '/http/host': {
-                                'string_value': {
-                                    'truncated_byte_count': 0,
-                                    'value': 'host'
-                                }
+            'spans': [{
+                'name':
+                'projects/{}/traces/{}/spans/{}'.format(project_id, trace_id,
+                                                        span_id),
+                'displayName': {
+                    'value': span_name,
+                    'truncated_byte_count': 0
+                },
+                'attributes': {
+                    'attributeMap': {
+                        'g.co/agent': {
+                            'string_value': {
+                                'truncated_byte_count':
+                                0,
+                                'value':
+                                'opencensus-python [{}]'.format(__version__)
+                            }
+                        },
+                        'key': {
+                            'string_value': {
+                                'truncated_byte_count': 0,
+                                'value': 'value'
+                            }
+                        },
+                        '/http/host': {
+                            'string_value': {
+                                'truncated_byte_count': 0,
+                                'value': 'host'
                             }
                         }
-                    },
-                    'spanId': str(span_id),
-                    'startTime': start_time,
-                    'endTime': end_time,
-                    'parentSpanId': str(parent_span_id),
-                    'status': None,
-                    'links': None,
-                    'stackTrace': None,
-                    'timeEvents': None,
-                    'childSpanCount': 0,
-                    'sameProcessAsParentSpan': None
-                }
-            ]
+                    }
+                },
+                'spanId':
+                str(span_id),
+                'startTime':
+                start_time,
+                'endTime':
+                end_time,
+                'parentSpanId':
+                str(parent_span_id),
+                'status':
+                None,
+                'links':
+                None,
+                'stackTrace':
+                None,
+                'timeEvents':
+                None,
+                'childSpanCount':
+                0,
+                'sameProcessAsParentSpan':
+                None
+            }]
         }
 
         self.assertEqual(spans, expected_traces)
@@ -251,8 +260,7 @@ class TestStackdriverExporter(unittest.TestCase):
         client = mock.Mock()
         client.project = project_id
         exporter = stackdriver_exporter.StackdriverExporter(
-            client=client,
-            project_id=project_id)
+            client=client, project_id=project_id)
 
         attributes = {'outer key': 'some value'}
         expected_attributes = {'outer key': 'some value'}
@@ -265,8 +273,7 @@ class TestStackdriverExporter(unittest.TestCase):
         client = mock.Mock()
         client.project = project_id
         exporter = stackdriver_exporter.StackdriverExporter(
-            client=client,
-            project_id=project_id)
+            client=client, project_id=project_id)
 
         # does not throw
         self.assertIsNone(exporter.map_attributes(None))
@@ -276,8 +283,7 @@ class TestStackdriverExporter(unittest.TestCase):
         client = mock.Mock()
         client.project = project_id
         exporter = stackdriver_exporter.StackdriverExporter(
-            client=client,
-            project_id=project_id)
+            client=client, project_id=project_id)
 
         attributes = {
             'outer key': 'some value',
@@ -533,11 +539,7 @@ class Test_set_attributes_gae(unittest.TestCase):
     def test_set_attributes_gae(self, monitor_resource_mock):
         import os
 
-        trace = {'spans': [
-            {
-                'attributes': {}
-            }
-        ]}
+        trace = {'spans': [{'attributes': {}}]}
 
         expected = {
             'attributes': {
@@ -569,9 +571,8 @@ class Test_set_attributes_gae(unittest.TestCase):
                     'g.co/agent': {
                         'string_value': {
                             'truncated_byte_count': 0,
-                            'value': 'opencensus-python [{}]'.format(
-                                __version__
-                            )
+                            'value':
+                            'opencensus-python [{}]'.format(__version__)
                         }
                     },
                 }
@@ -579,12 +580,13 @@ class Test_set_attributes_gae(unittest.TestCase):
         }
 
         with mock.patch.dict(
-                os.environ,
-                {stackdriver_exporter._APPENGINE_FLEXIBLE_ENV_VM: 'vm',
-                 stackdriver_exporter._APPENGINE_FLEXIBLE_ENV_FLEX: 'flex',
-                 'GOOGLE_CLOUD_PROJECT': 'project',
-                 'GAE_SERVICE': 'service',
-                 'GAE_VERSION': 'version'}):
+                os.environ, {
+                    stackdriver_exporter._APPENGINE_FLEXIBLE_ENV_VM: 'vm',
+                    stackdriver_exporter._APPENGINE_FLEXIBLE_ENV_FLEX: 'flex',
+                    'GOOGLE_CLOUD_PROJECT': 'project',
+                    'GAE_SERVICE': 'service',
+                    'GAE_VERSION': 'version'
+                }):
             self.assertTrue(stackdriver_exporter.is_gae_environment())
             stackdriver_exporter.set_attributes(trace)
 
@@ -599,11 +601,7 @@ class TestMonitoredResourceAttributes(unittest.TestCase):
     def test_monitored_resource_attributes_gke(self, gke_monitor_resource_mock):
         import os
 
-        trace = {'spans': [
-            {
-                'attributes': {}
-            }
-        ]}
+        trace = {'spans': [{'attributes': {}}]}
 
         expected = {
             'attributes': {
@@ -635,9 +633,8 @@ class TestMonitoredResourceAttributes(unittest.TestCase):
                     'g.co/agent': {
                         'string_value': {
                             'truncated_byte_count': 0,
-                            'value': 'opencensus-python [{}]'.format(
-                                __version__
-                            )
+                            'value':
+                            'opencensus-python [{}]'.format(__version__)
                         }
                     },
                     'g.co/r/k8s_container/project_id': {
@@ -693,12 +690,13 @@ class TestMonitoredResourceAttributes(unittest.TestCase):
             'zone': 'zone1'
         }
         with mock.patch.dict(
-                os.environ,
-                {stackdriver_exporter._APPENGINE_FLEXIBLE_ENV_VM: 'vm',
-                 stackdriver_exporter._APPENGINE_FLEXIBLE_ENV_FLEX: 'flex',
-                 'GOOGLE_CLOUD_PROJECT': 'project',
-                 'GAE_SERVICE': 'service',
-                 'GAE_VERSION': 'version'}):
+                os.environ, {
+                    stackdriver_exporter._APPENGINE_FLEXIBLE_ENV_VM: 'vm',
+                    stackdriver_exporter._APPENGINE_FLEXIBLE_ENV_FLEX: 'flex',
+                    'GOOGLE_CLOUD_PROJECT': 'project',
+                    'GAE_SERVICE': 'service',
+                    'GAE_VERSION': 'version'
+                }):
             self.assertTrue(stackdriver_exporter.is_gae_environment())
             stackdriver_exporter.set_attributes(trace)
 
@@ -708,11 +706,7 @@ class TestMonitoredResourceAttributes(unittest.TestCase):
     @mock.patch('opencensus.trace.exporters.stackdriver_exporter.'
                 'MonitoredResourceUtil.get_instance')
     def test_monitored_resource_attributes_gce(self, gce_monitor_resource_mock):
-        trace = {'spans': [
-            {
-                'attributes': {}
-            }
-        ]}
+        trace = {'spans': [{'attributes': {}}]}
 
         expected = {
             'attributes': {
@@ -720,9 +714,8 @@ class TestMonitoredResourceAttributes(unittest.TestCase):
                     'g.co/agent': {
                         'string_value': {
                             'truncated_byte_count': 0,
-                            'value': 'opencensus-python [{}]'.format(
-                                __version__
-                            )
+                            'value':
+                            'opencensus-python [{}]'.format(__version__)
                         }
                     },
                     'g.co/r/gce_instance/project_id': {
@@ -761,11 +754,7 @@ class TestMonitoredResourceAttributes(unittest.TestCase):
     @mock.patch('opencensus.trace.exporters.stackdriver_exporter.'
                 'MonitoredResourceUtil.get_instance')
     def test_monitored_resource_attributes_aws(self, aws_monitor_resource_mock):
-        trace = {'spans': [
-            {
-                'attributes': {}
-            }
-        ]}
+        trace = {'spans': [{'attributes': {}}]}
 
         expected = {
             'attributes': {
@@ -773,9 +762,8 @@ class TestMonitoredResourceAttributes(unittest.TestCase):
                     'g.co/agent': {
                         'string_value': {
                             'truncated_byte_count': 0,
-                            'value': 'opencensus-python [{}]'.format(
-                                __version__
-                            )
+                            'value':
+                            'opencensus-python [{}]'.format(__version__)
                         }
                     },
                     'g.co/r/aws_ec2_instance/aws_account': {
@@ -808,11 +796,7 @@ class TestMonitoredResourceAttributes(unittest.TestCase):
     @mock.patch('opencensus.trace.exporters.stackdriver_exporter.'
                 'MonitoredResourceUtil.get_instance')
     def test_monitored_resource_attributes_None(self, monitor_resource_mock):
-        trace = {'spans': [
-            {
-                'attributes': {}
-            }
-        ]}
+        trace = {'spans': [{'attributes': {}}]}
 
         expected = {
             'attributes': {
@@ -820,9 +804,8 @@ class TestMonitoredResourceAttributes(unittest.TestCase):
                     'g.co/agent': {
                         'string_value': {
                             'truncated_byte_count': 0,
-                            'value': 'opencensus-python [{}]'.format(
-                                __version__
-                            )
+                            'value':
+                            'opencensus-python [{}]'.format(__version__)
                         }
                     }
                 }
@@ -836,13 +819,15 @@ class TestMonitoredResourceAttributes(unittest.TestCase):
 
         monitor_resource_mock.return_value = mock.Mock()
         monitor_resource_mock.return_value.resource_type = mock.Mock()
-        monitor_resource_mock.return_value.get_resource_labels.return_value = mock.Mock()
+        monitor_resource_mock.return_value.get_resource_labels.return_value = mock.Mock(
+        )
         stackdriver_exporter.set_attributes(trace)
         span = trace.get('spans')[0]
         self.assertEqual(span, expected)
 
 
 class MockTransport(object):
+
     def __init__(self, exporter=None):
         self.export_called = False
         self.exporter = exporter

--- a/tests/unit/trace/exporters/test_zipkin_exporter.py
+++ b/tests/unit/trace/exporters/test_zipkin_exporter.py
@@ -23,6 +23,7 @@ from opencensus.trace.exporters import zipkin_exporter
 
 
 class TestZipkinExporter(unittest.TestCase):
+
     def test_constructor(self):
         service_name = 'my_service'
         host_name = '0.0.0.0'
@@ -54,8 +55,7 @@ class TestZipkinExporter(unittest.TestCase):
         self.assertTrue(exporter.transport.export_called)
 
     @mock.patch('requests.post')
-    @mock.patch.object(zipkin_exporter.ZipkinExporter,
-                       'translate_to_zipkin')
+    @mock.patch.object(zipkin_exporter.ZipkinExporter, 'translate_to_zipkin')
     def test_emit_succeeded(self, translate_mock, requests_mock):
         import json
 
@@ -74,8 +74,7 @@ class TestZipkinExporter(unittest.TestCase):
             headers=zipkin_exporter.ZIPKIN_HEADERS)
 
     @mock.patch('requests.post')
-    @mock.patch.object(zipkin_exporter.ZipkinExporter,
-                       'translate_to_zipkin')
+    @mock.patch.object(zipkin_exporter.ZipkinExporter, 'translate_to_zipkin')
     def test_emit_failed(self, translate_mock, requests_mock):
         import json
 
@@ -179,7 +178,9 @@ class TestZipkinExporter(unittest.TestCase):
                 'timestamp': 1502820146071158,
                 'duration': 10000000,
                 'localEndpoint': local_endpoint_ipv4,
-                'tags': {'test_key': 'test_value'},
+                'tags': {
+                    'test_key': 'test_value'
+                },
                 'annotations': [],
             },
             {
@@ -190,7 +191,9 @@ class TestZipkinExporter(unittest.TestCase):
                 'timestamp': 1502820146071158,
                 'duration': 10000000,
                 'localEndpoint': local_endpoint_ipv4,
-                'tags': {'test_key': '1'},
+                'tags': {
+                    'test_key': '1'
+                },
                 'annotations': [],
             },
         ]
@@ -203,7 +206,10 @@ class TestZipkinExporter(unittest.TestCase):
                 'timestamp': 1502820146071158,
                 'duration': 10000000,
                 'localEndpoint': local_endpoint_ipv6,
-                'tags': {'test_key': 'False', 'test_key2': 'raw_value'},
+                'tags': {
+                    'test_key': 'False',
+                    'test_key2': 'raw_value'
+                },
                 'kind': 'SERVER',
                 'annotations': [],
             },
@@ -326,55 +332,77 @@ class TestZipkinExporter(unittest.TestCase):
 
         expected_zipkin_spans_ipv4 = [
             {
-                'traceId': '6e0c63257de34c92bf9efcd03927272e',
-                'id': '6e0c63257de34c92',
-                'parentId': '6e0c63257de34c93',
-                'name': 'child_span',
-                'timestamp': 1502820146071158,
-                'duration': 10000000,
-                'localEndpoint': local_endpoint_ipv4,
-                'tags': {'test_key': 'test_value'},
-                'annotations': [
-                    {
-                        'timestamp': 1502820146071158,
-                        'value': 'First Annotation'
-                    }
-                ]
+                'traceId':
+                '6e0c63257de34c92bf9efcd03927272e',
+                'id':
+                '6e0c63257de34c92',
+                'parentId':
+                '6e0c63257de34c93',
+                'name':
+                'child_span',
+                'timestamp':
+                1502820146071158,
+                'duration':
+                10000000,
+                'localEndpoint':
+                local_endpoint_ipv4,
+                'tags': {
+                    'test_key': 'test_value'
+                },
+                'annotations': [{
+                    'timestamp': 1502820146071158,
+                    'value': 'First Annotation'
+                }]
             },
             {
-                'traceId': '6e0c63257de34c92bf9efcd03927272e',
-                'id': '6e0c63257de34c92',
-                'parentId': '6e0c63257de34c93',
-                'name': 'child_span',
-                'timestamp': 1502820146071158,
-                'duration': 10000000,
-                'localEndpoint': local_endpoint_ipv4,
-                'tags': {'test_key': '1'},
-                'annotations': [
-                    {
-                        'timestamp': 1502820146071158,
-                        'value': 'First Annotation'
-                    }
-                ]
+                'traceId':
+                '6e0c63257de34c92bf9efcd03927272e',
+                'id':
+                '6e0c63257de34c92',
+                'parentId':
+                '6e0c63257de34c93',
+                'name':
+                'child_span',
+                'timestamp':
+                1502820146071158,
+                'duration':
+                10000000,
+                'localEndpoint':
+                local_endpoint_ipv4,
+                'tags': {
+                    'test_key': '1'
+                },
+                'annotations': [{
+                    'timestamp': 1502820146071158,
+                    'value': 'First Annotation'
+                }]
             },
         ]
 
         expected_zipkin_spans_ipv6 = [
             {
-                'traceId': '6e0c63257de34c92bf9efcd03927272e',
-                'id': '6e0c63257de34c92',
-                'name': 'child_span',
-                'timestamp': 1502820146071158,
-                'duration': 10000000,
-                'localEndpoint': local_endpoint_ipv6,
-                'tags': {'test_key': 'False', 'test_key2': 'raw_value'},
-                'kind': 'SERVER',
-                'annotations': [
-                    {
-                        'timestamp': 1502820146071158,
-                        'value': 'First Annotation'
-                    }
-                ]
+                'traceId':
+                '6e0c63257de34c92bf9efcd03927272e',
+                'id':
+                '6e0c63257de34c92',
+                'name':
+                'child_span',
+                'timestamp':
+                1502820146071158,
+                'duration':
+                10000000,
+                'localEndpoint':
+                local_endpoint_ipv6,
+                'tags': {
+                    'test_key': 'False',
+                    'test_key2': 'raw_value'
+                },
+                'kind':
+                'SERVER',
+                'annotations': [{
+                    'timestamp': 1502820146071158,
+                    'value': 'First Annotation'
+                }]
             },
         ]
 
@@ -396,13 +424,16 @@ class TestZipkinExporter(unittest.TestCase):
 
     def test_ignore_incorrect_spans(self):
         attributes = {'float_value': 0.1}
-        self.assertEqual(zipkin_exporter._extract_tags_from_span(attributes), {})
+        self.assertEqual(
+            zipkin_exporter._extract_tags_from_span(attributes), {})
 
         attributes = None
-        self.assertEqual(zipkin_exporter._extract_tags_from_span(attributes), {})
+        self.assertEqual(
+            zipkin_exporter._extract_tags_from_span(attributes), {})
 
 
 class MockTransport(object):
+
     def __init__(self, exporter=None):
         self.export_called = False
         self.exporter = exporter

--- a/tests/unit/trace/exporters/transports/test_background_thread.py
+++ b/tests/unit/trace/exporters/transports/test_background_thread.py
@@ -18,6 +18,7 @@ import mock
 
 from opencensus.trace.exporters.transports import background_thread
 
+
 class Test_Worker(unittest.TestCase):
 
     def _start_worker(self, worker):
@@ -34,8 +35,8 @@ class Test_Worker(unittest.TestCase):
         grace_period = 10
         max_batch_size = 20
 
-        worker = background_thread._Worker(exporter, grace_period=grace_period,
-                                           max_batch_size=max_batch_size)
+        worker = background_thread._Worker(
+            exporter, grace_period=grace_period, max_batch_size=max_batch_size)
 
         self.assertEqual(worker.exporter, exporter)
         self.assertEqual(worker._grace_period, grace_period)
@@ -53,8 +54,8 @@ class Test_Worker(unittest.TestCase):
         self.assertIsNotNone(worker._thread)
         self.assertTrue(worker._thread.daemon)
         self.assertEqual(worker._thread._target, worker._thread_main)
-        self.assertEqual(
-            worker._thread._name, background_thread._WORKER_THREAD_NAME)
+        self.assertEqual(worker._thread._name,
+                         background_thread._WORKER_THREAD_NAME)
         mock_atexit.assert_called_once_with(worker._export_pending_spans)
 
         cur_thread = worker._thread
@@ -72,8 +73,8 @@ class Test_Worker(unittest.TestCase):
         worker.stop()
 
         self.assertEqual(worker._queue.qsize(), 1)
-        self.assertEqual(
-            worker._queue.get(), background_thread._WORKER_TERMINATOR)
+        self.assertEqual(worker._queue.get(),
+                         background_thread._WORKER_TERMINATOR)
         self.assertFalse(worker.is_alive)
         self.assertIsNone(worker._thread)
 
@@ -119,7 +120,7 @@ class Test_Worker(unittest.TestCase):
         trace1 = {
             'traceId': 'test1',
             'spans': [{}, {}],
-            }
+        }
         trace2 = {
             'traceId': 'test2',
             'spans': [{}],
@@ -171,6 +172,7 @@ class Test_Worker(unittest.TestCase):
     def test__thread_main_terminate_before_finish(self):
 
         class Exporter(object):
+
             def __init__(self):
                 self.exported = []
 
@@ -204,6 +206,7 @@ class Test_Worker(unittest.TestCase):
     def test__thread_main_alive_on_emit_failed(self, mock):
 
         class Exporter(object):
+
             def __init__(self):
                 self.exported = []
 

--- a/tests/unit/trace/exporters/transports/test_base_transport.py
+++ b/tests/unit/trace/exporters/transports/test_base_transport.py
@@ -14,6 +14,7 @@
 
 import unittest
 
+
 class TestBaseTransport(unittest.TestCase):
 
     def test_export_abstract(self):

--- a/tests/unit/trace/ext/dbapi/test_dbapi_trace.py
+++ b/tests/unit/trace/ext/dbapi/test_dbapi_trace.py
@@ -45,9 +45,7 @@ class TestDBAPITrace(unittest.TestCase):
 
         self.assertEqual(wrapped.__class__.__name__, 'function')
         self.assertEqual(
-            getattr(mock_return, cursor_func_name, None),
-            wrap_func_name)
-
+            getattr(mock_return, cursor_func_name, None), wrap_func_name)
 
     def test_wrap_cursor(self):
         wrap_func_name = 'wrap func'
@@ -76,9 +74,7 @@ class TestDBAPITrace(unittest.TestCase):
 
         for func in trace.QUERY_WRAP_METHODS:
             self.assertEqual(
-                getattr(mock_return, func, None),
-                wrap_func_name + func)
-
+                getattr(mock_return, func, None), wrap_func_name + func)
 
     def test_trace_cursor_query(self):
         return_value = 'trace test'

--- a/tests/unit/trace/ext/django/test_config.py
+++ b/tests/unit/trace/ext/django/test_config.py
@@ -37,9 +37,8 @@ class TestDjangoTraceSettings(unittest.TestCase):
 
         django_trace_settings = config.DjangoTraceSettings()
 
-        self.assertEqual(
-            django_trace_settings.settings,
-            config.DEFAULT_DJANGO_TRACER_CONFIG)
+        self.assertEqual(django_trace_settings.settings,
+                         config.DEFAULT_DJANGO_TRACER_CONFIG)
 
     def test__getattr___invalid(self):
         from opencensus.trace.ext.django import config
@@ -67,17 +66,20 @@ class Test__set_default_configs(unittest.TestCase):
 
         custom_django_params = {
             'SAMPLING_RATE': 0.6,
-            'BLACKLIST_PATHS': ['_ah/health', ],
+            'BLACKLIST_PATHS': [
+                '_ah/health',
+            ],
             'TRANSPORT':
-                'opencensus.trace.exporters.transports.sync.SyncTransport',
+            'opencensus.trace.exporters.transports.sync.SyncTransport',
         }
 
         params = config._set_default_configs(
-            custom_django_params,
-            config.DEFAULT_DJANGO_TRACER_PARAMS)
+            custom_django_params, config.DEFAULT_DJANGO_TRACER_PARAMS)
 
         expected_params = {
-            'BLACKLIST_PATHS': ['_ah/health', ],
+            'BLACKLIST_PATHS': [
+                '_ah/health',
+            ],
             'GCP_EXPORTER_PROJECT': None,
             'SAMPLING_RATE': 0.6,
             'SERVICE_NAME': 'my_service',
@@ -88,7 +90,7 @@ class Test__set_default_configs(unittest.TestCase):
             'OCAGENT_TRACE_EXPORTER_ENDPOINT': None,
             'BLACKLIST_HOSTNAMES': None,
             'TRANSPORT':
-                'opencensus.trace.exporters.transports.sync.SyncTransport',
+            'opencensus.trace.exporters.transports.sync.SyncTransport',
         }
 
         self.assertEqual(params, expected_params)
@@ -110,8 +112,8 @@ class Test_convert_to_import(unittest.TestCase):
         mock_import_module.return_value = mock_module
         mock_importlib.import_module = mock_import_module
 
-        patch = mock.patch(
-            'opencensus.trace.ext.django.config.importlib', mock_importlib)
+        patch = mock.patch('opencensus.trace.ext.django.config.importlib',
+                           mock_importlib)
 
         with patch:
             result = config.convert_to_import(path)

--- a/tests/unit/trace/ext/django/test_middleware.py
+++ b/tests/unit/trace/ext/django/test_middleware.py
@@ -50,6 +50,7 @@ class TestOpencensusMiddleware(unittest.TestCase):
         from opencensus.trace.ext.django import middleware
 
         class MockCloudExporter(object):
+
             def __init__(self, project_id, transport):
                 self.project_id = project_id
                 self.transport = transport
@@ -60,7 +61,7 @@ class TestOpencensusMiddleware(unittest.TestCase):
         params = {
             'GCP_EXPORTER_PROJECT': project_id,
             'TRANSPORT':
-                'opencensus.trace.exporters.transports.sync.SyncTransport',
+            'opencensus.trace.exporters.transports.sync.SyncTransport',
         }
 
         patch_params = mock.patch(
@@ -73,18 +74,14 @@ class TestOpencensusMiddleware(unittest.TestCase):
             middleware = middleware.OpencensusMiddleware()
 
         self.assertIs(middleware._sampler, always_on.AlwaysOnSampler)
-        self.assertIs(
-            middleware._exporter, MockCloudExporter)
-        self.assertIs(
-            middleware._propagator,
-            google_cloud_format.GoogleCloudFormatPropagator)
+        self.assertIs(middleware._exporter, MockCloudExporter)
+        self.assertIs(middleware._propagator,
+                      google_cloud_format.GoogleCloudFormatPropagator)
 
         assert isinstance(middleware.sampler, always_on.AlwaysOnSampler)
-        assert isinstance(
-            middleware.exporter, MockCloudExporter)
-        assert isinstance(
-            middleware.propagator,
-            google_cloud_format.GoogleCloudFormatPropagator)
+        assert isinstance(middleware.exporter, MockCloudExporter)
+        assert isinstance(middleware.propagator,
+                          google_cloud_format.GoogleCloudFormatPropagator)
 
         self.assertEqual(middleware.exporter.project_id, project_id)
         self.assertEqual(middleware.exporter.transport, sync.SyncTransport)
@@ -102,7 +99,7 @@ class TestOpencensusMiddleware(unittest.TestCase):
             'ZIPKIN_EXPORTER_PORT': port,
             'ZIPKIN_EXPORTER_PROTOCOL': protocol,
             'TRANSPORT':
-                'opencensus.trace.exporters.transports.sync.SyncTransport',
+            'opencensus.trace.exporters.transports.sync.SyncTransport',
         }
 
         patch_zipkin = mock.patch(
@@ -110,25 +107,20 @@ class TestOpencensusMiddleware(unittest.TestCase):
             zipkin_exporter.ZipkinExporter)
 
         patch_params = mock.patch(
-            'opencensus.trace.ext.django.config.settings.params',
-            params)
+            'opencensus.trace.ext.django.config.settings.params', params)
 
         with patch_zipkin, patch_params:
             middleware = middleware.OpencensusMiddleware()
 
         self.assertIs(middleware._sampler, always_on.AlwaysOnSampler)
-        self.assertIs(
-            middleware._exporter, zipkin_exporter.ZipkinExporter)
-        self.assertIs(
-            middleware._propagator,
-            google_cloud_format.GoogleCloudFormatPropagator)
+        self.assertIs(middleware._exporter, zipkin_exporter.ZipkinExporter)
+        self.assertIs(middleware._propagator,
+                      google_cloud_format.GoogleCloudFormatPropagator)
 
         assert isinstance(middleware.sampler, always_on.AlwaysOnSampler)
-        assert isinstance(
-            middleware.exporter, zipkin_exporter.ZipkinExporter)
-        assert isinstance(
-            middleware.propagator,
-            google_cloud_format.GoogleCloudFormatPropagator)
+        assert isinstance(middleware.exporter, zipkin_exporter.ZipkinExporter)
+        assert isinstance(middleware.propagator,
+                          google_cloud_format.GoogleCloudFormatPropagator)
 
         self.assertEqual(middleware.exporter.service_name, service_name)
         self.assertEqual(middleware.exporter.host_name, host_name)
@@ -141,7 +133,7 @@ class TestOpencensusMiddleware(unittest.TestCase):
         params = {
             'SERVICE_NAME': service_name,
             'TRANSPORT':
-                'opencensus.trace.exporters.transports.sync.SyncTransport',
+            'opencensus.trace.exporters.transports.sync.SyncTransport',
         }
 
         patch_jaeger = mock.patch(
@@ -149,25 +141,20 @@ class TestOpencensusMiddleware(unittest.TestCase):
             jaeger_exporter.JaegerExporter)
 
         patch_params = mock.patch(
-            'opencensus.trace.ext.django.config.settings.params',
-            params)
+            'opencensus.trace.ext.django.config.settings.params', params)
 
         with patch_jaeger, patch_params:
             middleware = middleware.OpencensusMiddleware()
 
         self.assertIs(middleware._sampler, always_on.AlwaysOnSampler)
-        self.assertIs(
-            middleware._exporter, jaeger_exporter.JaegerExporter)
-        self.assertIs(
-            middleware._propagator,
-            google_cloud_format.GoogleCloudFormatPropagator)
+        self.assertIs(middleware._exporter, jaeger_exporter.JaegerExporter)
+        self.assertIs(middleware._propagator,
+                      google_cloud_format.GoogleCloudFormatPropagator)
 
         assert isinstance(middleware.sampler, always_on.AlwaysOnSampler)
-        assert isinstance(
-            middleware.exporter, jaeger_exporter.JaegerExporter)
-        assert isinstance(
-            middleware.propagator,
-            google_cloud_format.GoogleCloudFormatPropagator)
+        assert isinstance(middleware.exporter, jaeger_exporter.JaegerExporter)
+        assert isinstance(middleware.propagator,
+                          google_cloud_format.GoogleCloudFormatPropagator)
 
         self.assertEqual(middleware.exporter.service_name, service_name)
 
@@ -184,7 +171,7 @@ class TestOpencensusMiddleware(unittest.TestCase):
             'ZIPKIN_EXPORTER_PORT': port,
             'ZIPKIN_EXPORTER_PROTOCOL': protocol,
             'TRANSPORT':
-                'opencensus.trace.exporters.transports.sync.SyncTransport',
+            'opencensus.trace.exporters.transports.sync.SyncTransport',
         }
 
         patch_zipkin = mock.patch(
@@ -192,8 +179,7 @@ class TestOpencensusMiddleware(unittest.TestCase):
             zipkin_exporter.ZipkinExporter)
 
         patch_params = mock.patch(
-            'opencensus.trace.ext.django.config.settings.params',
-            params)
+            'opencensus.trace.ext.django.config.settings.params', params)
 
         with patch_zipkin, patch_params:
             middleware = middleware.OpencensusMiddleware()
@@ -211,7 +197,7 @@ class TestOpencensusMiddleware(unittest.TestCase):
             'SERVICE_NAME': service_name,
             'OCAGENT_TRACE_EXPORTER_ENDPOINT': endpoint,
             'TRANSPORT':
-                'opencensus.trace.exporters.transports.sync.SyncTransport',
+            'opencensus.trace.exporters.transports.sync.SyncTransport',
         }
 
         patch_ocagent_trace = mock.patch(
@@ -219,25 +205,20 @@ class TestOpencensusMiddleware(unittest.TestCase):
             trace_exporter.TraceExporter)
 
         patch_params = mock.patch(
-            'opencensus.trace.ext.django.config.settings.params',
-            params)
+            'opencensus.trace.ext.django.config.settings.params', params)
 
         with patch_ocagent_trace, patch_params:
             middleware = middleware.OpencensusMiddleware()
 
         self.assertIs(middleware._sampler, always_on.AlwaysOnSampler)
-        self.assertIs(
-            middleware._exporter, trace_exporter.TraceExporter)
-        self.assertIs(
-            middleware._propagator,
-            google_cloud_format.GoogleCloudFormatPropagator)
+        self.assertIs(middleware._exporter, trace_exporter.TraceExporter)
+        self.assertIs(middleware._propagator,
+                      google_cloud_format.GoogleCloudFormatPropagator)
 
         assert isinstance(middleware.sampler, always_on.AlwaysOnSampler)
-        assert isinstance(
-            middleware.exporter, trace_exporter.TraceExporter)
-        assert isinstance(
-            middleware.propagator,
-            google_cloud_format.GoogleCloudFormatPropagator)
+        assert isinstance(middleware.exporter, trace_exporter.TraceExporter)
+        assert isinstance(middleware.propagator,
+                          google_cloud_format.GoogleCloudFormatPropagator)
 
         self.assertEqual(middleware.exporter.service_name, service_name)
         self.assertEqual(middleware.exporter.endpoint, endpoint)
@@ -249,7 +230,7 @@ class TestOpencensusMiddleware(unittest.TestCase):
         params = {
             'SERVICE_NAME': service_name,
             'TRANSPORT':
-                'opencensus.trace.exporters.transports.sync.SyncTransport',
+            'opencensus.trace.exporters.transports.sync.SyncTransport',
         }
 
         patch_ocagent_trace = mock.patch(
@@ -257,8 +238,7 @@ class TestOpencensusMiddleware(unittest.TestCase):
             trace_exporter.TraceExporter)
 
         patch_params = mock.patch(
-            'opencensus.trace.ext.django.config.settings.params',
-            params)
+            'opencensus.trace.ext.django.config.settings.params', params)
 
         with patch_ocagent_trace, patch_params:
             middleware = middleware.OpencensusMiddleware()
@@ -274,7 +254,7 @@ class TestOpencensusMiddleware(unittest.TestCase):
         params = {
             'SAMPLING_RATE': 0.8,
             'TRANSPORT':
-                'opencensus.trace.exporters.transports.sync.SyncTransport',
+            'opencensus.trace.exporters.transports.sync.SyncTransport',
         }
 
         patch_sampler = mock.patch(
@@ -285,25 +265,20 @@ class TestOpencensusMiddleware(unittest.TestCase):
             print_exporter.PrintExporter)
 
         patch_params = mock.patch(
-            'opencensus.trace.ext.django.config.settings.params',
-            params)
+            'opencensus.trace.ext.django.config.settings.params', params)
 
         with patch_sampler, patch_exporter, patch_params:
             middleware = middleware.OpencensusMiddleware()
 
         self.assertIs(middleware._sampler, probability.ProbabilitySampler)
-        self.assertIs(
-            middleware._exporter, print_exporter.PrintExporter)
-        self.assertIs(
-            middleware._propagator,
-            google_cloud_format.GoogleCloudFormatPropagator)
+        self.assertIs(middleware._exporter, print_exporter.PrintExporter)
+        self.assertIs(middleware._propagator,
+                      google_cloud_format.GoogleCloudFormatPropagator)
 
         assert isinstance(middleware.sampler, probability.ProbabilitySampler)
-        assert isinstance(
-            middleware.exporter, print_exporter.PrintExporter)
-        assert isinstance(
-            middleware.propagator,
-            google_cloud_format.GoogleCloudFormatPropagator)
+        assert isinstance(middleware.exporter, print_exporter.PrintExporter)
+        assert isinstance(middleware.propagator,
+                          google_cloud_format.GoogleCloudFormatPropagator)
 
         self.assertEqual(middleware.sampler.rate, rate)
 
@@ -314,8 +289,8 @@ class TestOpencensusMiddleware(unittest.TestCase):
         span_id = '6e0c63257de34c92'
         django_trace_id = '{}/{}'.format(trace_id, span_id)
 
-        django_request = RequestFactory().get('/', **{
-            'HTTP_X_CLOUD_TRACE_CONTEXT': django_trace_id})
+        django_request = RequestFactory().get(
+            '/', **{'HTTP_X_CLOUD_TRACE_CONTEXT': django_trace_id})
 
         middleware_obj = middleware.OpencensusMiddleware()
 
@@ -348,14 +323,18 @@ class TestOpencensusMiddleware(unittest.TestCase):
 
         execution_context.clear()
 
-        blacklist_paths = ['test_blacklist_path', ]
+        blacklist_paths = [
+            'test_blacklist_path',
+        ]
         params = {
-            'BLACKLIST_PATHS': ['test_blacklist_path', ],
+            'BLACKLIST_PATHS': [
+                'test_blacklist_path',
+            ],
             'TRANSPORT':
-                'opencensus.trace.exporters.transports.sync.SyncTransport', }
+            'opencensus.trace.exporters.transports.sync.SyncTransport',
+        }
         patch_params = mock.patch(
-            'opencensus.trace.ext.django.middleware.settings.params',
-            params)
+            'opencensus.trace.ext.django.middleware.settings.params', params)
 
         with patch_params:
             middleware_obj = middleware.OpencensusMiddleware()
@@ -398,8 +377,9 @@ class TestOpencensusMiddleware(unittest.TestCase):
         span_id = '6e0c63257de34c92'
         django_trace_id = '{}/{}'.format(trace_id, span_id)
 
-        django_request = RequestFactory().get('/', **{
-            google_cloud_format._TRACE_CONTEXT_HEADER_NAME: django_trace_id})
+        django_request = RequestFactory().get(
+            '/',
+            **{google_cloud_format._TRACE_CONTEXT_HEADER_NAME: django_trace_id})
 
         middleware_obj = middleware.OpencensusMiddleware()
 
@@ -437,8 +417,9 @@ class TestOpencensusMiddleware(unittest.TestCase):
         span_id = '6e0c63257de34c92'
         django_trace_id = '{}/{}'.format(trace_id, span_id)
 
-        django_request = RequestFactory().get('/', **{
-            google_cloud_format._TRACE_CONTEXT_HEADER_NAME: django_trace_id})
+        django_request = RequestFactory().get(
+            '/',
+            **{google_cloud_format._TRACE_CONTEXT_HEADER_NAME: django_trace_id})
 
         middleware_obj = middleware.OpencensusMiddleware()
 
@@ -473,7 +454,9 @@ class TestOpencensusMiddleware(unittest.TestCase):
 
 
 class Test__set_django_attributes(unittest.TestCase):
+
     class Span(object):
+
         def __init__(self):
             self.attributes = {}
 
@@ -528,6 +511,7 @@ class Test__set_django_attributes(unittest.TestCase):
 
         expected_attributes = {
             'django.user.id': '123',
-            'django.user.name': test_name}
+            'django.user.name': test_name
+        }
 
         self.assertEqual(span.attributes, expected_attributes)

--- a/tests/unit/trace/ext/flask/test_flask_middleware.py
+++ b/tests/unit/trace/ext/flask/test_flask_middleware.py
@@ -71,9 +71,8 @@ class TestFlaskMiddleware(unittest.TestCase):
         self.assertTrue(app.after_request.called)
         assert isinstance(middleware.sampler, always_on.AlwaysOnSampler)
         assert isinstance(middleware.exporter, print_exporter.PrintExporter)
-        assert isinstance(
-            middleware.propagator,
-            google_cloud_format.GoogleCloudFormatPropagator)
+        assert isinstance(middleware.propagator,
+                          google_cloud_format.GoogleCloudFormatPropagator)
 
     def test_constructor_explicit(self):
         app = mock.Mock(config={})
@@ -82,10 +81,7 @@ class TestFlaskMiddleware(unittest.TestCase):
         propagator = mock.Mock()
 
         middleware = flask_middleware.FlaskMiddleware(
-            app=app,
-            sampler=sampler,
-            exporter=exporter,
-            propagator=propagator)
+            app=app, sampler=sampler, exporter=exporter, propagator=propagator)
 
         self.assertIs(middleware.app, app)
         self.assertIs(middleware.sampler, sampler)
@@ -124,12 +120,12 @@ class TestFlaskMiddleware(unittest.TestCase):
         }
 
         class StackdriverExporter(object):
+
             def __init__(self, *args, **kwargs):
                 pass
 
         middleware = flask_middleware.FlaskMiddleware(
-            exporter=StackdriverExporter
-        )
+            exporter=StackdriverExporter)
         middleware.init_app(app)
 
         self.assertIs(middleware.app, app)
@@ -163,8 +159,7 @@ class TestFlaskMiddleware(unittest.TestCase):
         self.assertTrue(app.before_request.called)
         self.assertTrue(app.after_request.called)
 
-        assert isinstance(
-            middleware.exporter, zipkin_exporter.ZipkinExporter)
+        assert isinstance(middleware.exporter, zipkin_exporter.ZipkinExporter)
         self.assertEqual(middleware.exporter.service_name, service_name)
         self.assertEqual(middleware.exporter.host_name, host_name)
         self.assertEqual(middleware.exporter.port, port)
@@ -196,8 +191,7 @@ class TestFlaskMiddleware(unittest.TestCase):
         self.assertTrue(app.before_request.called)
         self.assertTrue(app.after_request.called)
 
-        assert isinstance(
-            middleware.exporter, zipkin_exporter.ZipkinExporter)
+        assert isinstance(middleware.exporter, zipkin_exporter.ZipkinExporter)
         self.assertEqual(middleware.exporter.service_name, service_name)
         self.assertEqual(middleware.exporter.host_name, host_name)
         self.assertEqual(middleware.exporter.port, port)
@@ -223,8 +217,7 @@ class TestFlaskMiddleware(unittest.TestCase):
         self.assertTrue(app.before_request.called)
         self.assertTrue(app.after_request.called)
 
-        assert isinstance(
-            middleware.exporter, jaeger_exporter.JaegerExporter)
+        assert isinstance(middleware.exporter, jaeger_exporter.JaegerExporter)
         self.assertEqual(middleware.exporter.service_name, service_name)
 
     def test_init_app_config_ocagent_trace_exporter(self):
@@ -245,8 +238,7 @@ class TestFlaskMiddleware(unittest.TestCase):
         middleware.init_app(app)
 
         self.assertIs(middleware.app, app)
-        assert isinstance(
-            middleware.exporter, trace_exporter.TraceExporter)
+        assert isinstance(middleware.exporter, trace_exporter.TraceExporter)
         self.assertEqual(middleware.exporter.service_name, 'foo')
         self.assertEqual(middleware.exporter.endpoint, 'localhost:50001')
 
@@ -270,8 +262,7 @@ class TestFlaskMiddleware(unittest.TestCase):
         middleware.init_app(app)
 
         self.assertIs(middleware.app, app)
-        assert isinstance(
-            middleware.exporter, trace_exporter.TraceExporter)
+        assert isinstance(middleware.exporter, trace_exporter.TraceExporter)
         self.assertEqual(middleware.exporter.service_name, 'foo')
         self.assertEqual(middleware.exporter.endpoint,
                          trace_exporter.DEFAULT_ENDPOINT)
@@ -290,8 +281,7 @@ class TestFlaskMiddleware(unittest.TestCase):
         app = self.create_app()
         flask_middleware.FlaskMiddleware(app=app)
         context = app.test_request_context(
-            path='/',
-            headers={flask_trace_header: flask_trace_id})
+            path='/', headers={flask_trace_header: flask_trace_id})
 
         with context:
             app.preprocess_request()
@@ -321,8 +311,7 @@ class TestFlaskMiddleware(unittest.TestCase):
         app = self.create_app()
         flask_middleware.FlaskMiddleware(app=app)
         context = app.test_request_context(
-            path='/_ah/health',
-            headers={flask_trace_header: flask_trace_id})
+            path='/_ah/health', headers={flask_trace_header: flask_trace_id})
 
         with context:
             app.preprocess_request()
@@ -348,8 +337,7 @@ class TestFlaskMiddleware(unittest.TestCase):
         app = self.create_app()
         flask_middleware.FlaskMiddleware(app=app)
         context = app.test_request_context(
-            path='/',
-            headers={flask_trace_header: flask_trace_id})
+            path='/', headers={flask_trace_header: flask_trace_id})
 
         with context:
             app.preprocess_request()
@@ -372,8 +360,7 @@ class TestFlaskMiddleware(unittest.TestCase):
     def test_header_is_none(self):
         app = self.create_app()
         flask_middleware.FlaskMiddleware(app=app)
-        context = app.test_request_context(
-            path='/')
+        context = app.test_request_context(path='/')
 
         with context:
             app.preprocess_request()
@@ -401,8 +388,7 @@ class TestFlaskMiddleware(unittest.TestCase):
         flask_middleware.FlaskMiddleware(app=app, sampler=sampler)
 
         response = app.test_client().get(
-            '/',
-            headers={flask_trace_header: flask_trace_id})
+            '/', headers={flask_trace_header: flask_trace_id})
 
         self.assertEqual(response.status_code, 200)
 
@@ -416,8 +402,7 @@ class TestFlaskMiddleware(unittest.TestCase):
         flask_middleware.FlaskMiddleware(app=app)
 
         response = app.test_client().get(
-            '/',
-            headers={flask_trace_header: flask_trace_id})
+            '/', headers={flask_trace_header: flask_trace_id})
 
         self.assertEqual(response.status_code, 200)
 
@@ -431,8 +416,7 @@ class TestFlaskMiddleware(unittest.TestCase):
         flask_middleware.FlaskMiddleware(app=app)
 
         response = app.test_client().get(
-            '/_ah/health',
-            headers={flask_trace_header: flask_trace_id})
+            '/_ah/health', headers={flask_trace_header: flask_trace_id})
 
         tracer = execution_context.get_opencensus_tracer()
 
@@ -466,8 +450,7 @@ class TestFlaskMiddleware(unittest.TestCase):
         self.assertIsInstance(exported_spandata.status, status.Status)
         self.assertEqual(exported_spandata.status.code, code_pb2.UNKNOWN)
         self.assertEqual(exported_spandata.status.message, 'error')
-        self.assertIsInstance(
-            exported_spandata.stack_trace, stack_trace.StackTrace
-        )
+        self.assertIsInstance(exported_spandata.stack_trace,
+                              stack_trace.StackTrace)
         self.assertIsNotNone(exported_spandata.stack_trace.stack_trace_hash_id)
         self.assertNotEqual(exported_spandata.stack_trace.stack_frames, [])

--- a/tests/unit/trace/ext/google_cloud_clientlibs/test_google_cloud_clientlibs_trace.py
+++ b/tests/unit/trace/ext/google_cloud_clientlibs/test_google_cloud_clientlibs_trace.py
@@ -47,20 +47,21 @@ class Test_google_cloud_clientlibs_trace(unittest.TestCase):
 
         mock_make_secure_channel_func = mock.Mock()
         mock_make_secure_channel_func.__name__ = 'make_secure_channel'
-        setattr(
-            mock__helpers,
-            'make_secure_channel',
-            mock_make_secure_channel_func)
+        setattr(mock__helpers, 'make_secure_channel',
+                mock_make_secure_channel_func)
 
         patch_wrap = mock.patch(
-            'opencensus.trace.ext.google_cloud_clientlibs.trace.wrap_make_secure_channel', mock_wrap)
+            'opencensus.trace.ext.google_cloud_clientlibs.trace.wrap_make_secure_channel',
+            mock_wrap)
         patch__helpers = mock.patch(
-            'opencensus.trace.ext.google_cloud_clientlibs.trace._helpers', mock__helpers)
+            'opencensus.trace.ext.google_cloud_clientlibs.trace._helpers',
+            mock__helpers)
 
         with patch_wrap, patch__helpers:
             trace.trace_integration()
 
-        self.assertEqual(getattr(mock__helpers, 'make_secure_channel'), wrap_result)
+        self.assertEqual(
+            getattr(mock__helpers, 'make_secure_channel'), wrap_result)
 
     def test_trace_http(self):
         mock_trace_requests = mock.Mock()

--- a/tests/unit/trace/ext/grpc/test_client_interceptor.py
+++ b/tests/unit/trace/ext/grpc/test_client_interceptor.py
@@ -33,8 +33,9 @@ class TestOpenCensusClientInterceptor(unittest.TestCase):
 
         self.assertIsNone(interceptor._tracer)
         self.assertIsNone(interceptor.host_port)
-        self.assertTrue(isinstance(
-            interceptor._propagator, binary_format.BinaryFormatPropagator))
+        self.assertTrue(
+            isinstance(interceptor._propagator,
+                       binary_format.BinaryFormatPropagator))
 
     def test_constructor_explicit(self):
         from opencensus.trace.propagation import binary_format
@@ -46,8 +47,9 @@ class TestOpenCensusClientInterceptor(unittest.TestCase):
 
         self.assertEqual(interceptor._tracer, tracer)
         self.assertEqual(interceptor.host_port, host_port)
-        self.assertTrue(isinstance(
-            interceptor._propagator, binary_format.BinaryFormatPropagator))
+        self.assertTrue(
+            isinstance(interceptor._propagator,
+                       binary_format.BinaryFormatPropagator))
 
     def test__start_client_span(self):
         tracer = mock.Mock()
@@ -89,9 +91,7 @@ class TestOpenCensusClientInterceptor(unittest.TestCase):
         mock_client_call_details.method = '/hello'
 
         client_call_details, request_iterator, current_span = interceptor._intercept_call(
-            mock_client_call_details,
-            mock.Mock(),
-            'unary_unary')
+            mock_client_call_details, mock.Mock(), 'unary_unary')
 
         expected_metadata = (('grpc-trace-bin', test_header),)
 
@@ -111,9 +111,7 @@ class TestOpenCensusClientInterceptor(unittest.TestCase):
         mock_client_call_details.method = '/hello'
 
         client_call_details, request_iterator, current_span = interceptor._intercept_call(
-            mock_client_call_details,
-            mock.Mock(),
-            'unary_unary')
+            mock_client_call_details, mock.Mock(), 'unary_unary')
 
         expected_metadata = (('grpc-trace-bin', test_header),)
 
@@ -130,16 +128,18 @@ class TestOpenCensusClientInterceptor(unittest.TestCase):
             tracer=tracer, host_port='test')
         interceptor._propagator = mock_propagator
         mock_client_call_details = mock.Mock()
-        mock_client_call_details.metadata = [('test_key', 'test_value'), ]
+        mock_client_call_details.metadata = [
+            ('test_key', 'test_value'),
+        ]
         mock_client_call_details.method = '/hello'
 
         client_call_details, request_iterator, current_span = interceptor._intercept_call(
-            mock_client_call_details,
-            mock.Mock(),
-            'unary_unary')
+            mock_client_call_details, mock.Mock(), 'unary_unary')
 
-        expected_metadata = [('test_key', 'test_value'),
-                             ('grpc-trace-bin', test_header), ]
+        expected_metadata = [
+            ('test_key', 'test_value'),
+            ('grpc-trace-bin', test_header),
+        ]
 
         self.assertEqual(expected_metadata, client_call_details.metadata)
 
@@ -158,12 +158,12 @@ class TestOpenCensusClientInterceptor(unittest.TestCase):
         mock_client_call_details.method = '/hello'
 
         client_call_details, request_iterator, current_span = interceptor._intercept_call(
-            mock_client_call_details,
-            mock.Mock(),
-            'unary_unary')
+            mock_client_call_details, mock.Mock(), 'unary_unary')
 
-        expected_metadata = (('test_key', 'test_value'),
-                             ('grpc-trace-bin', test_header),)
+        expected_metadata = (
+            ('test_key', 'test_value'),
+            ('grpc-trace-bin', test_header),
+        )
 
         self.assertEqual(expected_metadata, client_call_details.metadata)
 
@@ -221,16 +221,14 @@ class TestOpenCensusClientInterceptor(unittest.TestCase):
         interceptor, continuation, mock_response = self._unary_helper()
         client_call_details = mock.Mock()
         client_call_details.method = 'test'
-        interceptor.intercept_unary_unary(
-            continuation, client_call_details, [])
+        interceptor.intercept_unary_unary(continuation, client_call_details, [])
         self.assertTrue(mock_response.add_done_callback.called)
 
     def test_intercept_unary_unary_not_trace(self):
         interceptor, continuation, mock_response = self._unary_helper()
         client_call_details = mock.Mock()
         client_call_details.method = 'google.devtools.cloudtrace'
-        interceptor.intercept_unary_unary(
-            continuation, client_call_details, [])
+        interceptor.intercept_unary_unary(continuation, client_call_details, [])
         # Should skip tracing the cloud trace activities
         self.assertFalse(mock_response.add_done_callback.called)
 
@@ -240,8 +238,7 @@ class TestOpenCensusClientInterceptor(unittest.TestCase):
         client_call_details = mock.Mock()
         client_call_details.method = 'test'
         response_iter = interceptor.intercept_unary_stream(
-            continuation, client_call_details, []
-        )
+            continuation, client_call_details, [])
         for _ in response_iter:
             pass
         self.assertTrue(mock_tracer.end_span.called)
@@ -250,8 +247,8 @@ class TestOpenCensusClientInterceptor(unittest.TestCase):
         interceptor, continuation, mock_tracer = self._stream_helper()
         client_call_details = mock.Mock()
         client_call_details.method = 'google.devtools.cloudtrace'
-        interceptor.intercept_unary_stream(
-            continuation, client_call_details, [])
+        interceptor.intercept_unary_stream(continuation, client_call_details,
+                                           [])
         # Should skip tracing the cloud trace activities
         self.assertFalse(mock_tracer.end_span.called)
 
@@ -259,16 +256,16 @@ class TestOpenCensusClientInterceptor(unittest.TestCase):
         interceptor, continuation, mock_response = self._unary_helper()
         client_call_details = mock.Mock()
         client_call_details.method = 'test'
-        interceptor.intercept_stream_unary(
-            continuation, client_call_details, [])
+        interceptor.intercept_stream_unary(continuation, client_call_details,
+                                           [])
         self.assertTrue(mock_response.add_done_callback.called)
 
     def test_intercept_stream_unary_not_trace(self):
         interceptor, continuation, mock_tracer = self._stream_helper()
         client_call_details = mock.Mock()
         client_call_details.method = 'google.devtools.cloudtrace'
-        interceptor.intercept_stream_unary(
-            continuation, client_call_details, [])
+        interceptor.intercept_stream_unary(continuation, client_call_details,
+                                           [])
         # Should skip tracing the cloud trace activities
         self.assertFalse(mock_tracer.end_span.called)
 
@@ -278,8 +275,7 @@ class TestOpenCensusClientInterceptor(unittest.TestCase):
         client_call_details = mock.Mock()
         client_call_details.method = 'test'
         response_iter = interceptor.intercept_stream_stream(
-            continuation, client_call_details, []
-        )
+            continuation, client_call_details, [])
         for _ in response_iter:
             pass
 
@@ -289,13 +285,14 @@ class TestOpenCensusClientInterceptor(unittest.TestCase):
         interceptor, continuation, mock_tracer = self._stream_helper()
         client_call_details = mock.Mock()
         client_call_details.method = 'google.devtools.cloudtrace'
-        interceptor.intercept_stream_stream(
-            continuation, client_call_details, [])
+        interceptor.intercept_stream_stream(continuation, client_call_details,
+                                            [])
         # Should skip tracing the cloud trace activities
         self.assertFalse(mock_tracer.end_span.called)
 
 
 class MockTracer(object):
+
     def __init__(self, current_span):
         self.current_span = current_span
 

--- a/tests/unit/trace/ext/grpc/test_server_interceptor.py
+++ b/tests/unit/trace/ext/grpc/test_server_interceptor.py
@@ -23,6 +23,7 @@ from opencensus.trace.ext.grpc import server_interceptor
 
 
 class TestOpenCensusServerInterceptor(unittest.TestCase):
+
     def test_constructor(self):
         sampler = mock.Mock()
         exporter = mock.Mock()
@@ -38,17 +39,16 @@ class TestOpenCensusServerInterceptor(unittest.TestCase):
         mock_context = mock.Mock()
         mock_context.invocation_metadata = mock.Mock(return_value=None)
         mock_context._rpc_event.call_details.method = 'hello'
-        interceptor = server_interceptor.OpenCensusServerInterceptor(
-            None, None)
+        interceptor = server_interceptor.OpenCensusServerInterceptor(None, None)
         mock_handler = mock.Mock()
         mock_handler.request_streaming = False
         mock_handler.response_streaming = False
         mock_continuation = mock.Mock(return_value=mock_handler)
 
         with patch:
-            interceptor.intercept_service(
-                mock_continuation, mock.Mock()
-            ).unary_unary(mock.Mock(), mock_context)
+            interceptor.intercept_service(mock_continuation,
+                                          mock.Mock()).unary_unary(
+                                              mock.Mock(), mock_context)
 
         expected_attributes = {
             'component': 'grpc',
@@ -71,8 +71,7 @@ class TestOpenCensusServerInterceptor(unittest.TestCase):
                 MockTracer)
             mock_context = mock.Mock()
             mock_context.invocation_metadata = mock.Mock(
-                return_value=(('test_key', b'test_value'),)
-            )
+                return_value=(('test_key', b'test_value'),))
             mock_handler = mock.Mock()
             mock_handler.request_streaming = request_streaming
             mock_handler.response_streaming = response_streaming
@@ -83,9 +82,8 @@ class TestOpenCensusServerInterceptor(unittest.TestCase):
                 None, None)
 
             with patch:
-                handler = interceptor.intercept_service(
-                    mock_continuation, mock.Mock()
-                )
+                handler = interceptor.intercept_service(mock_continuation,
+                                                        mock.Mock())
                 getattr(handler, rpc_fn_name)(mock.Mock(), mock_context)
 
             expected_attributes = {
@@ -93,8 +91,8 @@ class TestOpenCensusServerInterceptor(unittest.TestCase):
             }
 
             self.assertEqual(
-                execution_context.get_opencensus_tracer().current_span().attributes,
-                expected_attributes)
+                execution_context.get_opencensus_tracer().current_span().
+                attributes, expected_attributes)
 
     def test_intercept_handler_exception(self):
         test_dimensions = [
@@ -122,20 +120,18 @@ class TestOpenCensusServerInterceptor(unittest.TestCase):
             # mock_continuation.unary_unary = mock.Mock())
             with patch:
                 # patch the wrapper's handler to return an exception
-                handler = interceptor.intercept_service(
-                    mock_continuation, mock.Mock())
+                handler = interceptor.intercept_service(mock_continuation,
+                                                        mock.Mock())
                 with self.assertRaises(Exception):
                     getattr(handler, rpc_fn_name)(mock.Mock(), mock_context)
 
-            expected_attributes = {
-                'component': 'grpc',
-                'error.message': 'Test'
-            }
+            expected_attributes = {'component': 'grpc', 'error.message': 'Test'}
 
-            current_span = execution_context.get_opencensus_tracer().current_span()
+            current_span = execution_context.get_opencensus_tracer(
+            ).current_span()
             self.assertEqual(
-                execution_context.get_opencensus_tracer().current_span().attributes,
-                expected_attributes)
+                execution_context.get_opencensus_tracer().current_span().
+                attributes, expected_attributes)
 
             self.assertEqual(current_span.span_kind,
                              span_module.SpanKind.SERVER)
@@ -156,6 +152,7 @@ class TestOpenCensusServerInterceptor(unittest.TestCase):
 
 
 class MockTracer(object):
+
     def __init__(self, *args, **kwargs):
         self._current_span = span_module.Span('mock_span')
         execution_context.set_opencensus_tracer(self)

--- a/tests/unit/trace/ext/httplib/test_httplib_trace.py
+++ b/tests/unit/trace/ext/httplib/test_httplib_trace.py
@@ -51,16 +51,18 @@ class Test_httplib_trace(unittest.TestCase):
         patch_wrap_response = mock.patch(
             'opencensus.trace.ext.httplib.trace.wrap_httplib_response',
             mock_wrap_response)
-        patch_httplib = mock.patch(
-            'opencensus.trace.ext.httplib.trace.httplib', mock_httplib)
+        patch_httplib = mock.patch('opencensus.trace.ext.httplib.trace.httplib',
+                                   mock_httplib)
 
         with patch_wrap_request, patch_wrap_response, patch_httplib:
             trace.trace_integration()
 
-        self.assertEqual(getattr(mock_httplib.HTTPConnection, 'request'),
-                         wrap_request_result)
-        self.assertEqual(getattr(mock_httplib.HTTPConnection, 'getresponse'),
-                         wrap_response_result)
+        self.assertEqual(
+            getattr(mock_httplib.HTTPConnection, 'request'),
+            wrap_request_result)
+        self.assertEqual(
+            getattr(mock_httplib.HTTPConnection, 'getresponse'),
+            wrap_response_result)
 
     def test_wrap_httplib_request(self):
         mock_span = mock.Mock()
@@ -86,20 +88,16 @@ class Test_httplib_trace(unittest.TestCase):
         with patch:
             wrapped(mock_self, method, url, body, headers)
 
-        expected_attributes = {
-            'http.url': url,
-            'http.method': method}
+        expected_attributes = {'http.url': url, 'http.method': method}
         expected_name = '[httplib]request'
 
-        mock_request_func.assert_called_with(
-            mock_self, method, url, body, {
-                'traceparent': '00-123-456-01',
-            }
-        )
-        self.assertEqual(expected_attributes,
-                         mock_tracer.span.attributes)
+        mock_request_func.assert_called_with(mock_self, method, url, body, {
+            'traceparent': '00-123-456-01',
+        })
+        self.assertEqual(expected_attributes, mock_tracer.span.attributes)
         self.assertEqual(expected_name, mock_tracer.span.name)
-        self.assertEqual(span_module.SpanKind.CLIENT, mock_tracer.span.span_kind)
+        self.assertEqual(span_module.SpanKind.CLIENT,
+                         mock_tracer.span.span_kind)
 
     def test_wrap_httplib_request_blacklist_ok(self):
         mock_span = mock.Mock()
@@ -129,16 +127,12 @@ class Test_httplib_trace(unittest.TestCase):
         with patch_tracer, patch_attr:
             wrapped(mock_self, method, url, body, headers)
 
-        expected_attributes = {
-            'http.url': url,
-            'http.method': method}
+        expected_attributes = {'http.url': url, 'http.method': method}
         expected_name = '[httplib]request'
 
-        mock_request_func.assert_called_with(
-            mock_self, method, url, body, {
-                'traceparent': '00-123-456-01',
-            }
-        )
+        mock_request_func.assert_called_with(mock_self, method, url, body, {
+            'traceparent': '00-123-456-01',
+        })
 
     def test_wrap_httplib_request_blacklist_nok(self):
         mock_span = mock.Mock()
@@ -170,14 +164,10 @@ class Test_httplib_trace(unittest.TestCase):
         with patch_tracer, patch_attr:
             wrapped(mock_self, method, url, body, headers)
 
-        expected_attributes = {
-            'http.url': url,
-            'http.method': method}
+        expected_attributes = {'http.url': url, 'http.method': method}
         expected_name = '[httplib]request'
 
-        mock_request_func.assert_called_with(
-            mock_self, method, url, body, {}
-        )
+        mock_request_func.assert_called_with(mock_self, method, url, body, {})
 
     def test_wrap_httplib_response(self):
         mock_span = mock.Mock()
@@ -194,20 +184,19 @@ class Test_httplib_trace(unittest.TestCase):
             'opencensus.trace.ext.requests.trace.execution_context.'
             'get_opencensus_tracer',
             return_value=mock_tracer)
-        patch_attr = mock.patch('opencensus.trace.ext.httplib.trace.'
-                                'execution_context.get_opencensus_attr',
-                                return_value=span_id)
+        patch_attr = mock.patch(
+            'opencensus.trace.ext.httplib.trace.'
+            'execution_context.get_opencensus_attr',
+            return_value=span_id)
 
         wrapped = trace.wrap_httplib_response(mock_response_func)
 
         with patch_tracer, patch_attr:
             wrapped(mock.Mock())
 
-        expected_attributes = {
-            'http.status_code': '200'}
+        expected_attributes = {'http.status_code': '200'}
 
-        self.assertEqual(expected_attributes,
-                         mock_tracer.span.attributes)
+        self.assertEqual(expected_attributes, mock_tracer.span.attributes)
 
     def test_wrap_httplib_response_no_open_span(self):
         mock_span = mock.Mock()
@@ -224,9 +213,10 @@ class Test_httplib_trace(unittest.TestCase):
             'opencensus.trace.ext.requests.trace.execution_context.'
             'get_opencensus_tracer',
             return_value=mock_tracer)
-        patch_attr = mock.patch('opencensus.trace.ext.httplib.trace.'
-                                'execution_context.get_opencensus_attr',
-                                return_value='1111')
+        patch_attr = mock.patch(
+            'opencensus.trace.ext.httplib.trace.'
+            'execution_context.get_opencensus_attr',
+            return_value='1111')
 
         wrapped = trace.wrap_httplib_response(mock_response_func)
 
@@ -236,16 +226,15 @@ class Test_httplib_trace(unittest.TestCase):
         # Attribute should be empty as there is no matching span
         expected_attributes = {}
 
-        self.assertEqual(expected_attributes,
-                         mock_tracer.span.attributes)
+        self.assertEqual(expected_attributes, mock_tracer.span.attributes)
 
 
 class MockTracer(object):
+
     def __init__(self, span=None):
         self.span = span
         self.propagator = (
-            trace_context_http_header_format.TraceContextPropagator()
-        )
+            trace_context_http_header_format.TraceContextPropagator())
 
     def current_span(self):
         return self.span

--- a/tests/unit/trace/ext/mysql/test_mysql_trace.py
+++ b/tests/unit/trace/ext/mysql/test_mysql_trace.py
@@ -35,9 +35,8 @@ class Test_mysql_trace(unittest.TestCase):
         patch_wrap = mock.patch(
             'opencensus.trace.ext.mysql.trace.trace.wrap_conn',
             side_effect=mock_wrap)
-        patch_inspect = mock.patch(
-            'opencensus.trace.ext.mysql.trace.inspect',
-            mock_inspect)
+        patch_inspect = mock.patch('opencensus.trace.ext.mysql.trace.inspect',
+                                   mock_inspect)
 
         with patch_wrap, patch_inspect:
             trace.trace_integration()

--- a/tests/unit/trace/ext/postgresql/test_postgresql_trace.py
+++ b/tests/unit/trace/ext/postgresql/test_postgresql_trace.py
@@ -35,9 +35,7 @@ class Test_postgresql_trace(unittest.TestCase):
             'opencensus.trace.ext.postgresql.trace.connect',
             side_effect=mock_connect)
         patch_inspect = mock.patch(
-            'opencensus.trace.ext.postgresql.trace.inspect',
-            mock_inspect)
-
+            'opencensus.trace.ext.postgresql.trace.inspect', mock_inspect)
 
         with patch_connect, patch_inspect:
             trace.trace_integration()
@@ -53,11 +51,9 @@ class Test_postgresql_trace(unittest.TestCase):
         mock_pg_connect.return_value = return_conn
         mock_cursor = mock.Mock(spec=trace.TraceCursor)
         patch_connect = mock.patch(
-            'opencensus.trace.ext.postgresql.trace.pg_connect',
-            mock_pg_connect)
+            'opencensus.trace.ext.postgresql.trace.pg_connect', mock_pg_connect)
         patch_cursor = mock.patch(
-            'opencensus.trace.ext.postgresql.trace.TraceCursor',
-            mock_cursor)
+            'opencensus.trace.ext.postgresql.trace.TraceCursor', mock_cursor)
 
         with patch_connect, patch_cursor:
             trace.connect()
@@ -110,6 +106,7 @@ class Test_postgresql_trace(unittest.TestCase):
         self.assertFalse(mock_tracer.add_attribute_to_current_span.called)
         self.assertFalse(mock_tracer.end_span.called)
 
+
 class TestTraceCursor(unittest.TestCase):
 
     def test_constructor(self):
@@ -140,5 +137,4 @@ class TestTraceCursor(unittest.TestCase):
 
         for func in trace.QUERY_WRAP_METHODS:
             self.assertEqual(
-                getattr(mock_cursor, func, None),
-                wrap_func_name + func)
+                getattr(mock_cursor, func, None), wrap_func_name + func)

--- a/tests/unit/trace/ext/pymysql/test_pymysql_trace.py
+++ b/tests/unit/trace/ext/pymysql/test_pymysql_trace.py
@@ -35,9 +35,8 @@ class Test_pymysql_trace(unittest.TestCase):
         patch_wrap = mock.patch(
             'opencensus.trace.ext.pymysql.trace.trace.wrap_conn',
             side_effect=mock_wrap)
-        patch_inspect = mock.patch(
-            'opencensus.trace.ext.pymysql.trace.inspect',
-            mock_inspect)
+        patch_inspect = mock.patch('opencensus.trace.ext.pymysql.trace.inspect',
+                                   mock_inspect)
 
         with patch_wrap, patch_inspect:
             trace.trace_integration()

--- a/tests/unit/trace/ext/pyramid/test_pyramid_config.py
+++ b/tests/unit/trace/ext/pyramid/test_pyramid_config.py
@@ -19,6 +19,7 @@ from opencensus.trace.ext.pyramid import config
 
 
 class TestPyramidTraceSettings(unittest.TestCase):
+
     def test_trace_settings_default(self):
         registry = mock.Mock()
         registry.settings = {}
@@ -30,7 +31,8 @@ class TestPyramidTraceSettings(unittest.TestCase):
         assert trace_settings.PROPAGATOR == default_config['PROPAGATOR']
 
         default_params = config.DEFAULT_PYRAMID_TRACER_PARAMS
-        assert trace_settings.params['BLACKLIST_PATHS'] == default_params['BLACKLIST_PATHS']
+        assert trace_settings.params['BLACKLIST_PATHS'] == default_params[
+            'BLACKLIST_PATHS']
 
     def test_trace_settings_override(self):
         mock_sampler = mock.Mock()

--- a/tests/unit/trace/ext/pyramid/test_pyramid_middleware.py
+++ b/tests/unit/trace/ext/pyramid/test_pyramid_middleware.py
@@ -35,6 +35,7 @@ from opencensus.trace.tracers import noop_tracer
 
 
 class TestPyramidMiddleware(unittest.TestCase):
+
     def tearDown(self):
         from opencensus.trace import execution_context
 
@@ -54,7 +55,8 @@ class TestPyramidMiddleware(unittest.TestCase):
         mock_registry = mock.Mock(spec=Registry)
         mock_registry.settings = {}
         mock_registry.settings['OPENCENSUS_TRACE'] = {
-            'EXPORTER': print_exporter.PrintExporter()}
+            'EXPORTER': print_exporter.PrintExporter()
+        }
 
         middleware = pyramid_middleware.OpenCensusTweenFactory(
             dummy_handler,
@@ -62,11 +64,9 @@ class TestPyramidMiddleware(unittest.TestCase):
         )
 
         assert isinstance(middleware.sampler, always_on.AlwaysOnSampler)
-        assert isinstance(
-            middleware.exporter, print_exporter.PrintExporter)
-        assert isinstance(
-            middleware.propagator,
-            google_cloud_format.GoogleCloudFormatPropagator)
+        assert isinstance(middleware.exporter, print_exporter.PrintExporter)
+        assert isinstance(middleware.propagator,
+                          google_cloud_format.GoogleCloudFormatPropagator)
 
         # Just a smoke test to make sure things work
         request = DummyRequest(
@@ -91,8 +91,7 @@ class TestPyramidMiddleware(unittest.TestCase):
             service_name=service_name,
             host_name=host_name,
             port=port,
-            transport=sync.SyncTransport
-        )
+            transport=sync.SyncTransport)
 
         mock_registry = mock.Mock(spec=Registry)
         mock_registry.settings = {}
@@ -106,11 +105,9 @@ class TestPyramidMiddleware(unittest.TestCase):
         )
 
         assert isinstance(middleware.sampler, always_on.AlwaysOnSampler)
-        assert isinstance(
-            middleware.exporter, zipkin_exporter.ZipkinExporter)
-        assert isinstance(
-            middleware.propagator,
-            google_cloud_format.GoogleCloudFormatPropagator)
+        assert isinstance(middleware.exporter, zipkin_exporter.ZipkinExporter)
+        assert isinstance(middleware.propagator,
+                          google_cloud_format.GoogleCloudFormatPropagator)
 
         self.assertEqual(middleware.exporter.service_name, service_name)
         self.assertEqual(middleware.exporter.host_name, host_name)

--- a/tests/unit/trace/ext/requests/test_requests_trace.py
+++ b/tests/unit/trace/ext/requests/test_requests_trace.py
@@ -72,7 +72,8 @@ class Test_requests_trace(unittest.TestCase):
         with patch_wrap, patch_requests:
             trace.trace_integration(tracer=TmpTracer())
 
-            self.assertIsInstance(execution_context.get_opencensus_tracer(), TmpTracer)
+            self.assertIsInstance(execution_context.get_opencensus_tracer(),
+                                  TmpTracer)
 
     def test_wrap_requests(self):
         mock_return = mock.Mock()
@@ -95,9 +96,7 @@ class Test_requests_trace(unittest.TestCase):
         with patch:
             wrapped(url)
 
-        expected_attributes = {
-            'http.url': url,
-            'http.status_code': '200'}
+        expected_attributes = {'http.url': url, 'http.status_code': '200'}
         expected_name = '[requests]get'
 
         self.assertEqual(span_module.SpanKind.CLIENT,
@@ -165,9 +164,9 @@ class Test_requests_trace(unittest.TestCase):
     def test_wrap_session_request(self):
         wrapped = mock.Mock(return_value=mock.Mock(status_code=200))
 
-        mock_tracer = MockTracer(propagator=mock.Mock(
-            to_headers=lambda x: {'x-trace': 'some-value'})
-        )
+        mock_tracer = MockTracer(
+            propagator=mock.Mock(
+                to_headers=lambda x: {'x-trace': 'some-value'}))
 
         patch = mock.patch(
             'opencensus.trace.ext.requests.trace.execution_context.'
@@ -179,12 +178,10 @@ class Test_requests_trace(unittest.TestCase):
         kwargs = {}
 
         with patch:
-            trace.wrap_session_request(
-                wrapped, 'Session.request', (request_method, url), kwargs)
+            trace.wrap_session_request(wrapped, 'Session.request',
+                                       (request_method, url), kwargs)
 
-        expected_attributes = {
-            'http.url': url,
-            'http.status_code': '200'}
+        expected_attributes = {'http.url': url, 'http.status_code': '200'}
         expected_name = '[requests]POST'
 
         self.assertEqual(span_module.SpanKind.CLIENT,
@@ -195,14 +192,15 @@ class Test_requests_trace(unittest.TestCase):
         self.assertEqual(expected_name, mock_tracer.current_span.name)
 
     def test_wrap_session_request_blacklist_ok(self):
+
         def wrapped(*args, **kwargs):
             result = mock.Mock()
             result.status_code = 200
             return result
 
-        mock_tracer = MockTracer(propagator=mock.Mock(
-            to_headers=lambda x: {'x-trace': 'some-value'})
-        )
+        mock_tracer = MockTracer(
+            propagator=mock.Mock(
+                to_headers=lambda x: {'x-trace': 'some-value'}))
 
         patch_tracer = mock.patch(
             'opencensus.trace.ext.requests.trace.execution_context.'
@@ -217,13 +215,14 @@ class Test_requests_trace(unittest.TestCase):
         request_method = 'POST'
 
         with patch_tracer, patch_attr:
-            trace.wrap_session_request(
-                wrapped, 'Session.request', (request_method, url), {})
+            trace.wrap_session_request(wrapped, 'Session.request',
+                                       (request_method, url), {})
 
         expected_name = '[requests]POST'
         self.assertEqual(expected_name, mock_tracer.current_span.name)
 
     def test_wrap_session_request_blacklist_nok(self):
+
         def wrapped(*args, **kwargs):
             result = mock.Mock()
             result.status_code = 200
@@ -244,15 +243,15 @@ class Test_requests_trace(unittest.TestCase):
         request_method = 'POST'
 
         with patch_tracer, patch_attr:
-            trace.wrap_session_request(
-                wrapped, 'Session.request', (request_method, url), {})
+            trace.wrap_session_request(wrapped, 'Session.request',
+                                       (request_method, url), {})
         self.assertEqual(None, mock_tracer.current_span)
 
     def test_header_is_passed_in(self):
         wrapped = mock.Mock(return_value=mock.Mock(status_code=200))
-        mock_tracer = MockTracer(propagator=mock.Mock(
-            to_headers=lambda x: {'x-trace': 'some-value'})
-        )
+        mock_tracer = MockTracer(
+            propagator=mock.Mock(
+                to_headers=lambda x: {'x-trace': 'some-value'}))
 
         patch = mock.patch(
             'opencensus.trace.ext.requests.trace.execution_context.'
@@ -264,16 +263,16 @@ class Test_requests_trace(unittest.TestCase):
         kwargs = {}
 
         with patch:
-            trace.wrap_session_request(
-                wrapped, 'Session.request', (request_method, url), kwargs)
+            trace.wrap_session_request(wrapped, 'Session.request',
+                                       (request_method, url), kwargs)
 
         self.assertEqual(kwargs['headers']['x-trace'], 'some-value')
 
     def test_headers_are_preserved(self):
         wrapped = mock.Mock(return_value=mock.Mock(status_code=200))
-        mock_tracer = MockTracer(propagator=mock.Mock(
-            to_headers=lambda x: {'x-trace': 'some-value'})
-        )
+        mock_tracer = MockTracer(
+            propagator=mock.Mock(
+                to_headers=lambda x: {'x-trace': 'some-value'}))
 
         patch = mock.patch(
             'opencensus.trace.ext.requests.trace.execution_context.'
@@ -285,17 +284,17 @@ class Test_requests_trace(unittest.TestCase):
         kwargs = {'headers': {'key': 'value'}}
 
         with patch:
-            trace.wrap_session_request(
-                wrapped, 'Session.request', (request_method, url), kwargs)
+            trace.wrap_session_request(wrapped, 'Session.request',
+                                       (request_method, url), kwargs)
 
         self.assertEqual(kwargs['headers']['key'], 'value')
         self.assertEqual(kwargs['headers']['x-trace'], 'some-value')
 
     def test_tracer_headers_are_overwritten(self):
         wrapped = mock.Mock(return_value=mock.Mock(status_code=200))
-        mock_tracer = MockTracer(propagator=mock.Mock(
-            to_headers=lambda x: {'x-trace': 'some-value'})
-        )
+        mock_tracer = MockTracer(
+            propagator=mock.Mock(
+                to_headers=lambda x: {'x-trace': 'some-value'}))
 
         patch = mock.patch(
             'opencensus.trace.ext.requests.trace.execution_context.'
@@ -307,13 +306,14 @@ class Test_requests_trace(unittest.TestCase):
         kwargs = {'headers': {'x-trace': 'original-value'}}
 
         with patch:
-            trace.wrap_session_request(
-                wrapped, 'Session.request', (request_method, url), kwargs)
+            trace.wrap_session_request(wrapped, 'Session.request',
+                                       (request_method, url), kwargs)
 
         self.assertEqual(kwargs['headers']['x-trace'], 'some-value')
 
 
 class MockTracer(object):
+
     def __init__(self, propagator=None):
         self.current_span = None
         self.span_context = {}

--- a/tests/unit/trace/ext/sqlalchemy/test_sqlalchemy_trace.py
+++ b/tests/unit/trace/ext/sqlalchemy/test_sqlalchemy_trace.py
@@ -67,8 +67,8 @@ class Test_sqlalchemy_trace(unittest.TestCase):
         parameters = 'test'
 
         with patch:
-            trace._before_cursor_execute(None, None, query,
-                                         parameters, None, False)
+            trace._before_cursor_execute(None, None, query, parameters, None,
+                                         False)
 
         expected_attributes = {
             'sqlalchemy.query': query,
@@ -96,8 +96,8 @@ class Test_sqlalchemy_trace(unittest.TestCase):
         parameters = 'test'
 
         with patch:
-            trace._before_cursor_execute(None, None, query,
-                                         parameters, None, True)
+            trace._before_cursor_execute(None, None, query, parameters, None,
+                                         True)
 
         expected_attributes = {
             'sqlalchemy.query': query,
@@ -126,6 +126,7 @@ class Test_sqlalchemy_trace(unittest.TestCase):
 
 
 class MockTracer(object):
+
     def __init__(self):
         self.current_span = None
 

--- a/tests/unit/trace/ext/threading/test_threading_trace.py
+++ b/tests/unit/trace/ext/threading/test_threading_trace.py
@@ -21,11 +21,11 @@ from concurrent.futures import ThreadPoolExecutor
 from opencensus.trace.ext.threading import trace
 from opencensus.trace import execution_context, tracer
 
+
 class Test_threading_trace(unittest.TestCase):
 
     def tearDown(self):
         execution_context.clear()
-
 
     def test_trace_integration(self):
         mock_wrap_start = mock.Mock()
@@ -63,18 +63,17 @@ class Test_threading_trace(unittest.TestCase):
             mock_wrap_apply_async)
         patch_threading = mock.patch(
             'opencensus.trace.ext.threading.trace.threading', mock_threading)
-        patch_pool = mock.patch(
-            'opencensus.trace.ext.threading.trace.pool', mock_pool)
+        patch_pool = mock.patch('opencensus.trace.ext.threading.trace.pool',
+                                mock_pool)
 
         with patch_wrap_start, patch_wrap_run, patch_wrap_apply_async, patch_threading, patch_pool:
             trace.trace_integration()
 
-        self.assertEqual(getattr(mock_threading.Thread, 'start'),
-                         wrap_start_result)
-        self.assertEqual(getattr(mock_threading.Thread, 'run'),
-                         wrap_run_result)
-        self.assertEqual(getattr(mock_pool.Pool, 'apply_async'),
-                         wrap_apply_async_result)
+        self.assertEqual(
+            getattr(mock_threading.Thread, 'start'), wrap_start_result)
+        self.assertEqual(getattr(mock_threading.Thread, 'run'), wrap_run_result)
+        self.assertEqual(
+            getattr(mock_pool.Pool, 'apply_async'), wrap_apply_async_result)
 
     def test_wrap_threading(self):
         global global_tracer
@@ -131,6 +130,7 @@ def fake_pooled_func():
 
 
 class MockTracer(object):
+
     def __init__(self, span=None):
         self.span = span
 

--- a/tests/unit/trace/propagation/test_binary_format.py
+++ b/tests/unit/trace/propagation/test_binary_format.py
@@ -52,9 +52,8 @@ class TestBinaryFormat(unittest.TestCase):
 
         self.assertEqual(span_context.trace_id, expected_trace_id)
         self.assertEqual(span_context.span_id, expected_span_id)
-        self.assertEqual(
-            span_context.trace_options.enabled,
-            expected_trace_option)
+        self.assertEqual(span_context.trace_options.enabled,
+                         expected_trace_option)
 
     def test_to_header_span_id_zero(self):
         from opencensus.trace.span_context import SpanContext

--- a/tests/unit/trace/propagation/test_google_cloud_format.py
+++ b/tests/unit/trace/propagation/test_google_cloud_format.py
@@ -101,7 +101,7 @@ class TestGoogleCloudFormatPropagator(unittest.TestCase):
         # Trace option is enabled.
         headers = {
             'X-Cloud-Trace-Context':
-                '6e0c63257de34c92bf9efcd03927272e/00f067aa0ba902b7;o=1',
+            '6e0c63257de34c92bf9efcd03927272e/00f067aa0ba902b7;o=1',
         }
         expected_trace_id = '6e0c63257de34c92bf9efcd03927272e'
         expected_span_id = '00f067aa0ba902b7'
@@ -127,8 +127,7 @@ class TestGoogleCloudFormatPropagator(unittest.TestCase):
         propagator = google_cloud_format.GoogleCloudFormatPropagator()
 
         header = propagator.to_header(span_context)
-        expected_header = '{}/{};o={}'.format(
-            trace_id, span_id, 1)
+        expected_header = '{}/{};o={}'.format(trace_id, span_id, 1)
 
         self.assertEqual(header, expected_header)
 

--- a/tests/unit/trace/propagation/test_text_format.py
+++ b/tests/unit/trace/propagation/test_text_format.py
@@ -66,15 +66,9 @@ class Test_from_carrier(unittest.TestCase):
         propagator = text_format.TextFormatPropagator()
         carrier = propagator.to_carrier(span_context, carrier)
 
-        self.assertEqual(
-            carrier[text_format._TRACE_ID_KEY],
-            test_trace_id)
-        self.assertEqual(
-            carrier[text_format._SPAN_ID_KEY],
-            str(test_span_id))
-        self.assertEqual(
-            carrier[text_format._TRACE_OPTIONS_KEY],
-            test_options)
+        self.assertEqual(carrier[text_format._TRACE_ID_KEY], test_trace_id)
+        self.assertEqual(carrier[text_format._SPAN_ID_KEY], str(test_span_id))
+        self.assertEqual(carrier[text_format._TRACE_OPTIONS_KEY], test_options)
 
     def test_to_carrier_no_span_id(self):
         test_trace_id = '6e0c63257de34c92bf9efcd03927272e'
@@ -89,11 +83,6 @@ class Test_from_carrier(unittest.TestCase):
         propagator = text_format.TextFormatPropagator()
         carrier = propagator.to_carrier(span_context, carrier)
 
-        self.assertEqual(
-            carrier[text_format._TRACE_ID_KEY],
-            test_trace_id)
-        self.assertIsNone(
-            carrier.get(text_format._SPAN_ID_KEY))
-        self.assertEqual(
-            carrier[text_format._TRACE_OPTIONS_KEY],
-            test_options)
+        self.assertEqual(carrier[text_format._TRACE_ID_KEY], test_trace_id)
+        self.assertIsNone(carrier.get(text_format._SPAN_ID_KEY))
+        self.assertEqual(carrier[text_format._TRACE_OPTIONS_KEY], test_options)

--- a/tests/unit/trace/propagation/test_trace_context_http_header_format.py
+++ b/tests/unit/trace/propagation/test_trace_context_http_header_format.py
@@ -47,8 +47,9 @@ class TestTraceContextPropagator(unittest.TestCase):
 
         span_context = propagator.from_headers({
             'traceparent':
-                '00-12345678901234567890123456789012-1234567890123456-00',
-            'tracestate': 'foo=1,bar=2,baz=3',
+            '00-12345678901234567890123456789012-1234567890123456-00',
+            'tracestate':
+            'foo=1,bar=2,baz=3',
         })
 
         self.assertTrue(isinstance(span_context, SpanContext))
@@ -60,8 +61,9 @@ class TestTraceContextPropagator(unittest.TestCase):
 
         span_context = propagator.from_headers({
             'traceparent':
-                '00-12345678901234567890123456789012-1234567890123456-00',
-            'tracestate': ','.join([
+            '00-12345678901234567890123456789012-1234567890123456-00',
+            'tracestate':
+            ','.join([
                 'a00=0,a01=1,a02=2,a03=3,a04=4,a05=5,a06=6,a07=7,a08=8,a09=9',
                 'b00=0,b01=1,b02=2,b03=3,b04=4,b05=5,b06=6,b07=7,b08=8,b09=9',
                 'c00=0,c01=1,c02=2,c03=3,c04=4,c05=5,c06=6,c07=7,c08=8,c09=9',
@@ -77,8 +79,9 @@ class TestTraceContextPropagator(unittest.TestCase):
 
         span_context = propagator.from_headers({
             'traceparent':
-                '00-12345678901234567890123456789012-1234567890123456-00',
-            'tracestate': 'foo=1,bar=2,foo=3',
+            '00-12345678901234567890123456789012-1234567890123456-00',
+            'tracestate':
+            'foo=1,bar=2,foo=3',
         })
 
         self.assertFalse(span_context.tracestate)
@@ -92,7 +95,7 @@ class TestTraceContextPropagator(unittest.TestCase):
         trace_id = '00000000000000000000000000000000'
         span_context = propagator.from_headers({
             'traceparent':
-                '00-00000000000000000000000000000000-1234567890123456-00',
+            '00-00000000000000000000000000000000-1234567890123456-00',
         })
 
         self.assertNotEqual(span_context.trace_id, trace_id)
@@ -100,7 +103,7 @@ class TestTraceContextPropagator(unittest.TestCase):
         span_id = '0000000000000000'
         span_context = propagator.from_headers({
             'traceparent':
-                '00-12345678901234567890123456789012-0000000000000000-00',
+            '00-12345678901234567890123456789012-0000000000000000-00',
         })
 
         self.assertNotEqual(span_context.span_id, span_id)
@@ -114,14 +117,14 @@ class TestTraceContextPropagator(unittest.TestCase):
         trace_id = '12345678901234567890123456789012'
         span_context = propagator.from_headers({
             'traceparent':
-                'ff-12345678901234567890123456789012-1234567890123456-00',
+            'ff-12345678901234567890123456789012-1234567890123456-00',
         })
 
         self.assertNotEqual(span_context.trace_id, trace_id)
 
         span_context = propagator.from_headers({
             'traceparent':
-                '00-12345678901234567890123456789012-1234567890123456-00-residue',
+            '00-12345678901234567890123456789012-1234567890123456-00-residue',
         })
 
         self.assertNotEqual(span_context.trace_id, trace_id)
@@ -136,7 +139,7 @@ class TestTraceContextPropagator(unittest.TestCase):
         # Trace option is not enabled.
         span_context = propagator.from_headers({
             'traceparent':
-                '00-12345678901234567890123456789012-1234567890123456-00',
+            '00-12345678901234567890123456789012-1234567890123456-00',
         })
 
         self.assertEqual(span_context.trace_id, trace_id)
@@ -146,7 +149,7 @@ class TestTraceContextPropagator(unittest.TestCase):
         # Trace option is enabled.
         span_context = propagator.from_headers({
             'traceparent':
-                '00-12345678901234567890123456789012-1234567890123456-01',
+            '00-12345678901234567890123456789012-1234567890123456-01',
         })
 
         self.assertEqual(span_context.trace_id, trace_id)
@@ -160,7 +163,7 @@ class TestTraceContextPropagator(unittest.TestCase):
         trace_id = 'invalid_trace_id'
         span_context = propagator.from_headers({
             'traceparent':
-                '00-invalid_trace_id-66666-00',
+            '00-invalid_trace_id-66666-00',
         })
 
         self.assertNotEqual(span_context.trace_id, trace_id)
@@ -182,8 +185,8 @@ class TestTraceContextPropagator(unittest.TestCase):
         headers = propagator.to_headers(span_context)
 
         self.assertTrue('traceparent' in headers)
-        self.assertEqual(headers['traceparent'],
-            '00-{}-{}-01'.format(trace_id, span_id_hex))
+        self.assertEqual(headers['traceparent'], '00-{}-{}-01'.format(
+            trace_id, span_id_hex))
 
         self.assertFalse('tracestate' in headers)
 
@@ -206,8 +209,8 @@ class TestTraceContextPropagator(unittest.TestCase):
         headers = propagator.to_headers(span_context)
 
         self.assertTrue('traceparent' in headers)
-        self.assertEqual(headers['traceparent'],
-            '00-{}-{}-01'.format(trace_id, span_id_hex))
+        self.assertEqual(headers['traceparent'], '00-{}-{}-01'.format(
+            trace_id, span_id_hex))
 
         self.assertFalse('tracestate' in headers)
 
@@ -224,14 +227,14 @@ class TestTraceContextPropagator(unittest.TestCase):
         span_context = span_context.SpanContext(
             trace_id=trace_id,
             span_id=span_id_hex,
-            tracestate=Tracestate(foo = "xyz"),
+            tracestate=Tracestate(foo="xyz"),
             trace_options=trace_options.TraceOptions('1'))
 
         headers = propagator.to_headers(span_context)
 
         self.assertTrue('traceparent' in headers)
-        self.assertEqual(headers['traceparent'],
-            '00-{}-{}-01'.format(trace_id, span_id_hex))
+        self.assertEqual(headers['traceparent'], '00-{}-{}-01'.format(
+            trace_id, span_id_hex))
 
         self.assertTrue('tracestate' in headers)
         self.assertEqual(headers['tracestate'], 'foo=xyz')

--- a/tests/unit/trace/samplers/test_always_off.py
+++ b/tests/unit/trace/samplers/test_always_off.py
@@ -14,6 +14,7 @@
 
 import unittest
 
+
 class TestAlwaysOffSampler(unittest.TestCase):
 
     def test_should_sample(self):

--- a/tests/unit/trace/samplers/test_always_on.py
+++ b/tests/unit/trace/samplers/test_always_on.py
@@ -14,6 +14,7 @@
 
 import unittest
 
+
 class TestAlwaysOnSampler(unittest.TestCase):
 
     def test_should_sample(self):

--- a/tests/unit/trace/samplers/test_base_sampler.py
+++ b/tests/unit/trace/samplers/test_base_sampler.py
@@ -14,6 +14,7 @@
 
 import unittest
 
+
 class TestBaseSampler(unittest.TestCase):
 
     def test_should_sample_abstract(self):

--- a/tests/unit/trace/test_attributes.py
+++ b/tests/unit/trace/test_attributes.py
@@ -20,14 +20,13 @@ from opencensus.trace import attributes as attributes_module
 
 
 class TestAttributes(unittest.TestCase):
+
     def test_constructor_default(self):
         attributes = attributes_module.Attributes()
         self.assertEqual(attributes.attributes, {})
 
     def test_constructor_explicit(self):
-        attr = {
-            'key': 'value'
-        }
+        attr = {'key': 'value'}
         attributes = attributes_module.Attributes(attr)
 
         self.assertEqual(attributes.attributes, attr)
@@ -38,29 +37,19 @@ class TestAttributes(unittest.TestCase):
         attributes = attributes_module.Attributes()
         attributes.set_attribute(key=key, value=value)
 
-        expected_attr = {
-            key: value
-        }
+        expected_attr = {key: value}
 
         self.assertEqual(expected_attr, attributes.attributes)
 
     def test_delete_attribute(self):
-        attr = {
-            'key1': 'value1',
-            'key2': 'value2'
-        }
+        attr = {'key1': 'value1', 'key2': 'value2'}
         attributes = attributes_module.Attributes(attr)
         attributes.delete_attribute('key1')
 
-        self.assertEqual(attributes.attributes, {
-            'key2': 'value2'
-        })
-
+        self.assertEqual(attributes.attributes, {'key2': 'value2'})
 
     def test_get_attribute(self):
-        attr = {
-            'key': 'value'
-        }
+        attr = {'key': 'value'}
         attributes = attributes_module.Attributes(attr)
         value = attributes.get_attribute('key')
 
@@ -100,9 +89,7 @@ class TestAttributes(unittest.TestCase):
             'key1': mock.Mock(),
         }
 
-        expected_json = {
-            'attributeMap': {}
-        }
+        expected_json = {'attributeMap': {}}
 
         attributes = attributes_module.Attributes(attrs)
         attributes_json = attributes.format_attributes_json()

--- a/tests/unit/trace/test_base_span.py
+++ b/tests/unit/trace/test_base_span.py
@@ -35,6 +35,7 @@ class TestBaseSpan(unittest.TestCase):
         span = BaseSpan()
 
         with self.assertRaises(NotImplementedError):
+
             @BaseSpan.on_create
             def callback(span):
                 pass
@@ -97,5 +98,3 @@ class TestBaseSpan(unittest.TestCase):
 
         with self.assertRaises(NotImplementedError):
             span.__exit__(None, None, None)
-
-

--- a/tests/unit/trace/test_blank_span.py
+++ b/tests/unit/trace/test_blank_span.py
@@ -75,7 +75,8 @@ class TestBlankSpan(unittest.TestCase):
             'endTime': None,
             'displayName': {
                 'truncated_byte_count': 0,
-                'value': 'test_span_name'},
+                'value': 'test_span_name'
+            },
             'childSpanCount': 0,
         }
         span_json = format_span_json(span)
@@ -157,9 +158,11 @@ class TestBlankSpan(unittest.TestCase):
         span = self._make_one('span1')
         self.assertFalse(self.on_create_called)
         try:
+
             @BlankSpan.on_create
             def callback(span):
                 self.on_create_called = True
+
             span = self._make_one('span2')
         finally:
             BlankSpan._on_create_callbacks = []

--- a/tests/unit/trace/test_config_integration.py
+++ b/tests/unit/trace/test_config_integration.py
@@ -32,15 +32,13 @@ class Test_trace_integrations(unittest.TestCase):
         mock_module = mock.Mock()
         mock_importlib = mock.Mock()
         mock_importlib.import_module.return_value = mock_module
-        patch = mock.patch(
-            'opencensus.trace.config_integration.importlib',
-            mock_importlib)
+        patch = mock.patch('opencensus.trace.config_integration.importlib',
+                           mock_importlib)
 
         integration_list = ['mysql', 'postgresql']
 
         with patch:
-            integrated = config_integration.trace_integrations(
-                integration_list)
+            integrated = config_integration.trace_integrations(integration_list)
 
         self.assertTrue(mock_module.trace_integration.called)
         self.assertEqual(integrated, integration_list)

--- a/tests/unit/trace/test_execution_context.py
+++ b/tests/unit/trace/test_execution_context.py
@@ -53,18 +53,22 @@ class Test__get_opencensus_attr(unittest.TestCase):
 
         self.assertEqual(mock_tracer_get, tracer)
         self.assertEqual(mock_span_get, span)
-        self.assertEqual({"test":"test_value"}, attrs)
+        self.assertEqual({"test": "test_value"}, attrs)
 
         mock_tracer_set = mock.Mock()
         mock_span_set = mock.Mock()
 
-        execution_context.set_opencensus_full_context(mock_tracer_set, mock_span_set, None)
-        self.assertEqual(mock_tracer_set, execution_context.get_opencensus_tracer())
+        execution_context.set_opencensus_full_context(mock_tracer_set,
+                                                      mock_span_set, None)
+        self.assertEqual(mock_tracer_set,
+                         execution_context.get_opencensus_tracer())
         self.assertEqual(mock_span_set, execution_context.get_current_span())
         self.assertEqual({}, execution_context.get_opencensus_attrs())
 
-        execution_context.set_opencensus_full_context(mock_tracer_set, mock_span_set, {"test": "test_value"})
-        self.assertEqual("test_value", execution_context.get_opencensus_attr("test"))
+        execution_context.set_opencensus_full_context(
+            mock_tracer_set, mock_span_set, {"test": "test_value"})
+        self.assertEqual("test_value",
+                         execution_context.get_opencensus_attr("test"))
 
     def test_clean_tracer(self):
         mock_tracer = mock.Mock()
@@ -76,8 +80,10 @@ class Test__get_opencensus_attr(unittest.TestCase):
 
         execution_context.clean()
 
-        self.assertNotEqual(mock_tracer, execution_context.get_opencensus_tracer())
-        self.assertEqual(some_value, getattr(thread_local, 'random_non_oc_attr'))
+        self.assertNotEqual(mock_tracer,
+                            execution_context.get_opencensus_tracer())
+        self.assertEqual(some_value, getattr(thread_local,
+                                             'random_non_oc_attr'))
 
     def test_clean_span(self):
         mock_span = mock.Mock()
@@ -90,10 +96,5 @@ class Test__get_opencensus_attr(unittest.TestCase):
         execution_context.clean()
 
         self.assertNotEqual(mock_span, execution_context.get_current_span())
-        self.assertEqual(some_value, getattr(thread_local, 'random_non_oc_attr'))
-
-
-
-
-
-
+        self.assertEqual(some_value, getattr(thread_local,
+                                             'random_non_oc_attr'))

--- a/tests/unit/trace/test_link.py
+++ b/tests/unit/trace/test_link.py
@@ -20,6 +20,7 @@ from opencensus.trace import link as link_module
 
 
 class TestLink(unittest.TestCase):
+
     def test_constructor_default(self):
         trace_id = 'test trace id'
         span_id = 'test span id'
@@ -27,9 +28,7 @@ class TestLink(unittest.TestCase):
         attributes = mock.Mock()
 
         link = link_module.Link(
-            trace_id=trace_id,
-            span_id=span_id,
-            attributes=attributes)
+            trace_id=trace_id, span_id=span_id, attributes=attributes)
 
         self.assertEqual(link.trace_id, trace_id)
         self.assertEqual(link.span_id, span_id)
@@ -52,7 +51,6 @@ class TestLink(unittest.TestCase):
         self.assertEqual(link.span_id, span_id)
         self.assertEqual(link.type, type)
         self.assertEqual(link.attributes, attributes)
-
 
     def test_format_link_json_with_attributes(self):
         trace_id = 'test trace id'
@@ -82,10 +80,7 @@ class TestLink(unittest.TestCase):
         span_id = 'test span id'
         type = link_module.Type.CHILD_LINKED_SPAN
 
-        link = link_module.Link(
-            trace_id=trace_id,
-            span_id=span_id,
-            type=type)
+        link = link_module.Link(trace_id=trace_id, span_id=span_id, type=type)
 
         link_json = link.format_link_json()
 

--- a/tests/unit/trace/test_span.py
+++ b/tests/unit/trace/test_span.py
@@ -41,8 +41,7 @@ class TestSpan(unittest.TestCase):
         span_name = 'test_span_name'
 
         patch = mock.patch(
-            'opencensus.trace.span.generate_span_id',
-            return_value=span_id)
+            'opencensus.trace.span.generate_span_id', return_value=span_id)
 
         with patch:
             span = self._make_one(span_name)
@@ -108,8 +107,7 @@ class TestSpan(unittest.TestCase):
         root_span._child_spans = []
 
         patch = mock.patch(
-            'opencensus.trace.span.generate_span_id',
-            return_value=span_id)
+            'opencensus.trace.span.generate_span_id', return_value=span_id)
 
         with patch:
             with root_span:
@@ -161,8 +159,8 @@ class TestSpan(unittest.TestCase):
         self.assertEqual(len(span.time_events), 1)
         a0 = span.time_events[0].annotation
         self.assertEqual(a0.description, 'This is a test')
-        self.assertEqual(a0.attributes.attributes,
-                         dict(name='octo-span', age=98))
+        self.assertEqual(a0.attributes.attributes, dict(
+            name='octo-span', age=98))
 
     def test_add_link(self):
         from opencensus.trace.link import Link
@@ -219,9 +217,11 @@ class TestSpan(unittest.TestCase):
         span = self._make_one('span1')
         self.assertFalse(self.on_create_called)
         try:
+
             @Span.on_create
             def callback(span):
                 self.on_create_called = True
+
             span = self._make_one('span2')
         finally:
             Span._on_create_callbacks = []
@@ -264,16 +264,12 @@ class TestSpan(unittest.TestCase):
 
         stack_frame = stack_trace.stack_frames[0]
         self.assertEqual(stack_frame['file_name']['value'], __file__)
-        self.assertEqual(
-            stack_frame['function_name']['value'], 'test_exception_in_span'
-        )
-        self.assertEqual(
-            stack_frame['load_module']['module']['value'], __file__
-        )
-        self.assertEqual(
-            stack_frame['original_function_name']['value'],
-            'test_exception_in_span'
-        )
+        self.assertEqual(stack_frame['function_name']['value'],
+                         'test_exception_in_span')
+        self.assertEqual(stack_frame['load_module']['module']['value'],
+                         __file__)
+        self.assertEqual(stack_frame['original_function_name']['value'],
+                         'test_exception_in_span')
         self.assertIsNotNone(stack_frame['source_version']['value'])
         self.assertIsNotNone(stack_frame['load_module']['build_id']['value'])
 
@@ -312,7 +308,8 @@ class Test_format_span_json(unittest.TestCase):
             'endTime': end_time,
             'displayName': {
                 'truncated_byte_count': 0,
-                'value': 'test span'},
+                'value': 'test span'
+            },
             'childSpanCount': 0,
         }
 
@@ -322,8 +319,8 @@ class Test_format_span_json(unittest.TestCase):
     @mock.patch.object(StackTrace, 'format_stack_trace_json')
     @mock.patch.object(Status, 'format_status_json')
     @mock.patch.object(TimeEvent, 'format_time_event_json')
-    def test_format_span_json_with_parent_span(
-            self, time_event_mock, status_mock, stack_trace_mock):
+    def test_format_span_json_with_parent_span(self, time_event_mock,
+                                               status_mock, stack_trace_mock):
         import datetime
 
         from opencensus.trace.link import Link
@@ -401,12 +398,12 @@ class Test_format_span_json(unittest.TestCase):
             'stackTrace': mock_stack_trace,
             'status': mock_status,
             'timeEvents': {
-                'timeEvent':
-                    [mock_time_event]
+                'timeEvent': [mock_time_event]
             },
             'displayName': {
                 'truncated_byte_count': 0,
-                'value': 'test span'},
+                'value': 'test span'
+            },
             'childSpanCount': 0,
             'sameProcessAsParentSpan': True
         }

--- a/tests/unit/trace/test_span_context.py
+++ b/tests/unit/trace/test_span_context.py
@@ -32,9 +32,7 @@ class TestSpanContext(unittest.TestCase):
 
     def test_constructor(self):
         span_context = self._make_one(
-            trace_id=self.trace_id,
-            span_id=self.span_id
-        )
+            trace_id=self.trace_id, span_id=self.span_id)
 
         self.assertEqual(span_context.trace_id, self.trace_id)
         self.assertEqual(span_context.span_id, self.span_id)
@@ -55,65 +53,47 @@ class TestSpanContext(unittest.TestCase):
         self.assertEqual(expected_repr, span_context.__repr__())
 
     def test_check_span_id_none(self):
-        span_context = self._make_one(
-            trace_id=self.trace_id,
-            from_header=True)
+        span_context = self._make_one(trace_id=self.trace_id, from_header=True)
         self.assertIsNone(span_context.span_id)
 
     def test_check_span_id_zero(self):
         span_context = self._make_one(
             from_header=True,
             trace_id=self.trace_id,
-            span_id=span_context_module.INVALID_SPAN_ID
-        )
+            span_id=span_context_module.INVALID_SPAN_ID)
         self.assertFalse(span_context.from_header)
         self.assertIsNone(span_context.span_id)
 
     def test_check_span_id_not_str(self):
         with self.assertRaises(AssertionError):
-            self._make_one(
-                from_header=True,
-                trace_id=self.trace_id,
-                span_id={}
-            )
+            self._make_one(from_header=True, trace_id=self.trace_id, span_id={})
 
     def test_check_span_id_valid(self):
         span_context = self._make_one(
-            from_header=True,
-            trace_id=self.trace_id,
-            span_id=self.span_id
-        )
+            from_header=True, trace_id=self.trace_id, span_id=self.span_id)
         self.assertEqual(span_context.span_id, self.span_id)
 
     def test_check_trace_id_invalid(self):
         span_context = self._make_one(
             from_header=True,
             trace_id=span_context_module._INVALID_TRACE_ID,
-            span_id=self.span_id
-        )
+            span_id=self.span_id)
 
         self.assertFalse(span_context.from_header)
-        self.assertNotEqual(
-            span_context.trace_id, span_context_module._INVALID_TRACE_ID
-        )
+        self.assertNotEqual(span_context.trace_id,
+                            span_context_module._INVALID_TRACE_ID)
 
     def test_check_trace_id_invalid_format(self):
         trace_id_test = 'test_trace_id'
         span_context = self._make_one(
-            from_header=True,
-            trace_id=trace_id_test,
-            span_id=self.span_id
-        )
+            from_header=True, trace_id=trace_id_test, span_id=self.span_id)
 
         self.assertFalse(span_context.from_header)
         self.assertNotEqual(span_context.trace_id, trace_id_test)
 
     def test_check_trace_id_valid_format(self):
         span_context = self._make_one(
-            from_header=True,
-            trace_id=self.trace_id,
-            span_id=self.span_id
-        )
+            from_header=True, trace_id=self.trace_id, span_id=self.span_id)
 
         self.assertEqual(span_context.trace_id, self.trace_id)
         self.assertTrue(span_context.from_header)
@@ -121,10 +101,7 @@ class TestSpanContext(unittest.TestCase):
     def test_check_span_id_invalid_format(self):
         span_id_test = 'test_trace_id'
         span_context = self._make_one(
-            from_header=True,
-            trace_id=self.trace_id,
-            span_id=span_id_test
-        )
+            from_header=True, trace_id=self.trace_id, span_id=span_id_test)
 
         self.assertFalse(span_context.from_header)
         self.assertIsNone(span_context.span_id)

--- a/tests/unit/trace/test_span_data.py
+++ b/tests/unit/trace/test_span_data.py
@@ -24,6 +24,7 @@ from opencensus.trace import time_event
 
 
 class TestSpanData(unittest.TestCase):
+
     def test_create_span_data(self):
         span_data_module.SpanData(
             name='root',
@@ -70,9 +71,7 @@ class TestSpanData(unittest.TestCase):
         span_data = span_data_module.SpanData(
             name='root',
             context=span_context.SpanContext(
-                trace_id=trace_id,
-                span_id='6e0c63257de34c92'
-            ),
+                trace_id=trace_id, span_id='6e0c63257de34c92'),
             span_id='6e0c63257de34c92',
             parent_span_id='6e0c63257de34c93',
             attributes={'key1': 'value1'},
@@ -82,9 +81,7 @@ class TestSpanData(unittest.TestCase):
             links=[link.Link('1111', span_id='6e0c63257de34c92')],
             status=status.Status(code=0, message='pok'),
             time_events=[
-                time_event.TimeEvent(
-                    timestamp=datetime.datetime(1970, 1, 1)
-                )
+                time_event.TimeEvent(timestamp=datetime.datetime(1970, 1, 1))
             ],
             same_process_as_parent_span=False,
             child_span_count=0,

--- a/tests/unit/trace/test_stack_trace.py
+++ b/tests/unit/trace/test_stack_trace.py
@@ -21,6 +21,7 @@ from opencensus.trace import stack_trace as stack_trace_module
 
 
 class TestStackFrame(unittest.TestCase):
+
     def test_constructor(self):
         func_name = 'func name'
         original_func_name = 'original func name'
@@ -32,14 +33,8 @@ class TestStackFrame(unittest.TestCase):
         source_version = 'source version'
 
         stack_frame = stack_trace_module.StackFrame(
-            func_name,
-            original_func_name,
-            file_name,
-            line_num,
-            col_num,
-            load_module,
-            build_id,
-            source_version)
+            func_name, original_func_name, file_name, line_num, col_num,
+            load_module, build_id, source_version)
 
         self.assertEqual(stack_frame.func_name, func_name)
         self.assertEqual(stack_frame.original_func_name, original_func_name)
@@ -61,21 +56,14 @@ class TestStackFrame(unittest.TestCase):
         source_version = 'source version'
 
         stack_frame = stack_trace_module.StackFrame(
-            func_name,
-            original_func_name,
-            file_name,
-            line_num,
-            col_num,
-            load_module,
-            build_id,
-            source_version)
+            func_name, original_func_name, file_name, line_num, col_num,
+            load_module, build_id, source_version)
 
         def mock_get_truncatable_str(str):
             return str
 
-        patch = mock.patch(
-            'opencensus.trace.stack_trace._get_truncatable_str',
-            mock_get_truncatable_str)
+        patch = mock.patch('opencensus.trace.stack_trace._get_truncatable_str',
+                           mock_get_truncatable_str)
 
         expected_stack_frame_json = {
             'function_name': func_name,
@@ -97,6 +85,7 @@ class TestStackFrame(unittest.TestCase):
 
 
 class TestStackTrace(unittest.TestCase):
+
     def test_constructor_default(self):
         hash_id = 1100
         patch = mock.patch(
@@ -122,9 +111,7 @@ class TestStackTrace(unittest.TestCase):
         stack_trace = stack_trace_module.StackTrace(stack_frames, 100)
         self.assertEqual(stack_trace.dropped_frames_count, 1)
         self.assertEqual(
-            len(stack_trace.stack_frames),
-            stack_trace_module.MAX_FRAMES
-        )
+            len(stack_trace.stack_frames), stack_trace_module.MAX_FRAMES)
 
     def test_add_stack_frame(self):
         stack_trace = stack_trace_module.StackTrace()
@@ -140,8 +127,7 @@ class TestStackTrace(unittest.TestCase):
         stack_frame = [mock.Mock()]
 
         stack_trace = stack_trace_module.StackTrace(
-            stack_frames=stack_frame,
-            stack_trace_hash_id=hash_id)
+            stack_frames=stack_frame, stack_trace_hash_id=hash_id)
 
         stack_trace_json = stack_trace.format_stack_trace_json()
 
@@ -158,14 +144,11 @@ class TestStackTrace(unittest.TestCase):
     def test_format_stack_trace_json_without_stack_frame(self):
         hash_id = 1100
 
-        stack_trace = stack_trace_module.StackTrace(
-            stack_trace_hash_id=hash_id)
+        stack_trace = stack_trace_module.StackTrace(stack_trace_hash_id=hash_id)
 
         stack_trace_json = stack_trace.format_stack_trace_json()
 
-        expected_stack_trace_json = {
-            'stack_trace_hash_id': hash_id
-        }
+        expected_stack_trace_json = {'stack_trace_hash_id': hash_id}
 
         self.assertEqual(expected_stack_trace_json, stack_trace_json)
 
@@ -182,27 +165,27 @@ class TestStackTrace(unittest.TestCase):
 
         stack_frame = stack_trace.stack_frames[0]
         self.assertEqual(stack_frame['file_name']['value'], __file__)
-        self.assertEqual(
-            stack_frame['function_name']['value'], 'test_create_from_traceback'
-        )
-        self.assertEqual(
-            stack_frame['load_module']['module']['value'], __file__
-        )
-        self.assertEqual(
-            stack_frame['original_function_name']['value'],
-            'test_create_from_traceback'
-        )
+        self.assertEqual(stack_frame['function_name']['value'],
+                         'test_create_from_traceback')
+        self.assertEqual(stack_frame['load_module']['module']['value'],
+                         __file__)
+        self.assertEqual(stack_frame['original_function_name']['value'],
+                         'test_create_from_traceback')
         self.assertIsNotNone(stack_frame['source_version']['value'])
         self.assertIsNotNone(stack_frame['load_module']['build_id']['value'])
 
     def test_dropped_frames(self):
         """Make sure the limit of 128 frames is enforced"""
+
         def recur(max_depth):
+
             def _recur_helper(depth):
                 if depth >= max_depth:
                     raise AssertionError('reached max depth')
-                _recur_helper(depth+1)
+                _recur_helper(depth + 1)
+
             _recur_helper(0)
+
         try:
             recur(stack_trace_module.MAX_FRAMES)
         except AssertionError:
@@ -212,6 +195,3 @@ class TestStackTrace(unittest.TestCase):
         # total frames should be MAX_FRAMES + 3 (1 for test function,
         # 1 for recursion start, one for exception, MAX_FRAMES in helper)
         self.assertEqual(stack_trace.dropped_frames_count, 3)
-
-
-

--- a/tests/unit/trace/test_status.py
+++ b/tests/unit/trace/test_status.py
@@ -20,6 +20,7 @@ from opencensus.trace import status as status_module
 
 
 class TestStatus(unittest.TestCase):
+
     def test_constructor(self):
         code = 100
         message = 'test message'
@@ -57,10 +58,7 @@ class TestStatus(unittest.TestCase):
         status = status_module.Status(code=code, message=message)
         status_json = status.format_status_json()
 
-        expected_status_json = {
-            'code': code,
-            'message': message
-        }
+        expected_status_json = {'code': code, 'message': message}
 
         self.assertEqual(expected_status_json, status_json)
 

--- a/tests/unit/trace/test_time_event.py
+++ b/tests/unit/trace/test_time_event.py
@@ -20,6 +20,7 @@ from opencensus.trace import time_event as time_event_module
 
 
 class TestAnnotation(unittest.TestCase):
+
     def test_constructor(self):
         description = 'test description'
         attributes = mock.Mock()
@@ -67,14 +68,15 @@ class TestAnnotation(unittest.TestCase):
 
 
 class TestMessageEvent(unittest.TestCase):
+
     def test_constructor_default(self):
         id = '1234'
 
         message_event = time_event_module.MessageEvent(id)
 
         self.assertEqual(message_event.id, id)
-        self.assertEqual(
-            message_event.type, time_event_module.Type.TYPE_UNSPECIFIED)
+        self.assertEqual(message_event.type,
+                         time_event_module.Type.TYPE_UNSPECIFIED)
         self.assertIsNone(message_event.uncompressed_size_bytes)
         self.assertIsNone(message_event.compressed_size_bytes)
 
@@ -83,24 +85,23 @@ class TestMessageEvent(unittest.TestCase):
         type = time_event_module.Type.SENT
         uncompressed_size_bytes = '100'
 
-        message_event = time_event_module.MessageEvent(
-            id, type, uncompressed_size_bytes)
+        message_event = time_event_module.MessageEvent(id, type,
+                                                       uncompressed_size_bytes)
 
         self.assertEqual(message_event.id, id)
-        self.assertEqual(
-            message_event.type, type)
-        self.assertEqual(
-            message_event.uncompressed_size_bytes, uncompressed_size_bytes)
-        self.assertEqual(
-            message_event.compressed_size_bytes, uncompressed_size_bytes)
+        self.assertEqual(message_event.type, type)
+        self.assertEqual(message_event.uncompressed_size_bytes,
+                         uncompressed_size_bytes)
+        self.assertEqual(message_event.compressed_size_bytes,
+                         uncompressed_size_bytes)
 
     def test_format_message_event_json(self):
         id = '1234'
         type = time_event_module.Type.SENT
         uncompressed_size_bytes = '100'
 
-        message_event = time_event_module.MessageEvent(
-            id, type, uncompressed_size_bytes)
+        message_event = time_event_module.MessageEvent(id, type,
+                                                       uncompressed_size_bytes)
 
         expected_message_event_json = {
             'type': type,
@@ -130,15 +131,15 @@ class TestMessageEvent(unittest.TestCase):
 
 
 class TestTimeEvent(unittest.TestCase):
+
     def test_constructor(self):
         import datetime
 
         timestamp = datetime.datetime.utcnow()
         message_event = mock.Mock()
 
-        time_event =  time_event_module.TimeEvent(
-            timestamp=timestamp,
-            message_event=message_event)
+        time_event = time_event_module.TimeEvent(
+            timestamp=timestamp, message_event=message_event)
 
         self.assertEqual(time_event.timestamp, timestamp.isoformat() + 'Z')
         self.assertEqual(time_event.message_event, message_event)
@@ -151,7 +152,7 @@ class TestTimeEvent(unittest.TestCase):
         message_event = mock.Mock()
 
         with self.assertRaises(ValueError):
-            time_event =  time_event_module.TimeEvent(
+            time_event = time_event_module.TimeEvent(
                 timestamp=timestamp,
                 annotation=annotation,
                 message_event=message_event)
@@ -165,8 +166,7 @@ class TestTimeEvent(unittest.TestCase):
         annotation.format_annotation_json.return_value = mock_annotation
 
         time_event = time_event_module.TimeEvent(
-            timestamp=timestamp,
-            annotation=annotation)
+            timestamp=timestamp, annotation=annotation)
 
         time_event_json = time_event.format_time_event_json()
         expected_time_event_json = {
@@ -186,8 +186,7 @@ class TestTimeEvent(unittest.TestCase):
             mock_message_event
 
         time_event = time_event_module.TimeEvent(
-            timestamp=timestamp,
-            message_event=message_event)
+            timestamp=timestamp, message_event=message_event)
 
         time_event_json = time_event.format_time_event_json()
         expected_time_event_json = {

--- a/tests/unit/trace/test_trace_options.py
+++ b/tests/unit/trace/test_trace_options.py
@@ -16,6 +16,7 @@ import unittest
 
 from opencensus.trace import trace_options as trace_opt
 
+
 class TestTraceOptions(unittest.TestCase):
 
     def test_constructor_default(self):

--- a/tests/unit/trace/test_tracer.py
+++ b/tests/unit/trace/test_tracer.py
@@ -34,9 +34,8 @@ class TestTracer(unittest.TestCase):
         assert isinstance(tracer.span_context, SpanContext)
         assert isinstance(tracer.sampler, AlwaysOnSampler)
         assert isinstance(tracer.exporter, print_exporter.PrintExporter)
-        assert isinstance(
-            tracer.propagator,
-            google_cloud_format.GoogleCloudFormatPropagator)
+        assert isinstance(tracer.propagator,
+                          google_cloud_format.GoogleCloudFormatPropagator)
         assert isinstance(tracer.tracer, context_tracer.ContextTracer)
 
     def test_constructor_explicit(self):
@@ -75,7 +74,7 @@ class TestTracer(unittest.TestCase):
         self.assertFalse(sampled)
 
     def test_should_sample_sampled(self):
-        sampler =mock.Mock()
+        sampler = mock.Mock()
         sampler.should_sample.return_value = True
         tracer = tracer_module.Tracer(sampler=sampler)
         sampled = tracer.should_sample()
@@ -203,8 +202,7 @@ class TestTracer(unittest.TestCase):
         span_context = mock.Mock()
         span_context.trace_options.enabled = False
         tracer = tracer_module.Tracer(
-            sampler=sampler,
-            span_context=span_context)
+            sampler=sampler, span_context=span_context)
 
         tracer.end_span()
 
@@ -221,12 +219,11 @@ class TestTracer(unittest.TestCase):
         span.time_events = []
         span.links = []
         span.children = []
-        span.__iter__ = mock.Mock(
-            return_value=iter([span]))
+        span.__iter__ = mock.Mock(return_value=iter([span]))
         execution_context.set_current_span(span)
 
-        patch = mock.patch(
-            'opencensus.trace.span._get_truncatable_str', mock.Mock())
+        patch = mock.patch('opencensus.trace.span._get_truncatable_str',
+                           mock.Mock())
 
         with patch:
             tracer.end_span()

--- a/tests/unit/trace/test_tracestate.py
+++ b/tests/unit/trace/test_tracestate.py
@@ -21,6 +21,7 @@ from opencensus.trace.propagation.tracestate_string_format \
 
 formatter = TracestateStringFormatter()
 
+
 class TestTracestate(unittest.TestCase):
 
     def test_ctor_no_arg(self):
@@ -38,8 +39,8 @@ class TestTracestate(unittest.TestCase):
     def test_all_allowed_chars(self):
         header = ''.join([
             # key
-            ''.join(map(chr, range(0x61, 0x7A + 1))), # lcalpha
-            '0123456789', # DIGIT
+            ''.join(map(chr, range(0x61, 0x7A + 1))),  # lcalpha
+            '0123456789',  # DIGIT
             '_',
             '-',
             '*',
@@ -145,4 +146,5 @@ class TestTracestate(unittest.TestCase):
 
         state['foo'] = 'x' * 256
         # throw if value exceeds 256 bytes
-        self.assertRaises(ValueError, lambda: state.__setitem__('foo', 'x' * 257))
+        self.assertRaises(ValueError,
+                          lambda: state.__setitem__('foo', 'x' * 257))

--- a/tests/unit/trace/test_utils.py
+++ b/tests/unit/trace/test_utils.py
@@ -23,14 +23,12 @@ from opencensus.trace import utils
 
 
 class TestUtils(unittest.TestCase):
+
     def test__get_truncatable_str(self):
         str_to_convert = 'test string'
         truncatable_str = utils._get_truncatable_str(str_to_convert)
 
-        expected_str = {
-            'value': str_to_convert,
-            'truncated_byte_count': 0
-        }
+        expected_str = {'value': str_to_convert, 'truncated_byte_count': 0}
 
         self.assertEqual(expected_str, truncatable_str)
 
@@ -42,10 +40,7 @@ class TestUtils(unittest.TestCase):
         with patch:
             truncatable_str = utils._get_truncatable_str(str_to_convert)
 
-        expected_str = {
-            'value': 'lengt',
-            'truncated_byte_count': 10
-        }
+        expected_str = {'value': 'lengt', 'truncated_byte_count': 10}
 
         self.assertEqual(expected_str, truncatable_str)
 

--- a/tests/unit/trace/tracers/test_context_tracer.py
+++ b/tests/unit/trace/tracers/test_context_tracer.py
@@ -136,8 +136,7 @@ class TestContextTracer(unittest.TestCase):
         mock_span.stack_trace = None
         mock_span.time_events = None
         mock_span.attributes = {}
-        mock_span.__iter__ = mock.Mock(
-            return_value=iter([mock_span]))
+        mock_span.__iter__ = mock.Mock(return_value=iter([mock_span]))
         parent_span_id = '6e0c63257de34c92'
         mock_span.parent_span.span_id = parent_span_id
         mock_current_span.return_value = mock_span
@@ -160,8 +159,7 @@ class TestContextTracer(unittest.TestCase):
         mock_span.stack_trace = None
         mock_span.time_events = None
         mock_span.attributes = {}
-        mock_span.__iter__ = mock.Mock(
-            return_value=iter([mock_span]))
+        mock_span.__iter__ = mock.Mock(return_value=iter([mock_span]))
         mock_current_span.return_value = mock_span
         tracer.end_span()
 


### PR DESCRIPTION
Run command:
$yapf -i -r --style google .

See https://github.com/google/yapf for details.

Next:
Enable formatter check in our build.

Other changes:
Allow 80 characters per line in flake8.