### PR TITLE
Add extra dependencies for requests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ from setuptools import setup
 
 extras = {
     "stackdriver": ['google-cloud-trace>=0.20.1, <0.30'],
-    "prometheus_client": ['prometheus_client==0.3.1']
+    "prometheus_client": ['prometheus_client==0.3.1'],
+    "requests": ['wrapt==1.10.11']
 }
 
 install_requires = [


### PR DESCRIPTION
The [requests integration](https://github.com/census-instrumentation/opencensus-python/blob/d0fbdb99cd22110d2a1f1e1a9eb0a1b642b87ec0/opencensus/trace/ext/requests/trace.pyurl) doesn't work out of the box because of a missing dependency.

This diff adds a `requests` extra which includes `wrapt` as an optional dependency. The package is only installed if the user installs opencensus as `opencensus[requests]`.

We should consider publishing integrations as separate distributions, e.g. `opencensus-requests`, to prevent an explosion of optional dependencies in the `opencensus` distribution.