### PR TITLE
Release 0.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.11
+Released 2018-01-16
+
+- Fix a bug in the stackdriver exporter that caused spans to be exported
+  individually
+  ([#425](https://github.com/census-instrumentation/opencensus-python/pull/425))
+- Add this changelog

--- a/opencensus/__version__.py
+++ b/opencensus/__version__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.10'
+__version__ = '0.1.11'

--- a/opencensus/trace/exporters/stackdriver_exporter.py
+++ b/opencensus/trace/exporters/stackdriver_exporter.py
@@ -216,13 +216,15 @@ class StackdriverExporter(base.Exporter):
         for sd in span_datas:
             trace_span_map[sd.context.trace_id] += [sd]
 
+        stackdriver_spans = []
         # Write spans to Stackdriver
         for _, sds in trace_span_map.items():
             # convert to the legacy trace json for easier refactoring
             # TODO: refactor this to use the span data directly
             trace = span_data.format_legacy_trace_json(sds)
-            stackdriver_spans = self.translate_to_stackdriver(trace)
-            self.client.batch_write_spans(project, stackdriver_spans)
+            stackdriver_spans.extend(self.translate_to_stackdriver(trace))
+
+        self.client.batch_write_spans(project, {'spans': stackdriver_spans})
 
     def export(self, span_datas):
         """
@@ -248,7 +250,6 @@ class StackdriverExporter(base.Exporter):
         set_attributes(trace)
         spans_json = trace.get('spans')
         trace_id = trace.get('traceId')
-        spans_list = []
 
         for span in spans_json:
             span_name = 'projects/{}/traces/{}/spans/{}'.format(
@@ -273,10 +274,7 @@ class StackdriverExporter(base.Exporter):
                 parent_span_id = str(span.get('parentSpanId'))
                 span_json['parentSpanId'] = parent_span_id
 
-            spans_list.append(span_json)
-
-        spans = {'spans': spans_list}
-        return spans
+            yield span_json
 
     def map_attributes(self, attribute_map):
         if attribute_map is None:

--- a/tests/unit/trace/exporters/test_stackdriver_exporter.py
+++ b/tests/unit/trace/exporters/test_stackdriver_exporter.py
@@ -195,54 +195,49 @@ class TestStackdriverExporter(unittest.TestCase):
             client=client,
             project_id=project_id)
 
-        spans = exporter.translate_to_stackdriver(trace)
+        spans = list(exporter.translate_to_stackdriver(trace))
 
-        expected_traces = {
-            'spans': [
-                {
-                    'name': 'projects/{}/traces/{}/spans/{}'.format(
-                        project_id, trace_id, span_id),
-                    'displayName': {
-                        'value': span_name,
-                        'truncated_byte_count': 0
-                    },
-                    'attributes': {
-                        'attributeMap': {
-                            'g.co/agent': {
-                                'string_value': {
-                                    'truncated_byte_count': 0,
-                                    'value': 'opencensus-python [{}]'.format(
-                                        __version__
-                                    )
-                                }
-                            },
-                            'key': {
-                                'string_value': {
-                                    'truncated_byte_count': 0,
-                                    'value': 'value'
-                                }
-                            },
-                            '/http/host': {
-                                'string_value': {
-                                    'truncated_byte_count': 0,
-                                    'value': 'host'
-                                }
-                            }
+        expected_traces = [{
+            'name': 'projects/{}/traces/{}/spans/{}'.format(
+                    project_id, trace_id, span_id),
+            'displayName': {
+                'value': span_name,
+                'truncated_byte_count': 0
+            },
+            'attributes': {
+                'attributeMap': {
+                    'g.co/agent': {
+                        'string_value': {
+                            'truncated_byte_count': 0,
+                            'value':
+                                'opencensus-python [{}]'.format(__version__)
                         }
                     },
-                    'spanId': str(span_id),
-                    'startTime': start_time,
-                    'endTime': end_time,
-                    'parentSpanId': str(parent_span_id),
-                    'status': None,
-                    'links': None,
-                    'stackTrace': None,
-                    'timeEvents': None,
-                    'childSpanCount': 0,
-                    'sameProcessAsParentSpan': None
+                    'key': {
+                        'string_value': {
+                            'truncated_byte_count': 0,
+                            'value': 'value'
+                        }
+                    },
+                    '/http/host': {
+                        'string_value': {
+                            'truncated_byte_count': 0,
+                            'value': 'host'
+                        }
+                    }
                 }
-            ]
-        }
+            },
+            'spanId': str(span_id),
+            'startTime': start_time,
+            'endTime': end_time,
+            'parentSpanId': str(parent_span_id),
+            'status': None,
+            'links': None,
+            'stackTrace': None,
+            'timeEvents': None,
+            'childSpanCount': 0,
+            'sameProcessAsParentSpan': None
+        }]
 
         self.assertEqual(spans, expected_traces)
 


### PR DESCRIPTION
This diff applies the fix from #425 to the `v0.1.x` branch and creates a new `v0.1.11` release. It fixes a bug in the stackdriver exporter that caused each span to be exported separately.

This is also the first release to include a changelog. I think it's worth the effort to maintain a changelog, especially as we start supporting more than one (minor) version of the library at a once.

Fixes #441. See #412 for info on the release branch.