### PR TITLE
Stats: Fix recording with None TagMap.

### DIFF
--- a/opencensus/stats/view_data.py
+++ b/opencensus/stats/view_data.py
@@ -83,7 +83,11 @@ class ViewData(object):
 
     def record(self, context, value, timestamp, attachments=None):
         """records the view data against context"""
-        tag_values = self.get_tag_values(tags=context.map,
+        if context is None:
+            tags = dict()
+        else:
+            tags = context.map
+        tag_values = self.get_tag_values(tags=tags,
                                          columns=self.view.columns)
         tuple_vals = tuple(tag_values)
         if tuple_vals not in self.tag_value_aggregation_data_map:

--- a/tests/unit/stats/test_view_data.py
+++ b/tests/unit/stats/test_view_data.py
@@ -293,3 +293,24 @@ class TestViewData(unittest.TestCase):
         self.assertTrue(tuple_vals in view_data.tag_value_aggregation_data_map)
         sum_data = view_data.tag_value_aggregation_data_map.get(tuple_vals)
         self.assertEqual(4, sum_data.sum_data)
+
+    def test_record_with_none_context(self):
+        measure = mock.Mock()
+        sum_aggregation = aggregation_module.SumAggregation()
+        view = view_module.View("test_view", "description", ['key1', 'key2'],
+                                measure, sum_aggregation)
+        start_time = datetime.utcnow()
+        end_time = datetime.utcnow()
+        view_data = view_data_module.ViewData(
+            view=view, start_time=start_time, end_time=end_time)
+        time = datetime.utcnow().isoformat() + 'Z'
+        value = 4
+        view_data.record(
+            context=None, value=value, timestamp=time, attachments=None)
+        tag_values = view_data.get_tag_values(
+            tags={}, columns=view.columns)
+        tuple_vals = tuple(tag_values)
+        self.assertEqual([None, None], tag_values)
+        self.assertTrue(tuple_vals in view_data.tag_value_aggregation_data_map)
+        sum_data = view_data.tag_value_aggregation_data_map.get(tuple_vals)
+        self.assertEqual(4, sum_data.sum_data)


### PR DESCRIPTION
The `record` method takes an optional `TagMap`. If `TagMap` is present, recorded measurements would be broken down by the key-value pairs in it. If not, recorded measurements are dimensionless. See also https://github.com/census-instrumentation/opencensus-specs/blob/master/stats/Record.md#recording-stats.

Currently if we record measurements with none `TagMap`, an error will be raised:
```
tag_values = self.get_tag_values(tags=context.map,
AttributeError: 'NoneType' object has no attribute 'map'
```
Fix this bug by checking if `TagMap` is `None` before using it.