### PR TITLE
Release 0.1.10

### DIFF
--- a/opencensus/__version__.py
+++ b/opencensus/__version__.py
@@ -1,0 +1,15 @@
+# Copyright 2018, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = '0.1.10'

--- a/opencensus/trace/exporters/ocagent/trace_exporter.py
+++ b/opencensus/trace/exporters/ocagent/trace_exporter.py
@@ -11,31 +11,29 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Export opencensus spans to ocagent"""
 
+from threading import Lock
 import datetime
 import grpc
 import os
 import socket
-from threading import Lock
+
+from opencensus.__version__ import __version__
 from opencensus.trace.exporters import base
-from opencensus.trace.exporters.gen.opencensus.agent.common.v1 import (
-    common_pb2
-)
-from opencensus.trace.exporters.gen.opencensus.agent.trace.v1 import (
-    trace_service_pb2,
-    trace_service_pb2_grpc
-)
+from opencensus.trace.exporters.gen.opencensus.agent.common.v1 \
+    import common_pb2
+from opencensus.trace.exporters.gen.opencensus.agent.trace.v1 \
+    import trace_service_pb2
+from opencensus.trace.exporters.gen.opencensus.agent.trace.v1 \
+    import trace_service_pb2_grpc
 from opencensus.trace.exporters.ocagent import utils
 from opencensus.trace.exporters.transports import sync
 
 # Default agent endpoint
 DEFAULT_ENDPOINT = 'localhost:55678'
 
-# OpenCensus Version
-# TODO: https://github.com/census-instrumentation/opencensus-python/issues/296
-CORE_LIBRARY_VERSION = '0.1.6'
+# OCAgent exporter version
 EXPORTER_VERSION = '0.0.1'
 
 
@@ -91,7 +89,7 @@ class TraceExporter(base.Exporter):
             library_info=common_pb2.LibraryInfo(
                 language=common_pb2.LibraryInfo.Language.Value('PYTHON'),
                 exporter_version=EXPORTER_VERSION,
-                core_library_version=CORE_LIBRARY_VERSION
+                core_library_version=__version__
             ),
             service_info=common_pb2.ServiceInfo(name=self.service_name))
 

--- a/opencensus/trace/exporters/stackdriver_exporter.py
+++ b/opencensus/trace/exporters/stackdriver_exporter.py
@@ -12,23 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from collections import defaultdict
+import os
+
 from google.cloud.trace.client import Client
 
+from opencensus.__version__ import __version__
+from opencensus.common.monitored_resource_util.monitored_resource_util \
+    import MonitoredResourceUtil
 from opencensus.trace import attributes_helper
 from opencensus.trace import span_data
 from opencensus.trace.attributes import Attributes
 from opencensus.trace.exporters import base
 from opencensus.trace.exporters.transports import sync
-from opencensus.common.monitored_resource_util.monitored_resource_util \
-    import MonitoredResourceUtil
 
-# OpenCensus Version
-VERSION = '0.1.9'
 
 # Agent
-AGENT = 'opencensus-python [{}]'.format(VERSION)
+AGENT = 'opencensus-python [{}]'.format(__version__)
 
 # Environment variable set in App Engine when vm:true is set.
 _APPENGINE_FLEXIBLE_ENV_VM = 'GAE_APPENGINE_HOSTNAME'

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,8 +1,8 @@
 Django==1.11.7
 Flask==0.12.3
-google-cloud-monitoring==0.29.0
-google-cloud-trace==0.17.0
-grpcio==1.8.3
+google-cloud-monitoring==0.31.0
+google-cloud-trace==0.20.1
+grpcio==1.16.1
 mock==2.0.0
 mysql-connector==2.1.6
 psycopg2==2.7.3.1

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,10 @@ install_requires = [
     'google-api-core >= 1.0.0, < 2.0.0',
 ]
 
+exec(open("opencensus/__version__.py").read())
 setup(
     name='opencensus',
-    version='0.1.9',
+    version=__version__,  # noqa
     author='OpenCensus Authors',
     author_email='census-developers@googlegroups.com',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -11,19 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """A setup module for Open Source Census Instrumentation Library"""
 
-import io
-from setuptools import setup, find_packages
+from setuptools import find_packages
+from setuptools import setup
 
 extras = {
-    "stackdriver": ['google-cloud-trace>=0.17.0, <0.20'],
+    "stackdriver": ['google-cloud-trace>=0.20.1, <0.30'],
     "prometheus_client": ['prometheus_client==0.3.1']
 }
 
 install_requires = [
-    'google-api-core >= 0.1.1, < 2.0.0',
+    'google-api-core >= 1.0.0, < 2.0.0',
 ]
 
 setup(

--- a/tests/unit/trace/exporters/ocagent/test_trace_exporter.py
+++ b/tests/unit/trace/exporters/ocagent/test_trace_exporter.py
@@ -19,13 +19,11 @@ import os
 import socket
 import unittest
 
-from google.protobuf.timestamp_pb2 import Timestamp
-
+from opencensus.__version__ import __version__
 from opencensus.trace import span_context as span_context_module
 from opencensus.trace import span_data as span_data_module
-from opencensus.trace.exporters.ocagent.trace_exporter import TraceExporter
-from opencensus.trace.exporters.gen.opencensus.agent.trace.v1 import trace_service_pb2
 from opencensus.trace.exporters.gen.opencensus.trace.v1 import trace_config_pb2
+from opencensus.trace.exporters.ocagent.trace_exporter import TraceExporter
 
 
 SERVICE_NAME = 'my-service'
@@ -79,7 +77,8 @@ class TestTraceExporter(unittest.TestCase):
         self.assertEqual(exporter.node.service_info.name, SERVICE_NAME)
         self.assertEqual(exporter.node.library_info.language, 8)
         self.assertIsNotNone(exporter.node.library_info.exporter_version)
-        self.assertIsNotNone(exporter.node.library_info.core_library_version)
+        self.assertEqual(exporter.node.library_info.core_library_version,
+                         __version__)
 
         self.assertEqual(exporter.node.identifier.host_name,
                          socket.gethostname())

--- a/tests/unit/trace/exporters/test_stackdriver_exporter.py
+++ b/tests/unit/trace/exporters/test_stackdriver_exporter.py
@@ -16,6 +16,7 @@ import unittest
 
 import mock
 
+from opencensus.__version__ import __version__
 from opencensus.trace import span_context
 from opencensus.trace import span_data as span_data_module
 from opencensus.trace.exporters import stackdriver_exporter
@@ -106,7 +107,7 @@ class TestStackdriverExporter(unittest.TestCase):
                                 'string_value': {
                                     'truncated_byte_count': 0,
                                     'value': 'opencensus-python [{}]'.format(
-                                        stackdriver_exporter.VERSION
+                                        __version__
                                     )
                                 }
                             }
@@ -211,7 +212,7 @@ class TestStackdriverExporter(unittest.TestCase):
                                 'string_value': {
                                     'truncated_byte_count': 0,
                                     'value': 'opencensus-python [{}]'.format(
-                                        stackdriver_exporter.VERSION
+                                        __version__
                                     )
                                 }
                             },
@@ -569,7 +570,7 @@ class Test_set_attributes_gae(unittest.TestCase):
                         'string_value': {
                             'truncated_byte_count': 0,
                             'value': 'opencensus-python [{}]'.format(
-                                stackdriver_exporter.VERSION
+                                __version__
                             )
                         }
                     },
@@ -635,7 +636,7 @@ class TestMonitoredResourceAttributes(unittest.TestCase):
                         'string_value': {
                             'truncated_byte_count': 0,
                             'value': 'opencensus-python [{}]'.format(
-                                stackdriver_exporter.VERSION
+                                __version__
                             )
                         }
                     },
@@ -720,7 +721,7 @@ class TestMonitoredResourceAttributes(unittest.TestCase):
                         'string_value': {
                             'truncated_byte_count': 0,
                             'value': 'opencensus-python [{}]'.format(
-                                stackdriver_exporter.VERSION
+                                __version__
                             )
                         }
                     },
@@ -773,7 +774,7 @@ class TestMonitoredResourceAttributes(unittest.TestCase):
                         'string_value': {
                             'truncated_byte_count': 0,
                             'value': 'opencensus-python [{}]'.format(
-                                stackdriver_exporter.VERSION
+                                __version__
                             )
                         }
                     },
@@ -820,7 +821,7 @@ class TestMonitoredResourceAttributes(unittest.TestCase):
                         'string_value': {
                             'truncated_byte_count': 0,
                             'value': 'opencensus-python [{}]'.format(
-                                stackdriver_exporter.VERSION
+                                __version__
                             )
                         }
                     }


### PR DESCRIPTION
This diff applies the fix from #429 to the `v0.1.x` branch and creates a new `v0.1.10` release. It fixes a memory leak in the stackdriver exporter. 

See #412 for details on the last release and creation of the `v0.1.x` release branch. 