### PR TITLE
Don't enable sampling by default

### DIFF
--- a/opencensus/trace/propagation/trace_context_http_header_format.py
+++ b/opencensus/trace/propagation/trace_context_http_header_format.py
@@ -95,7 +95,7 @@ class TraceContextPropagator(object):
         """
         trace_id = span_context.trace_id
         span_id = span_context.span_id
-        trace_options = span_context.trace_options.enabled
+        trace_options = span_context.trace_options.get_enabled()
 
         # Convert the trace options
         trace_options = '01' if trace_options else '00'

--- a/opencensus/trace/span_context.py
+++ b/opencensus/trace/span_context.py
@@ -18,19 +18,13 @@ import logging
 import re
 import uuid
 
-from opencensus.trace import trace_options
+from opencensus.trace import trace_options as trace_options_module
 
 _INVALID_TRACE_ID = '0' * 32
 INVALID_SPAN_ID = '0' * 16
 
 TRACE_ID_PATTERN = re.compile('[0-9a-f]{32}?')
 SPAN_ID_PATTERN = re.compile('[0-9a-f]{16}?')
-
-# Default options, enable tracing
-DEFAULT_OPTIONS = 1
-
-# Default trace options
-DEFAULT = trace_options.TraceOptions(DEFAULT_OPTIONS)
 
 
 class SpanContext(object):
@@ -64,7 +58,7 @@ class SpanContext(object):
             trace_id = generate_trace_id()
 
         if trace_options is None:
-            trace_options = DEFAULT
+            trace_options = trace_options_module.TraceOptions()
 
         self.from_header = from_header
         self.trace_id = self._check_trace_id(trace_id)

--- a/opencensus/trace/trace_options.py
+++ b/opencensus/trace/trace_options.py
@@ -18,7 +18,7 @@ import logging
 _ENABLED_BITMASK = 1 << 0
 
 # Default trace options
-DEFAULT = '1'
+DEFAULT = '0'
 
 
 class TraceOptions(object):

--- a/opencensus/trace/tracer.py
+++ b/opencensus/trace/tracer.py
@@ -73,7 +73,7 @@ class Tracer(object):
         :rtype: bool
         :returns: Whether to trace the request or not.
         """
-        return self.span_context.trace_options.enabled \
+        return self.span_context.trace_options.get_enabled() \
             or self.sampler.should_sample(self.span_context.trace_id)
 
     def get_tracer(self):

--- a/tests/unit/trace/exporters/test_jaeger_exporter.py
+++ b/tests/unit/trace/exporters/test_jaeger_exporter.py
@@ -308,7 +308,7 @@ class TestJaegerExporter(unittest.TestCase):
                 operationName='test1',
                 startTime=1502820146071158,
                 duration=10000000,
