### PR TITLE
only attempt to set the span status when a current span is available

### DIFF
--- a/opencensus/trace/ext/flask/flask_middleware.py
+++ b/opencensus/trace/ext/flask/flask_middleware.py
@@ -265,13 +265,15 @@ class FlaskMiddleware(object):
                         code=code_pb2.UNKNOWN,
                         message=str(exception)
                     )
-                    # try attaching the stack trace to the span, only populated if
-                    # the app has 'PROPAGATE_EXCEPTIONS', 'DEBUG', or 'TESTING'
-                    # enabled
+                    # try attaching the stack trace to the span, only populated
+                    # if the app has 'PROPAGATE_EXCEPTIONS', 'DEBUG', or
+                    # 'TESTING' enabled
                     exc_type, _, exc_traceback = sys.exc_info()
                     if exc_traceback is not None:
-                        span.stack_trace = stack_trace.StackTrace.from_traceback(
-                            exc_traceback
+                        span.stack_trace = (
+                            stack_trace.StackTrace.from_traceback(
+                                exc_traceback
+                            )
                         )
 
             tracer.end_span()

--- a/opencensus/trace/ext/flask/flask_middleware.py
+++ b/opencensus/trace/ext/flask/flask_middleware.py
@@ -260,18 +260,19 @@ class FlaskMiddleware(object):
 
             if exception is not None:
                 span = execution_context.get_current_span()
-                span.status = status.Status(
-                    code=code_pb2.UNKNOWN,
-                    message=str(exception)
-                )
-                # try attaching the stack trace to the span, only populated if
-                # the app has 'PROPAGATE_EXCEPTIONS', 'DEBUG', or 'TESTING'
-                # enabled
-                exc_type, _, exc_traceback = sys.exc_info()
-                if exc_traceback is not None:
-                    span.stack_trace = stack_trace.StackTrace.from_traceback(
-                        exc_traceback
+                if span is not None:
+                    span.status = status.Status(
+                        code=code_pb2.UNKNOWN,
+                        message=str(exception)
                     )
+                    # try attaching the stack trace to the span, only populated if
+                    # the app has 'PROPAGATE_EXCEPTIONS', 'DEBUG', or 'TESTING'
+                    # enabled
+                    exc_type, _, exc_traceback = sys.exc_info()
+                    if exc_traceback is not None:
+                        span.stack_trace = stack_trace.StackTrace.from_traceback(
+                            exc_traceback
+                        )
 
             tracer.end_span()
             tracer.finish()

--- a/tests/unit/trace/ext/flask/test_flask_middleware.py
+++ b/tests/unit/trace/ext/flask/test_flask_middleware.py
@@ -39,6 +39,10 @@ from opencensus.trace.span_context import SpanContext
 from opencensus.trace.trace_options import TraceOptions
 
 
+class FlaskTestException(Exception):
+    pass
+
+
 class TestFlaskMiddleware(unittest.TestCase):
 
     @staticmethod
@@ -55,7 +59,7 @@ class TestFlaskMiddleware(unittest.TestCase):
 
         @app.route('/error')
         def error():
-            raise Exception('error')
+            raise FlaskTestException('error')
 
         return app
 
@@ -460,7 +464,7 @@ class TestFlaskMiddleware(unittest.TestCase):
         app = self.create_app()
         app.config['TESTING'] = True
         flask_middleware.FlaskMiddleware(app=app, exporter=mock_exporter)
-        with self.assertRaises(Exception):
+        with self.assertRaises(FlaskTestException):
             app.test_client().get('/error')
 
         exported_spandata = mock_exporter.export.call_args[0][0][0]
@@ -490,7 +494,7 @@ class TestFlaskMiddleware(unittest.TestCase):
 
         middleware.propagator.from_headers = nope
 
-        with self.assertRaises(Exception):
+        with self.assertRaises(FlaskTestException):
             app.test_client().get('/error')
 
         middleware.propagator.from_headers = original_method

--- a/tests/unit/trace/ext/flask/test_flask_middleware.py
+++ b/tests/unit/trace/ext/flask/test_flask_middleware.py
@@ -17,26 +17,28 @@
 
 import unittest
 
+from google.rpc import code_pb2
 import flask
 import mock
-from google.rpc import code_pb2
 
 from opencensus.trace import execution_context
-from opencensus.trace import span_data
 from opencensus.trace import span as span_module
+from opencensus.trace import span_data
 from opencensus.trace import stack_trace
 from opencensus.trace import status
-from opencensus.trace.exporters import print_exporter, stackdriver_exporter, \
-    zipkin_exporter, jaeger_exporter
+from opencensus.trace.blank_span import BlankSpan
+from opencensus.trace.exporters import jaeger_exporter
+from opencensus.trace.exporters import print_exporter
+from opencensus.trace.exporters import stackdriver_exporter
+from opencensus.trace.exporters import zipkin_exporter
 from opencensus.trace.exporters.ocagent import trace_exporter
 from opencensus.trace.ext.flask import flask_middleware
 from opencensus.trace.propagation import google_cloud_format
 from opencensus.trace.samplers import always_off, always_on, ProbabilitySampler
-from opencensus.trace.tracers import base
-from opencensus.trace.tracers import noop_tracer
-from opencensus.trace.blank_span import BlankSpan
 from opencensus.trace.span_context import SpanContext
 from opencensus.trace.trace_options import TraceOptions
+from opencensus.trace.tracers import base
+from opencensus.trace.tracers import noop_tracer
 
 
 class FlaskTestException(Exception):

--- a/tests/unit/trace/ext/flask/test_flask_middleware.py
+++ b/tests/unit/trace/ext/flask/test_flask_middleware.py
@@ -480,6 +480,7 @@ class TestFlaskMiddleware(unittest.TestCase):
         app.config['TESTING'] = True
         middleware = flask_middleware.FlaskMiddleware(app=app, sampler=sampler)
 
+        # TODO: send trace options in header (#465)
         original_method = middleware.propagator.from_headers
 
         def nope(*args, **kwargs):

--- a/tests/unit/trace/ext/flask/test_flask_middleware.py
+++ b/tests/unit/trace/ext/flask/test_flask_middleware.py
@@ -473,7 +473,7 @@ class TestFlaskMiddleware(unittest.TestCase):
         )
         self.assertIsNotNone(exported_spandata.stack_trace.stack_trace_hash_id)
         self.assertNotEqual(exported_spandata.stack_trace.stack_frames, [])
-    
+
     def test_teardown_include_exception_and_traceback_span_disabled(self):
         sampler = always_off.AlwaysOffSampler()
         app = self.create_app()


### PR DESCRIPTION
Hey folks, not sure if this is a great approach but I'll explain how I got here and let you decide.

I've been working with Google support trying to figure out why we're seeing hundreds of thousands of exceptions in Stackdriver Errors that look like this.

```python
exc_info:  "Traceback (most recent call last):
  File "/<our-app-path>/image.binary.runfiles/pypi__opencensus_0_1_8/opencensus/trace/ext/flask/flask_middleware.py", line 255, in _teardown_request
    message=str(exception)
AttributeError: 'NoneType' object has no attribute 'status'"   
```

Turns out Stackdriver Errors simply parses app logs for anything that looks like a stack trace and reports it as an error. Because of this, the [log line](https://github.com/census-instrumentation/opencensus-python/blob/master/opencensus/trace/ext/flask/flask_middleware.py#L279) in the exception handler causes what at first glance should have been a handled exception, to appear as an unhandled one in Stackdriver.

In general I think that behaviour is desirable, in this specific case I am not certain if it is expected that a call to `get_current_span()` might return `None` but my guess is that this is what happens when we're not tracing. If that's the case then I think this change should eliminate the issue while maintaining desired behaviour.