### PR TITLE
Fix stats example project ID

### DIFF
--- a/examples/stats/exporter/stackdriver.py
+++ b/examples/stats/exporter/stackdriver.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import random
 import time
 
@@ -42,14 +41,11 @@ stats = stats_module.Stats()
 view_manager = stats.view_manager
 stats_recorder = stats.stats_recorder
 
-project_id = os.environ.get('PROJECT_ID')
-if project_id is None:
-    try:
-        _, project_id = google.auth.default()
-    except google.auth.exceptions.DefaultCredentialsError:
-        raise ValueError("Couldn't find Google Cloud credentials, set the "
-                         "project ID with 'gcloud set project' or set the "
-                         "PROJECT_ID env var")
+try:
+    _, project_id = google.auth.default()
+except google.auth.exceptions.DefaultCredentialsError:
+    raise ValueError("Couldn't find Google Cloud credentials, set the "
+                     "project ID with 'gcloud set project'")
 
 exporter = stackdriver.new_stats_exporter(
     stackdriver.Options(project_id=project_id))

--- a/examples/stats/exporter/stackdriver.py
+++ b/examples/stats/exporter/stackdriver.py
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
+import os
 import random
+import time
+
+import google.auth
+
 from opencensus.stats import aggregation as aggregation_module
-from opencensus.stats.exporters import stackdriver_exporter as stackdriver
 from opencensus.stats import measure as measure_module
 from opencensus.stats import stats as stats_module
 from opencensus.stats import view as view_module
+from opencensus.stats.exporters import stackdriver_exporter as stackdriver
 from opencensus.tags import tag_key as tag_key_module
 from opencensus.tags import tag_map as tag_map_module
 from opencensus.tags import tag_value as tag_value_module
@@ -38,8 +42,17 @@ stats = stats_module.Stats()
 view_manager = stats.view_manager
 stats_recorder = stats.stats_recorder
 
+project_id = os.environ.get('PROJECT_ID')
+if project_id is None:
+    try:
+        _, project_id = google.auth.default()
+    except google.auth.exceptions.DefaultCredentialsError:
+        raise ValueError("Couldn't find Google Cloud credentials, set the "
+                         "project ID with 'gcloud set project' or set the "
+                         "PROJECT_ID env var")
+
 exporter = stackdriver.new_stats_exporter(
-    stackdriver.Options(project_id="opencenus-node"))
+    stackdriver.Options(project_id=project_id))
 view_manager.register_exporter(exporter)
 
 # Register view.


### PR DESCRIPTION
Fixes a wart in the stackdriver stats example by fetching the gcloud project ID from the environment if it exists instead of trying to use the "opencensus-node" project. 