-                flags=1,
+                flags=0,
                 tags=[
                     jaeger.Tag(
                         key='key_bool', vType=jaeger.TagType.BOOL,

--- a/tests/unit/trace/propagation/test_binary_format.py
+++ b/tests/unit/trace/propagation/test_binary_format.py
@@ -51,7 +51,7 @@ class TestBinaryFormat(unittest.TestCase):
 
         self.assertEqual(span_context.trace_id, expected_trace_id)
         self.assertEqual(span_context.span_id, expected_span_id)
-        self.assertEqual(span_context.trace_options.enabled,
+        self.assertEqual(span_context.trace_options.get_enabled(),
                          expected_trace_option)
 
     def test_to_header_span_id_zero(self):

--- a/tests/unit/trace/propagation/test_google_cloud_format.py
+++ b/tests/unit/trace/propagation/test_google_cloud_format.py
@@ -62,7 +62,7 @@ class TestGoogleCloudFormatPropagator(unittest.TestCase):
 
         self.assertEqual(span_context.trace_id, expected_trace_id)
         self.assertEqual(span_context.span_id, expected_span_id)
-        self.assertFalse(span_context.trace_options.enabled)
+        self.assertFalse(span_context.trace_options.get_enabled())
 
         # Trace option is enabled.
         header = '6e0c63257de34c92bf9efcd03927272e/00f067aa0ba902b7;o=1'
@@ -74,7 +74,7 @@ class TestGoogleCloudFormatPropagator(unittest.TestCase):
 
         self.assertEqual(span_context.trace_id, expected_trace_id)
         self.assertEqual(span_context.span_id, expected_span_id)
-        self.assertTrue(span_context.trace_options.enabled)
+        self.assertTrue(span_context.trace_options.get_enabled())
 
     def test_header_match_no_option(self):
         header = '6e0c63257de34c92bf9efcd03927272e/00f067aa0ba902b7'
@@ -86,7 +86,7 @@ class TestGoogleCloudFormatPropagator(unittest.TestCase):
 
         self.assertEqual(span_context.trace_id, expected_trace_id)
         self.assertEqual(span_context.span_id, expected_span_id)
-        self.assertTrue(span_context.trace_options.enabled)
+        self.assertTrue(span_context.trace_options.get_enabled())
 
     def test_header_not_match(self):
         header = 'invalid_trace_id/66666;o=1'
@@ -111,7 +111,7 @@ class TestGoogleCloudFormatPropagator(unittest.TestCase):
 
         self.assertEqual(span_context.trace_id, expected_trace_id)
         self.assertEqual(span_context.span_id, expected_span_id)
-        self.assertTrue(span_context.trace_options.enabled)
+        self.assertTrue(span_context.trace_options.get_enabled())
 
     def test_to_header(self):
         from opencensus.trace import span_context

--- a/tests/unit/trace/propagation/test_text_format.py
+++ b/tests/unit/trace/propagation/test_text_format.py
@@ -37,7 +37,7 @@ class Test_from_carrier(unittest.TestCase):
 
         self.assertEqual(span_context.trace_id, test_trace_id)
         self.assertEqual(span_context.span_id, test_span_id)
-        self.assertEqual(span_context.trace_options.enabled,
+        self.assertEqual(span_context.trace_options.get_enabled(),
                          bool(test_options))
 
     def test_from_carrier_keys_not_exist(self):
@@ -50,7 +50,7 @@ class Test_from_carrier(unittest.TestCase):
         # Span_id should be None here which indicates no parent span_id for
         # the child spans
         self.assertIsNone(span_context.span_id)
-        self.assertTrue(span_context.trace_options.enabled)
+        self.assertTrue(span_context.trace_options.get_enabled())
 
     def test_to_carrier_has_span_id(self):
         test_trace_id = '6e0c63257de34c92bf9efcd03927272e'

--- a/tests/unit/trace/propagation/test_trace_context_http_header_format.py
+++ b/tests/unit/trace/propagation/test_trace_context_http_header_format.py
@@ -139,7 +139,7 @@ class TestTraceContextPropagator(unittest.TestCase):
 
         self.assertEqual(span_context.trace_id, trace_id)
         self.assertEqual(span_context.span_id, span_id)
-        self.assertFalse(span_context.trace_options.enabled)
+        self.assertFalse(span_context.trace_options.get_enabled())
 
         # Trace option is enabled.
         span_context = propagator.from_headers({
@@ -149,7 +149,7 @@ class TestTraceContextPropagator(unittest.TestCase):
 
         self.assertEqual(span_context.trace_id, trace_id)
         self.assertEqual(span_context.span_id, span_id)
-        self.assertTrue(span_context.trace_options.enabled)
+        self.assertTrue(span_context.trace_options.get_enabled())
 
     def test_header_not_match(self):
         propagator = trace_context_http_header_format.\

--- a/tests/unit/trace/test_trace_options.py
+++ b/tests/unit/trace/test_trace_options.py
@@ -25,20 +25,32 @@ class TestTraceOptions(unittest.TestCase):
         self.assertFalse(trace_options.enabled)
 
     def test_constructor_explicit(self):
-        trace_options_byte = '0'
+        trace_options_byte = 0x0
         trace_options = trace_opt.TraceOptions(trace_options_byte)
 
         self.assertEqual(trace_options.trace_options_byte, trace_options_byte)
         self.assertFalse(trace_options.enabled)
 
     def test_check_trace_options_valid(self):
-        trace_options_byte = '10'
+        trace_options_byte = 0xa
         trace_options = trace_opt.TraceOptions(trace_options_byte)
 
         self.assertEqual(trace_options.trace_options_byte, trace_options_byte)
 
     def test_check_trace_options_invalid(self):
-        trace_options_byte = '256'
+        trace_options_byte = 0x100
         trace_options = trace_opt.TraceOptions(trace_options_byte)
 
         self.assertEqual(trace_options.trace_options_byte, trace_opt.DEFAULT)
+
+    def test_enable_tracing(self):
+        trace_options = trace_opt.TraceOptions()
+        self.assertFalse(trace_options.get_enabled())
+        trace_options.set_enabled(True)
+        self.assertTrue(trace_options.get_enabled())
+        trace_options.set_enabled(True)
+        self.assertTrue(trace_options.get_enabled())
+        trace_options.set_enabled(False)
+        self.assertFalse(trace_options.get_enabled())
+        trace_options.set_enabled(False)
+        self.assertFalse(trace_options.get_enabled())

--- a/tests/unit/trace/test_trace_options.py
+++ b/tests/unit/trace/test_trace_options.py
@@ -22,7 +22,7 @@ class TestTraceOptions(unittest.TestCase):
         trace_options = trace_opt.TraceOptions()
 
         self.assertEqual(trace_options.trace_options_byte, trace_opt.DEFAULT)
-        self.assertTrue(trace_options.enabled)
+        self.assertFalse(trace_options.enabled)
 
     def test_constructor_explicit(self):
         trace_options_byte = '0'

--- a/tests/unit/trace/test_tracer.py
+++ b/tests/unit/trace/test_tracer.py
@@ -46,7 +46,7 @@ class TestTracer(unittest.TestCase):
         exporter = mock.Mock()
         propagator = mock.Mock()
         span_context = mock.Mock()
-        span_context.trace_options.enabled = False
+        span_context.trace_options.get_enabled.return_value = False
 
         tracer = tracer_module.Tracer(
             span_context=span_context,
@@ -63,7 +63,7 @@ class TestTracer(unittest.TestCase):
     def test_should_sample_force_not_trace(self):
 
         span_context = mock.Mock()
-        span_context.trace_options.enabled = False
+        span_context.trace_options.get_enabled.return_value = False
         sampler = mock.Mock()
         sampler.should_sample.return_value = False
         tracer = tracer_module.Tracer(
@@ -84,14 +84,14 @@ class TestTracer(unittest.TestCase):
         sampler = mock.Mock()
         sampler.should_sample.return_value = False
         span_context = mock.Mock()
-        span_context.trace_options.enabled = False
+        span_context.trace_options.get_enabled.return_value = False
         tracer = tracer_module.Tracer(
             span_context=span_context, sampler=sampler)
         sampled = tracer.should_sample()
 
         self.assertFalse(sampled)
 
-    def get_tracer_noop_tracer(self):
+    def test_get_tracer_noop_tracer(self):
         from opencensus.trace.tracers import noop_tracer
 
         sampler = mock.Mock()
@@ -102,7 +102,7 @@ class TestTracer(unittest.TestCase):
 
         assert isinstance(result, noop_tracer.NoopTracer)
 
-    def get_tracer_context_tracer(self):
+    def test_get_tracer_context_tracer(self):
         from opencensus.trace.tracers import context_tracer
 
         sampler = mock.Mock()
@@ -120,7 +120,7 @@ class TestTracer(unittest.TestCase):
         sampler = mock.Mock()
         sampler.should_sample.return_value = False
         span_context = mock.Mock()
-        span_context.trace_options.enabled = False
+        span_context.trace_options.get_enabled.return_value = False
         tracer = tracer_module.Tracer(
             span_context=span_context, sampler=sampler)
         assert isinstance(tracer.tracer, noop_tracer.NoopTracer)
@@ -147,7 +147,7 @@ class TestTracer(unittest.TestCase):
         sampler = mock.Mock()
         sampler.should_sample.return_value = False
         span_context = mock.Mock()
-        span_context.trace_options.enabled = False
+        span_context.trace_options.get_enabled.return_value = False
         tracer = tracer_module.Tracer(
             span_context=span_context, sampler=sampler)
 
@@ -177,7 +177,7 @@ class TestTracer(unittest.TestCase):
         sampler = mock.Mock()
         sampler.should_sample.return_value = False
         span_context = mock.Mock()
-        span_context.trace_options.enabled = False
+        span_context.trace_options.get_enabled.return_value = False
         tracer = tracer_module.Tracer(
             span_context=span_context, sampler=sampler)
 
@@ -199,7 +199,7 @@ class TestTracer(unittest.TestCase):
         sampler = mock.Mock()
         sampler.should_sample.return_value = False
         span_context = mock.Mock()
-        span_context.trace_options.enabled = False
+        span_context.trace_options.get_enabled.return_value = False
         tracer = tracer_module.Tracer(
             sampler=sampler, span_context=span_context)
 
@@ -235,7 +235,7 @@ class TestTracer(unittest.TestCase):
         sampler = mock.Mock()
         sampler.should_sample.return_value = False
         span_context = mock.Mock()
-        span_context.trace_options.enabled = False
+        span_context.trace_options.get_enabled.return_value = False
         tracer = tracer_module.Tracer(
             sampler=sampler, span_context=span_context)
 
@@ -262,7 +262,7 @@ class TestTracer(unittest.TestCase):
         sampler = mock.Mock()
         sampler.should_sample.return_value = False
         span_context = mock.Mock()
-        span_context.trace_options.enabled = False
+        span_context.trace_options.get_enabled.return_value = False
         tracer = tracer_module.Tracer(
             span_context=span_context, sampler=sampler)
         tracer.add_attribute_to_current_span('key', 'value')


### PR DESCRIPTION
This is a WIP PR to disable sampling using default trace options. This started as a drive-by fix to replace a string-valued bit field with an int and expanded as I compared `TraceOptions` and `SpanContext` to their counterparts in java.

@liyanhui1228 I'd appreciate some comments here since it's not obvious that sampling shouldn't be enabled by default, and there are a few design choices here I don't understand.

Addresses #481.