### PR TITLE
Fix stackdriver exporter

### DIFF
--- a/opencensus/common/utils.py
+++ b/opencensus/common/utils.py
@@ -86,3 +86,20 @@ def iuniq(ible):
 def uniq(ible):
     """Get a list of unique items of `ible`."""
     return list(iuniq(ible))
+
+
+def window(ible, length):
+    """Split `ible` into multiple lists of length `length`.
+
+    >>> [list(window(range(5), 2)]
+    [[0, 1], [2, 3], [4]]
+    """
+    if length <= 0:  # pragma: NO COVER
+        raise ValueError
+    ible = iter(ible)
+    while True:
+        elts = [xx for ii, xx in zip(range(length), ible)]
+        if elts:
+            yield elts
+        else:
+            break

--- a/opencensus/common/utils.py
+++ b/opencensus/common/utils.py
@@ -91,7 +91,7 @@ def uniq(ible):
 def window(ible, length):
     """Split `ible` into multiple lists of length `length`.
 
-    >>> [list(window(range(5), 2)]
+    >>> list(window(range(5), 2))
     [[0, 1], [2, 3], [4]]
     """
     if length <= 0:  # pragma: NO COVER

--- a/opencensus/stats/exporters/stackdriver_exporter.py
+++ b/opencensus/stats/exporters/stackdriver_exporter.py
@@ -190,7 +190,8 @@ class StackdriverStatsExporter(base.StatsExporter):
                 time_series = next(full_time_series_list, None)
                 if time_series:
                     batch.append(time_series)
-            time_series.append(batch)
+            if batch:
+                time_series_batches.append(batch)
             if len(batch) < batch_size:
                 break
         return time_series_batches
