### PR TITLE
Update version, add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+## Unreleased
+
+## 0.2.0
+Released 2018-01-18
+
+- Fix multiple stackdriver and prometheus exporter bugs
+- Increase size of trace batches and change transport behavior on exit
+  ([#452](https://github.com/census-instrumentation/opencensus-python/pull/452))
+
+## 0.1.11
+Released 2018-01-16
+
+- Fix a bug in the stackdriver exporter that caused spans to be exported
+  individually
+  ([#425](https://github.com/census-instrumentation/opencensus-python/pull/425))
+- Add this changelog

--- a/opencensus/__version__.py
+++ b/opencensus/__version__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.8'
+__version__ = '0.2.dev0'


### PR DESCRIPTION
This PR copies the changelog from #460 and adds an "unreleased" section. Significant changes on master should modify this section, and it should be copied verbatim into a new version-specific section of the changelog on each release. The changelog already exists on both release branches, this PR just adds it to master.

This PR also changes the version number to `0.3.dev0` to indicate that this is the development version of the unreleased `v0.3.0` version of the library.

Another option is to name this version `v0.2.dev0` and increment the version number on master with each patch-level update to the `v0.2.x` branch. This has the benefit of keeping the version numbers consistent across branches, but is potentially confusing since the version on master may include changes that won't be included in a release until the next minor- or major-version update.

Keeping the master version number one minor version ahead of the latest release is also consistent with the guidance in [PEP 440 for development releases](https://www.python.org/dev/peps/pep-0440/#developmental-releases) since development releases are ordered behind regular releases.

We should never upload code from master to PyPI without creating a release branch and updating the version number, so "dev" version numbers should only apply to distributions of the library built from source. Since packaging tools like `pip` use this version number syntax, this change also makes it possible to specify the unreleased version of the library as a dependency, as e.g. `opencensus>0.2`.