### PR TITLE
Prepare for 0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## 0.2.0
+Released 2018-01-18
+
+- Fix multiple stackdriver and prometheus exporter bugs
+- Increase size of trace batches and change transport behavior on exit
+  ([#452](https://github.com/census-instrumentation/opencensus-python/pull/452))
+
+## 0.1.11
+Released 2018-01-16
+
+- Fix a bug in the stackdriver exporter that caused spans to be exported
+  individually
+  ([#425](https://github.com/census-instrumentation/opencensus-python/pull/425))
+- Add this changelog

--- a/opencensus/__version__.py
+++ b/opencensus/__version__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.8'
+__version__ = '0.2.0'


### PR DESCRIPTION
After merging this change into master I'll create a separate `v0.2.x` release branch on the remote, tag the head commit as `v0.2.0`, and release to PyPI. The release branch will diverge from master as we cherry-pick bugfixes onto it, using the release strategy from #412.

Since the library is still changing quickly I think it makes sense to cut more minor version releases with the expectation that the behavior and API may change between versions. We won't maintain multiple minor versions at once; all new changes including bugfixes will happen on master or the `v.2.x` branch.

Merging this into master also means that the library will report the same version (`0.2.0`) when it's built from source as when it's installed from PyPI. We may want to change the version number on master to avoid this, e.g. to include `dev`.

Fixes #403 and #391.