### PR TITLE
Fix span batching to stackdriver

### DIFF
--- a/opencensus/trace/exporters/stackdriver_exporter.py
+++ b/opencensus/trace/exporters/stackdriver_exporter.py
@@ -223,7 +223,6 @@ class StackdriverExporter(base.Exporter):
             trace = span_data.format_legacy_trace_json(sds)
             stackdriver_spans.extend(self.translate_to_stackdriver(trace))
 
-        # FIXME: batch up to quota (25000 spans)
         self.client.batch_write_spans(project, {'spans': stackdriver_spans})
 
     def export(self, span_datas):

--- a/tests/unit/trace/exporters/test_stackdriver_exporter.py
+++ b/tests/unit/trace/exporters/test_stackdriver_exporter.py
@@ -200,63 +200,49 @@ class TestStackdriverExporter(unittest.TestCase):
         exporter = stackdriver_exporter.StackdriverExporter(
             client=client, project_id=project_id)
 
-        spans = exporter.translate_to_stackdriver(trace)
+        spans = list(exporter.translate_to_stackdriver(trace))
 
-        expected_traces = {
-            'spans': [{
-                'name':
-                'projects/{}/traces/{}/spans/{}'.format(
+        expected_traces = [{
+            'name': 'projects/{}/traces/{}/spans/{}'.format(
                     project_id, trace_id, span_id),
-                'displayName': {
-                    'value': span_name,
-                    'truncated_byte_count': 0
-                },
-                'attributes': {
-                    'attributeMap': {
-                        'g.co/agent': {
-                            'string_value': {
-                                'truncated_byte_count':
-                                0,
-                                'value':
+            'displayName': {
+                'value': span_name,
+                'truncated_byte_count': 0
+            },
+            'attributes': {
+                'attributeMap': {
+                    'g.co/agent': {
+                        'string_value': {
+                            'truncated_byte_count': 0,
+                            'value':
                                 'opencensus-python [{}]'.format(__version__)
-                            }
-                        },
-                        'key': {
-                            'string_value': {
-                                'truncated_byte_count': 0,
-                                'value': 'value'
-                            }
-                        },
-                        '/http/host': {
-                            'string_value': {
-                                'truncated_byte_count': 0,
-                                'value': 'host'
-                            }
+                        }
+                    },
+                    'key': {
+                        'string_value': {
+                            'truncated_byte_count': 0,
+                            'value': 'value'
+                        }
+                    },
+                    '/http/host': {
+                        'string_value': {
+                            'truncated_byte_count': 0,
+                            'value': 'host'
                         }
                     }
-                },
-                'spanId':
-                str(span_id),
-                'startTime':
-                start_time,
-                'endTime':
-                end_time,
-                'parentSpanId':
-                str(parent_span_id),
-                'status':
-                None,
-                'links':
-                None,
-                'stackTrace':
-                None,
-                'timeEvents':
-                None,
-                'childSpanCount':
-                0,
-                'sameProcessAsParentSpan':
-                None
-            }]
-        }
+                }
+            },
+            'spanId': str(span_id),
+            'startTime': start_time,
+            'endTime': end_time,
+            'parentSpanId': str(parent_span_id),
+            'status': None,
+            'links': None,
+            'stackTrace': None,
+            'timeEvents': None,
+            'childSpanCount': 0,
+            'sameProcessAsParentSpan': None
+        }]
 
         self.assertEqual(spans, expected_traces)
 


### PR DESCRIPTION
Currently every trace is being exported individually, burning through Stackdriver quota.

![screen shot 2018-12-03 at 6 00 29 pm](https://user-images.githubusercontent.com/659440/49476757-17420780-f7d8-11e8-93e2-2a7382e3188e.png)

This change was deployed at 5:46 PM.

@c24t @liyanhui1228 could you take a look?