@@ -480,16 +481,6 @@ def remove_non_alphanumeric(text):
     """
     return str(re.sub('[^0-9a-zA-Z ]+', '', text)).replace(" ", "")
 
-
-def as_float(value):
-    """ Converts a value to a float if possible
-          On success, it returns (converted_value, True)
-          On failure, it returns (None, False)
-    """
-    try:
-        return float(value), True
-    except Exception:  # Catch all exception including ValueError
-        return None, False
 
 def metric_labels_from_tags(columns, tag_values):
     return {key: value for key, value in zip(columns, tag_values) if value is not None}

--- a/opencensus/stats/exporters/stackdriver_exporter.py
+++ b/opencensus/stats/exporters/stackdriver_exporter.py
@@ -248,7 +248,7 @@ class StackdriverStatsExporter(base.StatsExporter):
                 if isinstance(v_data.view.measure, measure.MeasureFloat):
                     point.value.double_value = float(agg.value)
             else:
-                raise Exception("unsupported aggregation type: %s" %
+                raise TypeError("Unsupported aggregation type: %s" %
                                 type(v_data.view.aggregation))
 
             start = datetime.strptime(v_data.start_time, EPOCH_PATTERN)

--- a/opencensus/stats/exporters/stackdriver_exporter.py
+++ b/opencensus/stats/exporters/stackdriver_exporter.py
@@ -168,8 +168,9 @@ class StackdriverStatsExporter(base.StatsExporter):
         """ It receives an array of view_data object
             and create time series for each value
         """
+        view_data_set = utils.uniq(view_data)
         time_series_batches = self.create_batched_time_series(
-            view_data, MAX_TIME_SERIES_PER_UPLOAD)
+            view_data_set, MAX_TIME_SERIES_PER_UPLOAD)
         for time_series_batch in time_series_batches:
             self.client.create_time_series(
                 self.client.project_path(self.options.project_id),
@@ -241,6 +242,7 @@ class StackdriverStatsExporter(base.StatsExporter):
                     point.value.int64_value = int(agg.sum_data)
                 if isinstance(v_data.view.measure, measure.MeasureFloat):
                     point.value.double_value = float(agg.sum_data)
+            # TODO: Why is not?????
             elif aggregation_type is not aggregation.Type.LASTVALUE:
                 if isinstance(v_data.view.measure, measure.MeasureInt):
                     point.value.int64_value = int(agg.value)
@@ -260,8 +262,7 @@ class StackdriverStatsExporter(base.StatsExporter):
             secs = point.interval.end_time.seconds
             point.interval.end_time.nanos = int((timestamp_end - secs) * 10**9)
 
-            if aggregation_type is aggregation.Type.LASTVALUE:
-                    LastValueAggregationData:  # pragma: NO COVER
+            if aggregation_type is not aggregation.Type.LASTVALUE:
                 if timestamp_start == timestamp_end:
                     # avoiding start_time and end_time to be equal
                     timestamp_start = timestamp_start - 1

--- a/opencensus/stats/exporters/stackdriver_exporter.py
+++ b/opencensus/stats/exporters/stackdriver_exporter.py
@@ -180,22 +180,11 @@ class StackdriverStatsExporter(base.StatsExporter):
         """ Create the data structure that will be
             sent to Stackdriver Monitoring
         """
-        full_time_series_list = itertools.chain.from_iterable(
+        time_series_list = itertools.chain.from_iterable(
             self.create_time_series_list(
                 v_data, self.options.resource, self.options.metric_prefix)
             for v_data in view_data)
-        time_series_batches = []
-        while True:
-            batch = []
-            for _ in range(batch_size):
-                time_series = next(full_time_series_list, None)
-                if time_series is not None:
-                    batch.append(time_series)
-            if batch:
-                time_series_batches.append(batch)
-            if len(batch) < batch_size:
-                break
-        return time_series_batches
+        return list(utils.window(time_series_list, batch_size))
 
     def create_time_series_list(self, v_data, option_resource_type,
                                 metric_prefix):

--- a/opencensus/stats/exporters/stackdriver_exporter.py
+++ b/opencensus/stats/exporters/stackdriver_exporter.py
@@ -242,12 +242,12 @@ class StackdriverStatsExporter(base.StatsExporter):
                     point.value.int64_value = int(agg.sum_data)
                 if isinstance(v_data.view.measure, measure.MeasureFloat):
                     point.value.double_value = float(agg.sum_data)
-            # TODO: Why is not?????
-            elif aggregation_type is not aggregation.Type.LASTVALUE:
+            elif aggregation_type is aggregation.Type.LASTVALUE:
                 if isinstance(v_data.view.measure, measure.MeasureInt):
                     point.value.int64_value = int(agg.value)
                 elif isinstance(v_data.view.measure, measure.MeasureFloat):
                     point.value.double_value = float(agg.value)
+            # Is this else useful?
             else:
                 point.value.string_value = str(tag_value[0])
 
@@ -431,10 +431,10 @@ def get_task_value():
     """ getTaskValue returns a task label value in the format of
      "py-<pid>@<hostname>".
     """
-    task_value = "py@" + str(os.getpid())
     hostname = platform.uname()[1]
-    task_value += hostname if hostname is not None else "localhost"
-    return task_value
+    if not hostname:
+        hostname = "localhost"
+    return "py-%s@%s" % (os.getpid(), hostname)
 
 
 def namespaced_view_name(view_name, metric_prefix):

--- a/opencensus/stats/exporters/stackdriver_exporter.py
+++ b/opencensus/stats/exporters/stackdriver_exporter.py
@@ -431,10 +431,10 @@ def get_task_value():
     """ getTaskValue returns a task label value in the format of
      "py-<pid>@<hostname>".
     """
+    task_value = "py@" + str(os.getpid())
     hostname = platform.uname()[1]
-    if not hostname:
-        hostname = "localhost"
-    return "py-%s@%s" % (os.getpid(), hostname)
+    task_value += hostname if hostname is not None else "localhost"
+    return task_value
 
 
 def namespaced_view_name(view_name, metric_prefix):

--- a/opencensus/stats/exporters/stackdriver_exporter.py
+++ b/opencensus/stats/exporters/stackdriver_exporter.py
@@ -483,5 +483,5 @@ def remove_non_alphanumeric(text):
 
 
 def metric_labels_from_tags(columns, tag_values):
-    return {key: value for key, value
+    return {remove_non_alphanumeric(key): value for key, value
             in zip(columns, tag_values) if value is not None}

--- a/opencensus/stats/exporters/stackdriver_exporter.py
+++ b/opencensus/stats/exporters/stackdriver_exporter.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import itertools
+import logging
 import os
 import platform
 import re

--- a/opencensus/stats/exporters/stackdriver_exporter.py
+++ b/opencensus/stats/exporters/stackdriver_exporter.py
@@ -247,9 +247,6 @@ class StackdriverStatsExporter(base.StatsExporter):
                     point.value.int64_value = int(agg.value)
                 elif isinstance(v_data.view.measure, measure.MeasureFloat):
                     point.value.double_value = float(agg.value)
-            # Is this else useful?
-            else:
-                point.value.string_value = str(tag_value[0])
 
             start = datetime.strptime(v_data.start_time, EPOCH_PATTERN)
             end = datetime.strptime(v_data.end_time, EPOCH_PATTERN)

--- a/opencensus/stats/exporters/stackdriver_exporter.py
+++ b/opencensus/stats/exporters/stackdriver_exporter.py
@@ -189,7 +189,7 @@ class StackdriverStatsExporter(base.StatsExporter):
             batch = []
             for _ in range(batch_size):
                 time_series = next(full_time_series_list, None)
-                if time_series:
+                if time_series is not None:
                     batch.append(time_series)
             if batch:
                 time_series_batches.append(batch)
@@ -245,8 +245,11 @@ class StackdriverStatsExporter(base.StatsExporter):
             elif aggregation_type is aggregation.Type.LASTVALUE:
                 if isinstance(v_data.view.measure, measure.MeasureInt):
                     point.value.int64_value = int(agg.value)
-                elif isinstance(v_data.view.measure, measure.MeasureFloat):
+                if isinstance(v_data.view.measure, measure.MeasureFloat):
                     point.value.double_value = float(agg.value)
+            else:
+                raise Exception("unsupported aggregation type: %s" %
+                                type(v_data.view.aggregation))
 
             start = datetime.strptime(v_data.start_time, EPOCH_PATTERN)
             end = datetime.strptime(v_data.end_time, EPOCH_PATTERN)

--- a/opencensus/stats/exporters/stackdriver_exporter.py
+++ b/opencensus/stats/exporters/stackdriver_exporter.py
@@ -469,10 +469,9 @@ def set_metric_labels(series, view, tag_values):
             "TagKeys and TagValues don't have same size."
         )  # pragma: NO COVER
 
-    for ii, tag_value in enumerate(tag_values):
-        if tag_value is not None:
-            metric_label = remove_non_alphanumeric(view.columns[ii])
-            series.metric.labels[metric_label] = tag_value
+    for key, value in zip(view.columns, tag_values):
+        if value is not None:
+            series.metric.labels[remove_non_alphanumeric(key)] = value
     series.metric.labels[OPENCENSUS_TASK] = get_task_value()
 
 
@@ -480,8 +479,3 @@ def remove_non_alphanumeric(text):
     """ Remove characters not accepted in labels key
     """
     return str(re.sub('[^0-9a-zA-Z ]+', '', text)).replace(" ", "")
-
-
-def metric_labels_from_tags(columns, tag_values):
-    return {remove_non_alphanumeric(key): value for key, value
-            in zip(columns, tag_values) if value is not None}

--- a/opencensus/stats/exporters/stackdriver_exporter.py
+++ b/opencensus/stats/exporters/stackdriver_exporter.py
@@ -483,4 +483,5 @@ def remove_non_alphanumeric(text):
 
 
 def metric_labels_from_tags(columns, tag_values):
-    return {key: value for key, value in zip(columns, tag_values) if value is not None}
+    return {remove_non_alphanumeric(key): value for key, value
+            in zip(columns, tag_values) if value is not None}

--- a/opencensus/stats/exporters/stackdriver_exporter.py
+++ b/opencensus/stats/exporters/stackdriver_exporter.py
@@ -483,5 +483,5 @@ def remove_non_alphanumeric(text):
 
 
 def metric_labels_from_tags(columns, tag_values):
-    return {remove_non_alphanumeric(key): value for key, value
+    return {key: value for key, value
             in zip(columns, tag_values) if value is not None}

--- a/opencensus/stats/view_data.py
+++ b/opencensus/stats/view_data.py
@@ -81,9 +81,11 @@ class ViewData(object):
 
     def record(self, context, value, timestamp, attachments=None):
         """records the view data against context"""
+        print("context: %s", context.__dict__)
         tag_values = self.get_tag_values(tags=context.map,
                                          columns=self.view.columns)
         tuple_vals = tuple(tag_values)
+        print("tuple vals: %s", tuple_vals)
         if tuple_vals not in self.tag_value_aggregation_data_map:
             self.tag_value_aggregation_data_map[tuple_vals] = copy.deepcopy(
                 self.view.aggregation.aggregation_data)

--- a/opencensus/stats/view_data.py
+++ b/opencensus/stats/view_data.py
@@ -43,6 +43,8 @@ class ViewData(object):
         """the current view in the view data"""
         return self._view
 
+    # TODO: `start_time` and `end_time` are sometimes a `datetime` object but
+    # should always be a `string`.
     @property
     def start_time(self):
         """the current start time in the view data"""

--- a/opencensus/stats/view_data.py
+++ b/opencensus/stats/view_data.py
@@ -81,11 +81,9 @@ class ViewData(object):
 
     def record(self, context, value, timestamp, attachments=None):
         """records the view data against context"""
-        print("context: %s", context.__dict__)
         tag_values = self.get_tag_values(tags=context.map,
                                          columns=self.view.columns)
         tuple_vals = tuple(tag_values)
-        print("tuple vals: %s", tuple_vals)
         if tuple_vals not in self.tag_value_aggregation_data_map:
             self.tag_value_aggregation_data_map[tuple_vals] = copy.deepcopy(
                 self.view.aggregation.aggregation_data)

--- a/tests/unit/stats/exporter/test_stackdriver_stats.py
+++ b/tests/unit/stats/exporter/test_stackdriver_stats.py
@@ -37,6 +37,11 @@ FRONTEND_KEY_FLOAT = tag_key_module.TagKey("my.org/keys/frontend-FLOAT")
 FRONTEND_KEY_INT = tag_key_module.TagKey("my.org/keys/frontend-INT")
 FRONTEND_KEY_STR = tag_key_module.TagKey("my.org/keys/frontend-STR")
 
+FRONTEND_KEY_CLEAN = "myorgkeysfrontend"
+FRONTEND_KEY_FLOAT_CLEAN = "myorgkeysfrontendFLOAT"
+FRONTEND_KEY_INT_CLEAN = "myorgkeysfrontendINT"
+FRONTEND_KEY_STR_CLEAN = "myorgkeysfrontendSTR"
+
 VIDEO_SIZE_MEASURE = measure_module.MeasureInt(
     "my.org/measure/video_size_test2", "size of processed videos", "By")
 VIDEO_SIZE_MEASURE_2 = measure_module.MeasureInt(
@@ -395,7 +400,7 @@ class TestStackdriverStatsExporter(unittest.TestCase):
             time_series_list[0].metric.type,
             "custom.googleapis.com/opencensus/my.org/views/video_size_test2")
         self.assertEquals(dict(time_series.metric.labels),
-                          {FRONTEND_KEY: "1200"})
+                          {FRONTEND_KEY_CLEAN: "1200"})
         self.assertIsNotNone(time_series.resource)
 
         self.assertEquals(len(time_series.points), 1)
@@ -411,7 +416,7 @@ class TestStackdriverStatsExporter(unittest.TestCase):
         self.assertEquals(time_series.metric.type,
                           "kubernetes.io/myorg/my.org/views/video_size_test2")
         self.assertEquals(dict(time_series.metric.labels),
-                          {FRONTEND_KEY: "1200"})
+                          {FRONTEND_KEY_CLEAN: "1200"})
         self.assertIsNotNone(time_series.resource)
 
         self.assertEquals(len(time_series.points), 1)
@@ -582,7 +587,7 @@ class TestStackdriverStatsExporter(unittest.TestCase):
         self.assertEquals(time_series.metric.type,
                           "kubernetes.io/myorg/view-name1")
         self.assertEquals(dict(time_series.metric.labels),
-                          {FRONTEND_KEY_INT: "Abc"})
+                          {FRONTEND_KEY_INT_CLEAN: "Abc"})
         self.assertIsNotNone(time_series.resource)
 
         self.assertEquals(len(time_series.points), 1)
@@ -624,7 +629,7 @@ class TestStackdriverStatsExporter(unittest.TestCase):
         self.assertEquals(time_series.metric.type,
                           "kubernetes.io/myorg/view-name1")
         self.assertEquals(dict(time_series.metric.labels),
-                          {FRONTEND_KEY_FLOAT: "Abc"})
+                          {FRONTEND_KEY_FLOAT_CLEAN: "Abc"})
         self.assertIsNotNone(time_series.resource)
 
         self.assertEquals(len(time_series.points), 1)
@@ -712,7 +717,7 @@ class TestStackdriverStatsExporter(unittest.TestCase):
         self.assertEquals(time_series.metric.type,
                           "custom.googleapis.com/opencensus/view-name2")
         self.assertEquals(dict(time_series.metric.labels),
-                          {FRONTEND_KEY_FLOAT: "1200"})
+                          {FRONTEND_KEY_FLOAT_CLEAN: "1200"})
         self.assertIsNotNone(time_series.resource)
 
         self.assertEquals(len(time_series.points), 1)
@@ -765,7 +770,7 @@ class TestStackdriverStatsExporter(unittest.TestCase):
         self.assertItemsEqual(
             [dict(time_series1.metric.labels),
              dict(time_series2.metric.labels)],
-            [{FRONTEND_KEY: "1200"}, {FRONTEND_KEY: "1400"}])
+            [{FRONTEND_KEY_CLEAN: "1200"}, {FRONTEND_KEY_CLEAN: "1400"}])
         self.assertIsNotNone(time_series1.resource)
         self.assertIsNotNone(time_series2.resource)
 
@@ -818,7 +823,7 @@ class TestStackdriverStatsExporter(unittest.TestCase):
         self.assertEquals(time_series.metric.type,
                           "custom.googleapis.com/opencensus/" + view_name)
         self.assertEquals(dict(time_series.metric.labels),
-                          {FRONTEND_KEY: "1200"})
+                          {FRONTEND_KEY_CLEAN: "1200"})
         self.assertIsNotNone(time_series.resource)
 
         self.assertEquals(len(time_series.points), 1)
@@ -879,7 +884,7 @@ class TestStackdriverStatsExporter(unittest.TestCase):
         [time_series] = time_series_list
 
         self.assertEquals(dict(time_series.metric.labels),
-                          {'tag_key': 'tag_value'})
+                          {'tagkey': 'tag_value'})
         self.assertEqual(len(time_series.points), 1)
         [point] = time_series.points
         dv = point.value.distribution_value

--- a/tests/unit/stats/exporter/test_stackdriver_stats.py
+++ b/tests/unit/stats/exporter/test_stackdriver_stats.py
@@ -383,10 +383,10 @@ class TestStackdriverStatsExporter(unittest.TestCase):
 
         time_series_list = exporter.create_time_series_list(v_data, "", "")
 
-        self.assertEquals(len(time_series_list), 1)
+        self.assertEqual(len(time_series_list), 1)
         time_series = time_series_list[0]
-        self.assertEquals(time_series.resource.type, "global")
-        self.assertEquals(
+        self.assertEqual(time_series.resource.type, "global")
+        self.assertEqual(
             time_series_list[0].metric.type,
             "custom.googleapis.com/opencensus/my.org/views/video_size_test2")
         self.assertCorrectLabels(time_series.metric.labels,
@@ -394,27 +394,27 @@ class TestStackdriverStatsExporter(unittest.TestCase):
                                  include_opencensus=True)
         self.assertIsNotNone(time_series.resource)
 
-        self.assertEquals(len(time_series.points), 1)
+        self.assertEqual(len(time_series.points), 1)
         value = time_series.points[0].value
-        self.assertEquals(value.distribution_value.count, 1)
-        self.assertEquals(value.distribution_value.mean, 25 * MiB)
+        self.assertEqual(value.distribution_value.count, 1)
+        self.assertEqual(value.distribution_value.mean, 25 * MiB)
 
         time_series_list = exporter.create_time_series_list(
             v_data, "global", "kubernetes.io/myorg")
 
-        self.assertEquals(len(time_series_list), 1)
+        self.assertEqual(len(time_series_list), 1)
         time_series = time_series_list[0]
-        self.assertEquals(time_series.metric.type,
-                          "kubernetes.io/myorg/my.org/views/video_size_test2")
+        self.assertEqual(time_series.metric.type,
+                         "kubernetes.io/myorg/my.org/views/video_size_test2")
         self.assertCorrectLabels(time_series.metric.labels,
                                  {FRONTEND_KEY_CLEAN: "1200"},
                                  include_opencensus=True)
         self.assertIsNotNone(time_series.resource)
 
-        self.assertEquals(len(time_series.points), 1)
+        self.assertEqual(len(time_series.points), 1)
         value = time_series.points[0].value
-        self.assertEquals(value.distribution_value.count, 1)
-        self.assertEquals(value.distribution_value.mean, 25 * MiB)
+        self.assertEqual(value.distribution_value.count, 1)
+        self.assertEqual(value.distribution_value.mean, 25 * MiB)
 
     @mock.patch('opencensus.stats.exporters.stackdriver_exporter.'
                 'MonitoredResourceUtil.get_instance')
@@ -450,26 +450,26 @@ class TestStackdriverStatsExporter(unittest.TestCase):
             mocked_labels
 
         time_series_list = exporter.create_time_series_list(v_data, "", "")
-        self.assertEquals(len(time_series_list), 1)
+        self.assertEqual(len(time_series_list), 1)
         time_series = time_series_list[0]
-        self.assertEquals(time_series.resource.type, "gce_instance")
+        self.assertEqual(time_series.resource.type, "gce_instance")
         self.assertCorrectLabels(time_series.resource.labels, {
             'instance_id': 'my-instance',
             'project_id': 'my-project',
             'zone': 'us-east1',
         })
-        self.assertEquals(
+        self.assertEqual(
             time_series.metric.type,
             "custom.googleapis.com/opencensus/my.org/views/video_size_test2")
         self.assertIsNotNone(time_series)
 
         time_series_list = exporter.create_time_series_list(
             v_data, "global", "")
-        self.assertEquals(len(time_series_list), 1)
+        self.assertEqual(len(time_series_list), 1)
         time_series = time_series_list[0]
-        self.assertEquals(time_series.resource.type, "global")
+        self.assertEqual(time_series.resource.type, "global")
         self.assertCorrectLabels(time_series.resource.labels, {})
-        self.assertEquals(
+        self.assertEqual(
             time_series.metric.type,
             "custom.googleapis.com/opencensus/my.org/views/video_size_test2")
 
@@ -489,9 +489,9 @@ class TestStackdriverStatsExporter(unittest.TestCase):
             mocked_labels
 
         time_series_list = exporter.create_time_series_list(v_data, "", "")
-        self.assertEquals(len(time_series_list), 1)
+        self.assertEqual(len(time_series_list), 1)
         time_series = time_series_list[0]
-        self.assertEquals(time_series.resource.type, "k8s_container")
+        self.assertEqual(time_series.resource.type, "k8s_container")
         self.assertCorrectLabels(time_series.resource.labels, {
             'project_id': 'my-project',
             'location': 'us-east1',
@@ -499,7 +499,7 @@ class TestStackdriverStatsExporter(unittest.TestCase):
             'pod_name': 'localhost',
             'namespace_name': 'namespace',
         })
-        self.assertEquals(
+        self.assertEqual(
             time_series.metric.type,
             "custom.googleapis.com/opencensus/my.org/views/video_size_test2")
         self.assertIsNotNone(time_series)
@@ -517,15 +517,15 @@ class TestStackdriverStatsExporter(unittest.TestCase):
             mocked_labels
 
         time_series_list = exporter.create_time_series_list(v_data, "", "")
-        self.assertEquals(len(time_series_list), 1)
+        self.assertEqual(len(time_series_list), 1)
         time_series = time_series_list[0]
-        self.assertEquals(time_series.resource.type, "aws_ec2_instance")
+        self.assertEqual(time_series.resource.type, "aws_ec2_instance")
         self.assertCorrectLabels(time_series.resource.labels, {
             'instance_id': 'my-instance',
             'aws_account': 'my-project',
             'region': 'aws:us-east1',
         })
-        self.assertEquals(
+        self.assertEqual(
             time_series.metric.type,
             "custom.googleapis.com/opencensus/my.org/views/video_size_test2")
         self.assertIsNotNone(time_series)
@@ -537,11 +537,11 @@ class TestStackdriverStatsExporter(unittest.TestCase):
             mock.Mock()
 
         time_series_list = exporter.create_time_series_list(v_data, "", "")
-        self.assertEquals(len(time_series_list), 1)
+        self.assertEqual(len(time_series_list), 1)
         time_series = time_series_list[0]
-        self.assertEquals(time_series.resource.type, 'global')
+        self.assertEqual(time_series.resource.type, 'global')
         self.assertCorrectLabels(time_series.resource.labels, {})
-        self.assertEquals(
+        self.assertEqual(
             time_series.metric.type,
             "custom.googleapis.com/opencensus/my.org/views/video_size_test2")
         self.assertIsNotNone(time_series)
@@ -573,19 +573,19 @@ class TestStackdriverStatsExporter(unittest.TestCase):
 
         time_series_list = exporter.create_time_series_list(
             v_data, "global", "kubernetes.io/myorg/")
-        self.assertEquals(len(time_series_list), 1)
+        self.assertEqual(len(time_series_list), 1)
         time_series = time_series_list[0]
-        self.assertEquals(time_series.metric.type,
-                          "kubernetes.io/myorg/view-name1")
+        self.assertEqual(time_series.metric.type,
+                         "kubernetes.io/myorg/view-name1")
         self.assertCorrectLabels(time_series.metric.labels,
                                  {FRONTEND_KEY_INT_CLEAN: "Abc"},
                                  include_opencensus=True)
         self.assertIsNotNone(time_series.resource)
 
-        self.assertEquals(len(time_series.points), 1)
+        self.assertEqual(len(time_series.points), 1)
         expected_value = monitoring_v3.types.TypedValue()
         expected_value.int64_value = 25 * MiB
-        self.assertEquals(time_series.points[0].value, expected_value)
+        self.assertEqual(time_series.points[0].value, expected_value)
 
     @mock.patch('opencensus.stats.exporters.stackdriver_exporter.'
                 'MonitoredResourceUtil.get_instance',
@@ -615,19 +615,19 @@ class TestStackdriverStatsExporter(unittest.TestCase):
 
         time_series_list = exporter.create_time_series_list(
             v_data, "global", "kubernetes.io/myorg/")
-        self.assertEquals(len(time_series_list), 1)
+        self.assertEqual(len(time_series_list), 1)
         time_series = time_series_list[0]
-        self.assertEquals(time_series.metric.type,
-                          "kubernetes.io/myorg/view-name1")
+        self.assertEqual(time_series.metric.type,
+                         "kubernetes.io/myorg/view-name1")
         self.assertCorrectLabels(time_series.metric.labels,
                                  {FRONTEND_KEY_INT_CLEAN: "Abc"},
                                  include_opencensus=True)
         self.assertIsNotNone(time_series.resource)
 
-        self.assertEquals(len(time_series.points), 1)
+        self.assertEqual(len(time_series.points), 1)
         expected_value = monitoring_v3.types.TypedValue()
         expected_value.int64_value = 3
-        self.assertEquals(time_series.points[0].value, expected_value)
+        self.assertEqual(time_series.points[0].value, expected_value)
 
     @mock.patch('opencensus.stats.exporters.stackdriver_exporter.'
                 'MonitoredResourceUtil.get_instance',
@@ -657,19 +657,19 @@ class TestStackdriverStatsExporter(unittest.TestCase):
 
         time_series_list = exporter.create_time_series_list(
             v_data, "global", "kubernetes.io/myorg")
-        self.assertEquals(len(time_series_list), 1)
+        self.assertEqual(len(time_series_list), 1)
         time_series = time_series_list[0]
-        self.assertEquals(time_series.metric.type,
-                          "kubernetes.io/myorg/view-name2")
+        self.assertEqual(time_series.metric.type,
+                         "kubernetes.io/myorg/view-name2")
         self.assertCorrectLabels(time_series.metric.labels,
                                  {FRONTEND_KEY_FLOAT_CLEAN: "Abc"},
                                  include_opencensus=True)
         self.assertIsNotNone(time_series.resource)
 
-        self.assertEquals(len(time_series.points), 1)
+        self.assertEqual(len(time_series.points), 1)
         expected_value = monitoring_v3.types.TypedValue()
         expected_value.double_value = 25.7 * MiB
-        self.assertEquals(time_series.points[0].value, expected_value)
+        self.assertEqual(time_series.points[0].value, expected_value)
 
     @mock.patch('opencensus.stats.exporters.stackdriver_exporter.'
                 'MonitoredResourceUtil.get_instance',
@@ -712,19 +712,19 @@ class TestStackdriverStatsExporter(unittest.TestCase):
 
         time_series_list = exporter.create_time_series_list(
             v_data, "global", "")
-        self.assertEquals(len(time_series_list), 1)
+        self.assertEqual(len(time_series_list), 1)
         [time_series] = time_series_list
-        self.assertEquals(time_series.metric.type,
-                          "custom.googleapis.com/opencensus/view-name3")
+        self.assertEqual(time_series.metric.type,
+                         "custom.googleapis.com/opencensus/view-name3")
         self.assertCorrectLabels(time_series.metric.labels,
                                  {FRONTEND_KEY_FLOAT_CLEAN: "1200"},
                                  include_opencensus=True)
         self.assertIsNotNone(time_series.resource)
 
-        self.assertEquals(len(time_series.points), 1)
+        self.assertEqual(len(time_series.points), 1)
         expected_value = monitoring_v3.types.TypedValue()
         expected_value.double_value = 2.2 + 25 * MiB
-        self.assertEquals(time_series.points[0].value, expected_value)
+        self.assertEqual(time_series.points[0].value, expected_value)
 
     @mock.patch('opencensus.stats.exporters.stackdriver_exporter.'
                 'MonitoredResourceUtil.get_instance',
@@ -755,7 +755,7 @@ class TestStackdriverStatsExporter(unittest.TestCase):
 
         time_series_list = exporter.create_time_series_list(v_data, "", "")
 
-        self.assertEquals(len(time_series_list), 2)
+        self.assertEqual(len(time_series_list), 2)
         ts_by_frontend = {ts.metric.labels.get(FRONTEND_KEY_CLEAN): ts
                           for ts in time_series_list}
         self.assertEqual(set(ts_by_frontend.keys()), {"1200", "1400"})
@@ -763,28 +763,28 @@ class TestStackdriverStatsExporter(unittest.TestCase):
         ts2 = ts_by_frontend["1400"]
 
         # Verify first time series
-        self.assertEquals(ts1.resource.type, "global")
-        self.assertEquals(
+        self.assertEqual(ts1.resource.type, "global")
+        self.assertEqual(
             ts1.metric.type,
             "custom.googleapis.com/opencensus/my.org/views/video_size_test2")
         self.assertIsNotNone(ts1.resource)
 
         self.assertEqual(len(ts1.points), 1)
         value1 = ts1.points[0].value
-        self.assertEquals(value1.distribution_value.count, 1)
-        self.assertEquals(value1.distribution_value.mean, 25 * MiB)
+        self.assertEqual(value1.distribution_value.count, 1)
+        self.assertEqual(value1.distribution_value.mean, 25 * MiB)
 
         # Verify second time series
-        self.assertEquals(ts2.resource.type, "global")
-        self.assertEquals(
+        self.assertEqual(ts2.resource.type, "global")
+        self.assertEqual(
             ts2.metric.type,
             "custom.googleapis.com/opencensus/my.org/views/video_size_test2")
         self.assertIsNotNone(ts2.resource)
 
-        self.assertEquals(len(ts2.points), 1)
+        self.assertEqual(len(ts2.points), 1)
         value2 = ts2.points[0].value
-        self.assertEquals(value2.distribution_value.count, 1)
-        self.assertEquals(value2.distribution_value.mean, 12 * MiB)
+        self.assertEqual(value2.distribution_value.count, 1)
+        self.assertEqual(value2.distribution_value.mean, 12 * MiB)
 
     @mock.patch('opencensus.stats.exporters.stackdriver_exporter.'
                 'MonitoredResourceUtil.get_instance',
@@ -814,22 +814,22 @@ class TestStackdriverStatsExporter(unittest.TestCase):
 
         time_series_list = exporter.create_time_series_list(v_data, "", "")
 
-        self.assertEquals(len(time_series_list), 1)
+        self.assertEqual(len(time_series_list), 1)
         [time_series] = time_series_list
 
         # Verify first time series
-        self.assertEquals(time_series.resource.type, "global")
-        self.assertEquals(time_series.metric.type,
-                          "custom.googleapis.com/opencensus/" + view_name)
+        self.assertEqual(time_series.resource.type, "global")
+        self.assertEqual(time_series.metric.type,
+                         "custom.googleapis.com/opencensus/" + view_name)
         self.assertCorrectLabels(time_series.metric.labels,
                                  {FRONTEND_KEY_CLEAN: "1200"},
                                  include_opencensus=True)
         self.assertIsNotNone(time_series.resource)
 
-        self.assertEquals(len(time_series.points), 1)
+        self.assertEqual(len(time_series.points), 1)
         expected_value = monitoring_v3.types.TypedValue()
         expected_value.int64_value = 25 * MiB
-        self.assertEquals(time_series.points[0].value, expected_value)
+        self.assertEqual(time_series.points[0].value, expected_value)
 
     def setup_create_timeseries_test(self):
         client = mock.Mock()
@@ -1061,23 +1061,23 @@ class TestStackdriverStatsExporter(unittest.TestCase):
         series = monitoring_v3.types.TimeSeries()
         tag_value = tag_value_module.TagValue("1200")
         stackdriver.set_metric_labels(series, VIDEO_SIZE_VIEW, [tag_value])
-        self.assertEquals(len(series.metric.labels), 2)
+        self.assertEqual(len(series.metric.labels), 2)
 
     def test_set_metric_labels_with_None(self):
         series = monitoring_v3.types.TimeSeries()
         stackdriver.set_metric_labels(series, VIDEO_SIZE_VIEW, [None])
-        self.assertEquals(len(series.metric.labels), 1)
+        self.assertEqual(len(series.metric.labels), 1)
 
     @mock.patch('os.getpid', return_value=12345)
     @mock.patch('platform.uname', return_value=('system', 'node', 'release',
                                                 'version', 'machine',
                                                 'processor'))
     def test_get_task_value_with_hostname(self, mock_uname, mock_pid):
-        self.assertEquals(stackdriver.get_task_value(), "py@12345node")
+        self.assertEqual(stackdriver.get_task_value(), "py@12345node")
 
     @mock.patch('os.getpid', return_value=12345)
     @mock.patch('platform.uname', return_value=('system', None, 'release',
                                                 'version', 'machine',
                                                 'processor'))
     def test_get_task_value_without_hostname(self, mock_uname, mock_pid):
-        self.assertEquals(stackdriver.get_task_value(), "py@12345localhost")
+        self.assertEqual(stackdriver.get_task_value(), "py@12345localhost")

--- a/tests/unit/stats/exporter/test_stackdriver_stats.py
+++ b/tests/unit/stats/exporter/test_stackdriver_stats.py
@@ -752,33 +752,33 @@ class TestStackdriverStatsExporter(unittest.TestCase):
         self.assertEquals(len(time_series_list), 2)
         [time_series1, time_series2] = time_series_list
 
-        # Verify first time series
         self.assertEquals(time_series1.resource.type, "global")
+        self.assertEquals(time_series2.resource.type, "global")
         self.assertEquals(
             time_series1.metric.type,
             "custom.googleapis.com/opencensus/my.org/views/video_size_test2")
-        self.assertEquals(dict(time_series1.metric.labels),
-                          {FRONTEND_KEY: "1200"})
-        self.assertIsNotNone(time_series1.resource)
-
-        self.assertEquals(len(time_series1.points), 1)
-        value = time_series1.points[0].value
-        self.assertEquals(value.distribution_value.count, 1)
-        self.assertEquals(value.distribution_value.mean, 25 * MiB)
-
-        # Verify second time series
-        self.assertEquals(time_series2.resource.type, "global")
         self.assertEquals(
             time_series2.metric.type,
             "custom.googleapis.com/opencensus/my.org/views/video_size_test2")
-        self.assertEquals(dict(time_series2.metric.labels),
-                          {FRONTEND_KEY: "1400"})
+
+        # Order isn't guaranteed, so compare them in a set.
+        self.assertEquals(set(dict(time_series1.metric.labels),
+                              dict(time_series2.metric.labels)),
+                          set({FRONTEND_KEY: "1200"}, {FRONTEND_KEY: "1400"}))
+        self.assertIsNotNone(time_series1.resource)
         self.assertIsNotNone(time_series2.resource)
 
+        self.assertEquals(len(time_series1.points), 1)
         self.assertEquals(len(time_series2.points), 1)
-        value = time_series2.points[0].value
-        self.assertEquals(value.distribution_value.count, 1)
-        self.assertEquals(value.distribution_value.mean, 12 * MiB)
+        value1 = time_series1.points[0].value
+        value2 = time_series2.points[0].value
+        self.assertEquals(value1.distribution_value.count, 1)
+        self.assertEquals(value2.distribution_value.count, 1)
+
+        # Order isn't guaranteed, so compare them in a set.
+        self.assertEquals(set(value1.distribution_value.mean,
+                              value2.distribution_value.mean),
+                          set(12 * MiB, 25 * MiB))
 
     @mock.patch('opencensus.stats.exporters.stackdriver_exporter.'
                 'MonitoredResourceUtil.get_instance',

--- a/tests/unit/stats/exporter/test_stackdriver_stats.py
+++ b/tests/unit/stats/exporter/test_stackdriver_stats.py
@@ -956,7 +956,7 @@ class TestStackdriverStatsExporter(unittest.TestCase):
             options=mock.Mock(),
             client=mock.Mock(),
         )
-        self.assertRaises(Exception, exporter.create_time_series_list,
+        self.assertRaises(TypeError, exporter.create_time_series_list,
                           v_data, "", "")
 
     def test_create_metric_descriptor_count(self):

--- a/tests/unit/stats/exporter/test_stackdriver_stats.py
+++ b/tests/unit/stats/exporter/test_stackdriver_stats.py
@@ -271,7 +271,7 @@ class TestStackdriverStatsExporter(unittest.TestCase):
         if include_opencensus:
             opencensus_tag = actual_labels.pop(stackdriver.OPENCENSUS_TASK)
             self.assertIsNotNone(opencensus_tag)
-            self.assertIn("py-", opencensus_tag)
+            self.assertIn("py@", opencensus_tag)
         self.assertDictEqual(actual_labels, expected_labels)
 
     @mock.patch('opencensus.stats.exporters.stackdriver_exporter.'
@@ -1073,11 +1073,11 @@ class TestStackdriverStatsExporter(unittest.TestCase):
                                                 'version', 'machine',
                                                 'processor'))
     def test_get_task_value_with_hostname(self, mock_uname, mock_pid):
-        self.assertEquals(stackdriver.get_task_value(), "py-12345@node")
+        self.assertEquals(stackdriver.get_task_value(), "py@12345node")
 
     @mock.patch('os.getpid', return_value=12345)
-    @mock.patch('platform.uname', return_value=('system', '', 'release',
+    @mock.patch('platform.uname', return_value=('system', None, 'release',
                                                 'version', 'machine',
                                                 'processor'))
     def test_get_task_value_without_hostname(self, mock_uname, mock_pid):
-        self.assertEquals(stackdriver.get_task_value(), "py-12345@localhost")
+        self.assertEquals(stackdriver.get_task_value(), "py@12345localhost")

--- a/tests/unit/stats/exporter/test_stackdriver_stats.py
+++ b/tests/unit/stats/exporter/test_stackdriver_stats.py
@@ -1041,3 +1041,17 @@ class TestStackdriverStatsExporter(unittest.TestCase):
         series = monitoring_v3.types.TimeSeries()
         stackdriver.set_metric_labels(series, VIDEO_SIZE_VIEW, [None])
         self.assertEquals(len(series.metric.labels), 1)
+
+    @mock.patch('os.getpid', return_value=12345)
+    @mock.patch('platform.uname', return_value=('system', 'node', 'release',
+                                                'version', 'machine',
+                                                'processor'))
+    def test_get_task_value_with_hostname(self, mock_uname, mock_pid):
+        self.assertEquals(stackdriver.get_task_value(), "py-12345@node")
+
+    @mock.patch('os.getpid', return_value=12345)
+    @mock.patch('platform.uname', return_value=('system', '', 'release',
+                                                'version', 'machine',
+                                                'processor'))
+    def test_get_task_value_without_hostname(self, mock_uname, mock_pid):
+        self.assertEquals(stackdriver.get_task_value(), "py-12345@localhost")

--- a/tests/unit/stats/exporter/test_stackdriver_stats.py
+++ b/tests/unit/stats/exporter/test_stackdriver_stats.py
@@ -938,6 +938,27 @@ class TestStackdriverStatsExporter(unittest.TestCase):
         self.assertEqual(rs_ts.points[0].value.int64_value, 10)
         self.assertEqual(bc_ts.points[0].value.int64_value, 20)
 
+    def test_create_timeseries_invalid_aggregation(self):
+        v_data = mock.Mock(spec=view_data_module.ViewData)
+        v_data.view.name = "example.org/base_view"
+        v_data.view.columns = [tag_key_module.TagKey('base_key')]
+        v_data.view.aggregation.aggregation_type = \
+            aggregation_module.Type.NONE
+        v_data.start_time = TEST_TIME
+        v_data.end_time = TEST_TIME
+
+        base_data = aggregation_data_module.BaseAggregationData(10)
+        v_data.tag_value_aggregation_data_map = {
+            (None,): base_data,
+        }
+
+        exporter = stackdriver.StackdriverStatsExporter(
+            options=mock.Mock(),
+            client=mock.Mock(),
+        )
+        self.assertRaises(Exception, exporter.create_time_series_list,
+                          v_data, "", "")
+
     def test_create_metric_descriptor_count(self):
         client = mock.Mock()
         option = stackdriver.Options(

--- a/tests/unit/stats/exporter/test_stackdriver_stats.py
+++ b/tests/unit/stats/exporter/test_stackdriver_stats.py
@@ -767,10 +767,10 @@ class TestStackdriverStatsExporter(unittest.TestCase):
             "custom.googleapis.com/opencensus/my.org/views/video_size_test2")
 
         # Order isn't guaranteed, so compare them in a set.
-        self.assertItemsEqual(
-            [dict(time_series1.metric.labels),
-             dict(time_series2.metric.labels)],
-            [{FRONTEND_KEY_CLEAN: "1200"}, {FRONTEND_KEY_CLEAN: "1400"}])
+        self.assertEqual(
+            {time_series1.metric.labels[FRONTEND_KEY_CLEAN],
+             time_series2.metric.labels[FRONTEND_KEY_CLEAN]},
+            {"1200", "1400"})
         self.assertIsNotNone(time_series1.resource)
         self.assertIsNotNone(time_series2.resource)
 
@@ -782,9 +782,9 @@ class TestStackdriverStatsExporter(unittest.TestCase):
         self.assertEquals(value2.distribution_value.count, 1)
 
         # Order isn't guaranteed, so compare them in a set.
-        self.assertItemsEqual(
-            [value1.distribution_value.mean, value2.distribution_value.mean],
-            [12 * MiB, 25 * MiB])
+        self.assertEqual(
+            {value1.distribution_value.mean, value2.distribution_value.mean},
+            {12 * MiB, 25 * MiB})
 
     @mock.patch('opencensus.stats.exporters.stackdriver_exporter.'
                 'MonitoredResourceUtil.get_instance',

--- a/tests/unit/stats/exporter/test_stackdriver_stats.py
+++ b/tests/unit/stats/exporter/test_stackdriver_stats.py
@@ -762,9 +762,10 @@ class TestStackdriverStatsExporter(unittest.TestCase):
             "custom.googleapis.com/opencensus/my.org/views/video_size_test2")
 
         # Order isn't guaranteed, so compare them in a set.
-        self.assertEquals(set(dict(time_series1.metric.labels),
-                              dict(time_series2.metric.labels)),
-                          set({FRONTEND_KEY: "1200"}, {FRONTEND_KEY: "1400"}))
+        self.assertItemsEqual(
+            [dict(time_series1.metric.labels),
+             dict(time_series2.metric.labels)],
+            [{FRONTEND_KEY: "1200"}, {FRONTEND_KEY: "1400"}])
         self.assertIsNotNone(time_series1.resource)
         self.assertIsNotNone(time_series2.resource)
 
@@ -776,9 +777,9 @@ class TestStackdriverStatsExporter(unittest.TestCase):
         self.assertEquals(value2.distribution_value.count, 1)
 
         # Order isn't guaranteed, so compare them in a set.
-        self.assertEquals(set(value1.distribution_value.mean,
-                              value2.distribution_value.mean),
-                          set(12 * MiB, 25 * MiB))
+        self.assertItemsEqual(
+            [value1.distribution_value.mean, value2.distribution_value.mean],
+            [12 * MiB, 25 * MiB])
 
     @mock.patch('opencensus.stats.exporters.stackdriver_exporter.'
                 'MonitoredResourceUtil.get_instance',

--- a/tests/unit/stats/exporter/test_stackdriver_stats.py
+++ b/tests/unit/stats/exporter/test_stackdriver_stats.py
@@ -699,9 +699,14 @@ class TestStackdriverStatsExporter(unittest.TestCase):
         time_series_list = exporter.create_time_series_list(
             v_data, "global", "")
         self.assertEquals(len(time_series_list), 1)
-        self.assertEquals(time_series_list[0].metric.type,
+        [time_series] = time_series_list
+        self.assertEquals(time_series.metric.type,
                           "custom.googleapis.com/opencensus/view-name3")
-        self.assertIsNotNone(time_series_list)
+
+        self.assertEquals(len(time_series.points), 1)
+        expected_value = monitoring_v3.types.TypedValue()
+        expected_value.double_value = 2.2
+        self.assertEquals(time_series.points[0].value, expected_value)
 
     def test_create_timeseries_from_distribution(self):
         """Check for explicit 0-bound bucket for SD export."""


### PR DESCRIPTION
The main changes here are:
* Send correct point value type, based on aggregation output type
* Set the correct labels for each time series, only adding a singe point per time series

I updated the unit tests to verify this behavior. The only untested piece (I think) is the changes that I made to the batching logic. I didn't run the integration tests so maybe those will catch it, or I can add some more tests. Wanted to get this sent out for a first pass.

[EDIT]
#374 fixed the above main issues. This now fixes the batching logic and makes some other minor changes, as well as adding/expanding unit tests for the exporter