### PR TITLE
Exporter/Prometheus: Convert None label values to empty string.

### DIFF
--- a/opencensus/stats/exporters/prometheus_exporter.py
+++ b/opencensus/stats/exporters/prometheus_exporter.py
@@ -169,7 +169,7 @@ class Collector(object):
         # Prometheus requires that all tag values be strings hence
         # the need to cast none to the empty string before exporting. See
         # https://github.com/census-instrumentation/opencensus-python/issues/480
-        tag_values = list(map(cast_none_to_empty_str, tag_values))
+        tag_values = [tv if tv else "" for tv in tag_values]
 
         if isinstance(agg_data, aggregation_data_module.CountAggregationData):
             metric = CounterMetricFamily(name=metric_name,
@@ -363,12 +363,3 @@ def sanitize(key):
     Replace all characters other than [A-Za-z0-9_] with '_'.
     """
     return _NON_LETTERS_NOR_DIGITS_RE.sub('_', key)
-
-
-def cast_none_to_empty_str(label_value):
-    """ convert None label to '' since Prometheus doesn't allow label values
-    to be None.
-    """
-    if label_value is None:
-        return ""
-    return label_value

--- a/tests/unit/stats/exporter/test_prometheus_stats.py
+++ b/tests/unit/stats/exporter/test_prometheus_stats.py
@@ -308,8 +308,3 @@ class TestPrometheusStatsExporter(unittest.TestCase):
         self.assertEqual("demo_latency", v_name)
         label_name = prometheus.sanitize("my.org/demo/key1")
         self.assertEqual("my_org_demo_key1", label_name)
-
-    def test_cast_none_to_empty_str(self):
-        self.assertEqual("", prometheus.cast_none_to_empty_str(None))
-        self.assertEqual(
-            "label_value", prometheus.cast_none_to_empty_str("label_value"))

--- a/tests/unit/stats/exporter/test_prometheus_stats.py
+++ b/tests/unit/stats/exporter/test_prometheus_stats.py
@@ -240,6 +240,25 @@ class TestCollectorPrometheus(unittest.TestCase):
         self.assertEqual('histogram', metric.type)
         self.assertEqual(4, len(metric.samples))
 
+    def test_collector_collect_with_none_label_value(self):
+        agg = aggregation_module.LastValueAggregation(256)
+        view = view_module.View("new_view", "processed video size over time",
+                                [FRONTEND_KEY], VIDEO_SIZE_MEASURE, agg)
+        registry = mock.Mock()
+        options = prometheus.Options("test3", 8001, "localhost", registry)
+        collector = prometheus.Collector(options=options)
+        collector.register_view(view)
+        desc = collector.registered_views['test3_new_view']
+        metric = collector.to_metric(
+            desc=desc, tag_values=[None], agg_data=agg.aggregation_data)
+
+        self.assertEqual(1, len(metric.samples))
+        sample = metric.samples[0]
+        # Sample is a namedtuple
+        # ('Sample', ['name', 'labels', 'value', 'timestamp', 'exemplar'])
+        label_map = sample[1]
+        self.assertEqual({"myorg_keys_frontend": ""}, label_map)
+
 
 class TestPrometheusStatsExporter(unittest.TestCase):
     def test_exporter_constructor_no_namespace(self):
@@ -289,3 +308,8 @@ class TestPrometheusStatsExporter(unittest.TestCase):
         self.assertEqual("demo_latency", v_name)
         label_name = prometheus.sanitize("my.org/demo/key1")
         self.assertEqual("my_org_demo_key1", label_name)
+
+    def test_cast_none_to_empty_str(self):
+        self.assertEqual("", prometheus.cast_none_to_empty_str(None))
+        self.assertEqual(
+            "label_value", prometheus.cast_none_to_empty_str("label_value"))


### PR DESCRIPTION
Fixes https://github.com/census-instrumentation/opencensus-python/issues/480.

/cc @PikBot