### PR TITLE
Exporter/Prometheus: Upgrade version and fix buckets and labels.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+- Fix bugs in Prometheus exporter. Use ordered list for histogram buckets.
+  Use `UnknownMetricFamily` for `SumData` instead of `UntypedMetricFamily`.
+  Check if label keys and values match before exporting.
 
 ## Unreleased
 

--- a/opencensus/stats/exporters/prometheus_exporter.py
+++ b/opencensus/stats/exporters/prometheus_exporter.py
@@ -184,7 +184,7 @@ class Collector(object):
                         aggregation_data_module.DistributionAggregationData):
 
             assert(agg_data.bounds == sorted(agg_data.bounds))
-            # buckets are a list of bucket. Each bucket is another list with
+            # buckets are a list of buckets. Each bucket is another list with
             # a pair of bucket name and value, or a triple of bucket name,
             # value, and exemplar. buckets need to be in order.
             buckets = []

--- a/opencensus/stats/exporters/prometheus_exporter.py
+++ b/opencensus/stats/exporters/prometheus_exporter.py
@@ -166,6 +166,7 @@ class Collector(object):
         metric_description = desc['documentation']
         label_keys = desc['labels']
 
+        assert(len(tag_values) == len(label_keys))
         # Prometheus requires that all tag values be strings hence
         # the need to cast none to the empty string before exporting. See
         # https://github.com/census-instrumentation/opencensus-python/issues/480

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -15,4 +15,4 @@ SQLAlchemy==1.1.14
 WebOb==1.7.3
 wrapt==1.10.11
 thrift==0.10.0
-prometheus_client==0.3.1
+prometheus_client==0.5.0

--- a/tests/system/stats/prometheus/prometheus_stats_test.py
+++ b/tests/system/stats/prometheus/prometheus_stats_test.py
@@ -74,11 +74,11 @@ class TestPrometheusStats(unittest.TestCase):
             import urllib2
             contents = urllib2.urlopen("http://localhost:9303/metrics").read()
 
-        self.assertIn(b'# TYPE opencensus_request_count_view counter',
+        self.assertIn(b'# TYPE opencensus_request_count_view_total counter',
                       contents)
-        self.assertIn(b'opencensus_request_count_view'
+        self.assertIn(b'opencensus_request_count_view_total'
                       b'{method="some method"} 1.0',
                       contents)
-        self.assertIn(b'opencensus_request_count_view'
+        self.assertIn(b'opencensus_request_count_view_total'
                       b'{method="some other method"} 2.0',
                       contents)

--- a/tests/unit/stats/exporters/test_prometheus_stats.py
+++ b/tests/unit/stats/exporters/test_prometheus_stats.py
@@ -140,7 +140,7 @@ class TestCollectorPrometheus(unittest.TestCase):
         collector.register_view(view)
         desc = collector.registered_views[list(REGISTERED_VIEW)[0]]
         metric = collector.to_metric(
-            desc=desc, tag_values=[], agg_data=agg.aggregation_data)
+            desc=desc, tag_values=[None], agg_data=agg.aggregation_data)
 
         self.assertEqual(desc['name'], metric.name)
         self.assertEqual(desc['documentation'], metric.documentation)
@@ -158,7 +158,7 @@ class TestCollectorPrometheus(unittest.TestCase):
         collector.register_view(view)
         desc = collector.registered_views[list(REGISTERED_VIEW)[0]]
         metric = collector.to_metric(
-            desc=desc, tag_values=[], agg_data=agg.aggregation_data)
+            desc=desc, tag_values=[None], agg_data=agg.aggregation_data)
 
         self.assertEqual(desc['name'], metric.name)
         self.assertEqual(desc['documentation'], metric.documentation)
@@ -176,7 +176,7 @@ class TestCollectorPrometheus(unittest.TestCase):
         collector.register_view(view)
         desc = collector.registered_views[list(REGISTERED_VIEW)[0]]
         metric = collector.to_metric(
-            desc=desc, tag_values=[], agg_data=agg.aggregation_data)
+            desc=desc, tag_values=[None], agg_data=agg.aggregation_data)
 
         self.assertEqual(desc['name'], metric.name)
         self.assertEqual(desc['documentation'], metric.documentation)
@@ -192,17 +192,27 @@ class TestCollectorPrometheus(unittest.TestCase):
         distribution = copy.deepcopy(VIDEO_SIZE_DISTRIBUTION.aggregation_data)
         distribution.add_sample(280.0 * MiB, None, None)
         metric = collector.to_metric(
-            desc=desc, tag_values=[], agg_data=distribution)
+            desc=desc,
+            tag_values=[tag_value_module.TagValue("ios")],
+            agg_data=distribution)
 
         self.assertEqual(desc['name'], metric.name)
         self.assertEqual(desc['documentation'], metric.documentation)
         self.assertEqual('histogram', metric.type)
         expected_samples = [
-            Sample(metric.name + '_bucket', {"le": str(16.0 * MiB)}, 0),
-            Sample(metric.name + '_bucket', {"le": str(256.0 * MiB)}, 0),
-            Sample(metric.name + '_bucket', {"le": "+Inf"}, 1),
-            Sample(metric.name + '_count', {}, 1),
-            Sample(metric.name + '_sum', {}, 280.0 * MiB)]
+            Sample(metric.name + '_bucket',
+                   {"myorg_keys_frontend": "ios", "le": str(16.0 * MiB)},
+                   0),
+            Sample(metric.name + '_bucket',
+                   {"myorg_keys_frontend": "ios", "le": str(256.0 * MiB)},
+                   0),
+            Sample(metric.name + '_bucket',
+                   {"myorg_keys_frontend": "ios", "le": "+Inf"},
+                   1),
+            Sample(metric.name + '_count', {"myorg_keys_frontend": "ios"}, 1),
+            Sample(metric.name + '_sum',
+                   {"myorg_keys_frontend": "ios"},
+                   280.0 * MiB)]
         self.assertEqual(expected_samples, metric.samples)
 
     def test_collector_to_metric_invalid_dist(self):
@@ -219,7 +229,7 @@ class TestCollectorPrometheus(unittest.TestCase):
         with self.assertRaisesRegexp(
                 ValueError,
                 'unsupported aggregation type <class \'mock.mock.Mock\'>'):
-            collector.to_metric(desc=desc, tag_values=[], agg_data=agg)
+            collector.to_metric(desc=desc, tag_values=[None], agg_data=agg)
 
     def test_collector_collect(self):
         agg = aggregation_module.LastValueAggregation(256)


### PR DESCRIPTION
- Upgrade to latest Prometheus client.
- Use `UnknownMetricFamily` instead of `UntypedMetricFamily`, as the latter is now deprecated.
- Use ordered list for histogram buckets. Previously we use unordered map and that led to unpredictable behavior.
- Label keys and values must match when uploading metrics.
- Update unit tests to test against more precise results.