### PR TITLE
Exporter/Prometheus: Append +Inf to histogram buckets.

### DIFF
--- a/opencensus/stats/exporters/prometheus_exporter.py
+++ b/opencensus/stats/exporters/prometheus_exporter.py
@@ -188,6 +188,10 @@ class Collector(object):
             for ii, bound in enumerate(agg_data.bounds):
                 cum_count += agg_data.counts_per_bucket[ii]
                 points[str(bound)] = cum_count
+            # Prometheus requires buckets to be sorted, and +Inf present.
+            # In OpenCensus we don't have +Inf in the bucket bonds so need to
+            # append it here.
+            points["+Inf"] = agg_data.count_data
             metric = HistogramMetricFamily(name=metric_name,
                                            documentation=metric_description,
                                            labels=label_keys)

--- a/tests/unit/stats/exporter/test_prometheus_stats.py
+++ b/tests/unit/stats/exporter/test_prometheus_stats.py
@@ -195,7 +195,7 @@ class TestCollectorPrometheus(unittest.TestCase):
         self.assertEqual(desc['name'], metric.name)
         self.assertEqual(desc['documentation'], metric.documentation)
         self.assertEqual('histogram', metric.type)
-        self.assertEqual(4, len(metric.samples))
+        self.assertEqual(5, len(metric.samples))
 
     def test_collector_to_metric_invalid_dist(self):
         agg = mock.Mock()
@@ -238,7 +238,7 @@ class TestCollectorPrometheus(unittest.TestCase):
         self.assertEqual(desc['name'], metric.name)
         self.assertEqual(desc['documentation'], metric.documentation)
         self.assertEqual('histogram', metric.type)
-        self.assertEqual(4, len(metric.samples))
+        self.assertEqual(5, len(metric.samples))
 
     def test_collector_collect_with_none_label_value(self):
         agg = aggregation_module.LastValueAggregation(256)


### PR DESCRIPTION
Prometheus requires buckets to be sorted, and +Inf present. Append +Inf to the bucket boundary list. Prometheus client comment is https://github.com/prometheus/client_python/blob/master/prometheus_client/metrics_core.py#L204. Also see the corresponding changes in [Java](https://github.com/census-instrumentation/opencensus-java/blob/master/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtils.java#L192-L193)