### PR TITLE
Add stats and metrics reprs

### DIFF
--- a/opencensus/metrics/export/metric.py
+++ b/opencensus/metrics/export/metric.py
@@ -42,6 +42,13 @@ class Metric(object):
         self._descriptor = descriptor
         self._check_type()
 
+    def __repr__(self):
+        return ('{}(descriptor.name="{}")'
+                .format(
+                    type(self).__name__,
+                    self.descriptor.name
+                ))
+
     @property
     def time_series(self):
         return self._time_series

--- a/opencensus/metrics/export/metric_descriptor.py
+++ b/opencensus/metrics/export/metric_descriptor.py
@@ -142,6 +142,17 @@ class MetricDescriptor(object):
         self._type = type_
         self._label_keys = label_keys
 
+    def __repr__(self):
+        type_name = MetricDescriptorType.to_type_class(self.type).__name__
+        return ('{}(name="{}", description="{}", unit={}, type={})'
+                .format(
+                    type(self).__name__,
+                    self.name,
+                    self.description,
+                    self.unit,
+                    type_name,
+                ))
+
     @property
     def name(self):
         return self._name

--- a/opencensus/metrics/export/point.py
+++ b/opencensus/metrics/export/point.py
@@ -36,3 +36,11 @@ class Point(object):
     def timestamp(self):
         """Returns the Timestamp when this Point was recorded."""
         return self._timestamp
+
+    def __repr__(self):
+        return ("{}(value={}, timestamp={})"
+                .format(
+                    type(self).__name__,
+                    self.value,
+                    self.timestamp
+                ))

--- a/opencensus/metrics/export/time_series.py
+++ b/opencensus/metrics/export/time_series.py
@@ -46,6 +46,15 @@ class TimeSeries(object):
         self._points = points
         self._start_timestamp = start_timestamp
 
+    def __repr__(self):
+        return ('{}(points={}, label_values={}, start_timestamp={})'
+                .format(
+                    type(self).__name__,
+                    self.points,
+                    self.label_values,
+                    self.start_timestamp
+                ))
+
     @property
     def start_timestamp(self):
         return self._start_timestamp

--- a/opencensus/metrics/export/value.py
+++ b/opencensus/metrics/export/value.py
@@ -79,6 +79,13 @@ class ValueDouble(Value):
     def __init__(self, value):
         super(ValueDouble, self).__init__(value)
 
+    def __repr__(self):
+        return ("{}({})"
+                .format(
+                    type(self).__name__,
+                    self.value,
+                ))
+
 
 class ValueLong(Value):
     """A 64-bit integer.

--- a/opencensus/metrics/label_key.py
+++ b/opencensus/metrics/label_key.py
@@ -26,6 +26,20 @@ class LabelKey(object):
         self._key = key
         self._description = description
 
+    def __repr__(self):
+        if self.description:
+            return ('{}({}, description="{}")'
+                    .format(
+                        type(self).__name__,
+                        self.key,
+                        self.description
+                    ))
+        return ("{}({})"
+                .format(
+                    type(self).__name__,
+                    self.key,
+                ))
+
     @property
     def key(self):
         """the key for the label"""

--- a/opencensus/metrics/label_value.py
+++ b/opencensus/metrics/label_value.py
@@ -22,6 +22,13 @@ class LabelValue(object):
     def __init__(self, value=None):
         self._value = value
 
+    def __repr__(self):
+        return ("{}({})"
+                .format(
+                    type(self).__name__,
+                    self.value,
+                ))
+
     @property
     def value(self):
         """the value for the label"""

--- a/opencensus/stats/aggregation_data.py
+++ b/opencensus/stats/aggregation_data.py
@@ -64,6 +64,13 @@ class SumAggregationDataFloat(BaseAggregationData):
         super(SumAggregationDataFloat, self).__init__(sum_data)
         self._sum_data = sum_data
 
+    def __repr__(self):
+        return ("{}({})"
+                .format(
+                    type(self).__name__,
+                    self.sum_data,
+                ))
+
     def add_sample(self, value, timestamp=None, attachments=None):
         """Allows the user to add a sample to the Sum Aggregation Data
         The value of the sample is then added to the current sum data
@@ -99,6 +106,13 @@ class CountAggregationData(BaseAggregationData):
     def __init__(self, count_data):
         super(CountAggregationData, self).__init__(count_data)
         self._count_data = count_data
+
+    def __repr__(self):
+        return ("{}({})"
+                .format(
+                    type(self).__name__,
+                    self.count_data,
+                ))
 
     def add_sample(self, value, timestamp=None, attachments=None):
         """Adds a sample to the current Count Aggregation Data and adds 1 to
@@ -193,6 +207,13 @@ class DistributionAggregationData(BaseAggregationData):
             assert all(cc >= 0 for cc in counts_per_bucket)
             assert len(counts_per_bucket) == len(bounds) + 1
         self._counts_per_bucket = counts_per_bucket
+
+    def __repr__(self):
+        return ("{}({})"
+                .format(
+                    type(self).__name__,
+                    self.count_data,
+                ))
 
     @property
     def mean_data(self):
@@ -332,6 +353,13 @@ class LastValueAggregationData(BaseAggregationData):
     def __init__(self, value):
         super(LastValueAggregationData, self).__init__(value)
         self._value = value
+
+    def __repr__(self):
+        return ("{}({})"
+                .format(
+                    type(self).__name__,
+                    self.value,
+                ))
 
     def add_sample(self, value, timestamp=None, attachments=None):
         """Adds a sample to the current


### PR DESCRIPTION
This PR adds `__repr__` methods for a few stats and metrics classes in the style of @reyang's changes in #259.

```
>>> metric
Metric(descriptor.name="sum by oslang")

>>> metric.descriptor
MetricDescriptor(name="sum by oslang", description="Sum of something by os, lang", unit=kW/s, type=ValueDouble)

>>> metric.time_series[0]
TimeSeries(points=[Point(value=ValueDouble(12.34), timestamp=2019-01-31 11:28:58.553910)], label_values=[LabelValue(android), LabelValue(en_us)], start_timestamp=2019-01-31T19:28:38.383422Z)

>>> metric.time_series[0].points[0]
Point(value=ValueDouble(12.34), timestamp=2019-01-31 11:28:58.553910)

>>> vd.view.aggregation.aggregation_data
SumAggregationDataFloat(0.0)

>>> metric.time_series[0].points[0]
Point(value=ValueDouble(12.34), timestamp=2019-01-31 11:28:58.553910)
```

Not all reprs include all the attributes of the class, and in general don't allow the user to reconstruct the object by `eval`ing it. I'd prefer for reprs to be short and human-readable, and not an exhaustive description of the object, but this is potentially confusing if the user doesn't realize that not every attribute is reflected in the repr. I'm interested to hear other reviewers' opinions. 

This PR doesn't include reprs for all classes, just ones that were helpful while writing #476. If you agree with this style we can add reprs to new objects going forward.