### PR TITLE
Add derived gauges

### DIFF
--- a/opencensus/common/backports.py
+++ b/opencensus/common/backports.py
@@ -1,0 +1,76 @@
+# Copyright 2019, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import weakref
+
+
+class WeakMethod(weakref.ref):  # pragma: NO COVER
+    """
+    A custom `weakref.ref` subclass which simulates a weak reference to
+    a bound method, working around the lifetime problem of bound methods.
+
+    This is a copy of the WeakMethod class that ships with weakref in the
+    python 3.7 standard library, adapted to work in 2.6. See:
+    https://github.com/python/cpython/blob/a31f4cc881992e84d351957bd9ac1a92f882fa39/Lib/weakref.py#L36-L87
+    """  # noqa
+
+    __slots__ = "_func_ref", "_meth_type", "_alive", "__weakref__"
+
+    def __new__(cls, meth, callback=None):
+        try:
+            obj = meth.__self__
+            func = meth.__func__
+        except AttributeError:
+            raise TypeError("argument should be a bound method, not {}"
+                            .format(type(meth)))
+
+        def _cb(arg):
+            # The self-weakref trick is needed to avoid creating a reference
+            # cycle.
+            self = self_wr()
+            if self._alive:
+                self._alive = False
+                if callback is not None:
+                    callback(self)
+        self = weakref.ref.__new__(cls, obj, _cb)
+        self._func_ref = weakref.ref(func, _cb)
+        self._meth_type = type(meth)
+        self._alive = True
+        self_wr = weakref.ref(self)
+        return self
+
+    def __call__(self):
+        obj = super(WeakMethod, self).__call__()
+        func = self._func_ref()
+        if obj is None or func is None:
+            return None
+        return self._meth_type(func, obj)
+
+    def __eq__(self, other):
+        if isinstance(other, WeakMethod):
+            if not self._alive or not other._alive:
+                return self is other
+            return (weakref.ref.__eq__(self, other)
+                    and self._func_ref == other._func_ref)
+        return False
+
+    def __ne__(self, other):
+        if isinstance(other, WeakMethod):
+            if not self._alive or not other._alive:
+                return self is not other
+            return (weakref.ref.__ne__(self, other)
+                    or self._func_ref != other._func_ref)
+        return True
+
+    __hash__ = weakref.ref.__hash__

--- a/opencensus/common/backports.py
+++ b/opencensus/common/backports.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import six
 import weakref
 
 
@@ -32,8 +33,9 @@ class WeakMethod(weakref.ref):  # pragma: NO COVER
             obj = meth.__self__
             func = meth.__func__
         except AttributeError:
-            raise TypeError("argument should be a bound method, not {}"
-                            .format(type(meth)))
+            error = TypeError("argument should be a bound method, not {}"
+                              .format(type(meth)))
+            six.raise_from(error, None)
 
         def _cb(arg):
             # The self-weakref trick is needed to avoid creating a reference

--- a/opencensus/common/utils.py
+++ b/opencensus/common/utils.py
@@ -115,7 +115,7 @@ def get_weakref(func):
     """Get a weak reference to bound or unbound `func`.
 
     If `func` is unbound (i.e. has no __self__ attr) get a weakref.ref,
-    otherwise get a wrapper that simulates simulates weakref.ref.
+    otherwise get a wrapper that simulates weakref.ref.
     """
     if func is None:
         raise ValueError

--- a/opencensus/common/utils.py
+++ b/opencensus/common/utils.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import wraps
 import calendar
 import datetime
+import weakref
 
 UTF8 = 'utf-8'
 
@@ -103,3 +105,39 @@ def window(ible, length):
             yield elts
         else:
             break
+
+
+class WeakrefWrapper(object):
+    """Wrapper for weak references to bound methods.
+
+    See the O'Reilley Python Cookbook for a pre-2.6 implementation:
+    - https://www.oreilly.com/library/view/python-cookbook/0596001673/ch05s15.html
+    - https://github.com/ActiveState/code/blob/master/recipes/Python/81253_WeakMethod/recipe-81253.py
+    """  # noqa
+    def __init__(self, obj, func):
+        self.__self__ = weakref.ref(obj)
+        self.__func__ = weakref.ref(func)
+
+    def __call__(self):
+        if self.__self__() is None:
+            return None
+
+        @wraps(self.__func__())
+        def wrapped_func(*args, **kws):
+            return self.__func__()(self.__self__(), *args, **kws)
+
+        return wrapped_func
+
+
+def get_weakref(func):
+    """Get a weak reference to bound or unbound `func`.
+
+    If `func` is unbound (i.e. has no __self__ attr) get a weakref.ref,
+    otherwise get a wrapper that simulates simulates weakref.ref.
+    """
+    if func is None:
+        raise ValueError
+    try:
+        return WeakrefWrapper(func.__self__, func.__func__)
+    except AttributeError:
+        return weakref.ref(func)

--- a/opencensus/metrics/export/gauge.py
+++ b/opencensus/metrics/export/gauge.py
@@ -16,6 +16,7 @@ from collections import OrderedDict
 import six
 import threading
 
+from opencensus.common import utils
 from opencensus.metrics.export import metric
 from opencensus.metrics.export import metric_descriptor
 from opencensus.metrics.export import point as point_module
@@ -23,7 +24,40 @@ from opencensus.metrics.export import time_series
 from opencensus.metrics.export import value as value_module
 
 
-class GaugePointLong(object):
+def get_timeseries_list(points, timestamp):
+    """Get a metric including all current time series.
+
+    Get a :class:`opencensus.metrics.export.metric.Metric` with one
+    :class:`opencensus.metrics.export.time_series.TimeSeries` for each
+    set of label values with a recorded measurement. Each `TimeSeries`
+    has a single point that represents the last recorded value.
+
+    :type points: :class:`datetime.datetime`
+    :param points: Recording time to report, usually the current time.
+
+    :type timestamp: :class:`datetime.datetime`
+    :param timestamp: Recording time to report, usually the current time.
+
+    :rtype: :class:`opencensus.metrics.export.metric.Metric` or None
+    :return: A converted metric for all current measurements.
+    """
+    ts_list = []
+    for lv, gp in points.items():
+        point = point_module.Point(gp.to_point_value(), timestamp)
+        ts_list.append(time_series.TimeSeries(lv, [point], timestamp))
+    return ts_list
+
+
+class GaugePoint(object):
+
+    def to_point_value(self):
+        raise NotImplementedError  # pragma: NO COVER
+
+    def get_value(self):
+        raise NotImplementedError  # pragma: NO COVER
+
+
+class GaugePointLong(GaugePoint):
     """An instantaneous measurement from a LongGauge.
 
     A GaugePointLong represents the most recent measurement from a
@@ -63,11 +97,27 @@ class GaugePointLong(object):
         with self._value_lock:
             self.value = val
 
+    def get_value(self):
+        """Get the current value.
 
-class GaugePointDouble(object):
+        :rtype: int
+        :return: The current value of the measurement.
+        """
+        return self.value
+
+    def to_point_value(self):
+        """Get a point value conversion of the current value.
+
+        :rtype: :class:`opencensus.metrics.export.value.ValueLong`
+        :return: A converted `ValueLong`.
+        """
+        return value_module.ValueLong(self.value)
+
+
+class GaugePointDouble(GaugePoint):
     """An instantaneous measurement from a DoubleGauge.
 
-    A GaugePointDouble represents the most recent measurement from a
+    A `GaugePointDouble` represents the most recent measurement from a
     :class:`DoubleGauge` for a given set of label values.
     """
 
@@ -100,17 +150,83 @@ class GaugePointDouble(object):
         with self._value_lock:
             self.value = float(val)
 
+    def get_value(self):
+        """Get the current value.
 
-class Gauge(object):
-    """A set of instantaneous measurements of the same type.
+        :rtype: float
+        :return: The current value of the measurement.
+        """
+        return self.value
 
-    End users should use :class:`LongGauge` or :class:`DoubleGauge` instead of
-    using this class directly.
+    def to_point_value(self):
+        """Get a point value conversion of the current value.
 
-    The constructor arguments are used to create a
-    :class:`opencensus.metrics.export.metric_descriptor.MetricDescriptor` for
-    converted metrics. See that class for details.
+        :rtype: :class:`opencensus.metrics.export.value.ValueDouble`
+        :return: A converted `ValueDouble`.
+        """
+        return value_module.ValueDouble(self.value)
+
+
+class DerivedGaugePoint(GaugePoint):
+    """Wraps a `GaugePoint` to automatically track the value of a function.
+
+    A `DerivedGaugePoint` is a read-only measure that stores the most recently
+    read value of a given function in a mutable `GaugePoint`. Calling
+    `get_value` or `to_point_value` calls the tracked function and updates the
+    wrapped `GaugePoint`.
+
+    :type func: function
+    :param func: The function to track.
+
+    :type gauge_point: :class:`GaugePointLong` or :class:`GaugePointDouble`
+    :param gauge_point: The underlying `GaugePoint`.
     """
+    def __init__(self, func, gauge_point):
+        self.gauge_point = gauge_point
+        self.func = utils.get_weakref(func)
+
+    def __repr__(self):
+        return ("{}({})"
+                .format(
+                    type(self).__name__,
+                    self.func()
+                ))
+
+    def get_value(self):
+        """Get the current value of the underlying measurement.
+
+        Calls the tracked function and stores the value in the wrapped
+        measurement as a side-effect.
+
+        :rtype: int, float, or None
+        :return: The current value of the wrapped function, or `None` if it no
+        longer exists.
+        """
+        try:
+            self.gauge_point.set(self.func()())
+        # The underlying function has been GC'd
+        except TypeError:
+            return None
+        return self.gauge_point.get_value()
+
+    def to_point_value(self):
+        """Get a point value conversion of the current value.
+
+        Calls the tracked function and stores the value in the wrapped
+        measurement as a side-effect.
+
+        :rtype: :class:`opencensus.metrics.export.value.ValueLong`,
+        :class:`opencensus.metrics.export.value.ValueDouble`, or None
+        :return: The point value conversion of the underlying `GaugePoint`, or
+        None if the tracked function no longer exists.
+        """
+        if self.get_value() is None:
+            return None
+        return self.gauge_point.to_point_value()
+
+
+class BaseGauge(object):
+    """Base class for sets instantaneous measurements."""
 
     def __init__(self, name, description, unit, label_keys):
         self._len_label_keys = len(label_keys)
@@ -127,42 +243,6 @@ class Gauge(object):
                     self.descriptor.name,
                     self.points
                 ))
-
-    def _get_or_create_time_series(self, label_values):
-        with self._points_lock:
-            return self.points.setdefault(
-                tuple(label_values), self.point_type())
-
-    def get_or_create_time_series(self, label_values):
-        """Get a mutable measurement for the given set of label values.
-
-        :type label_values: list(:class:`LabelValue`)
-        :param label_values: The measurement's label values.
-
-        :rtype: :class:`GaugePointLong` or :class:`GaugePointDouble`
-        :return: A mutable point that represents the last value of the
-        measurement.
-        """
-        if label_values is None:
-            raise ValueError
-        if any(lv is None for lv in label_values):
-            raise ValueError
-        if len(label_values) != self._len_label_keys:
-            raise ValueError
-        return self._get_or_create_time_series(label_values)
-
-    def get_or_create_default_time_series(self):
-        """Get the default measurement for this gauge.
-
-        Each gauge has a default point not associated with any specific label
-        values. When this gauge is exported as a metric via `get_metric` the
-        time series associated with this point will have null label values.
-
-        :rtype: :class:`GaugePointLong` or :class:`GaugePointDouble`
-        :return: A mutable point that represents the last value of the
-        measurement.
-        """
-        return self._get_or_create_time_series(self.default_label_values)
 
     def _remove_time_series(self, label_values):
         with self._points_lock:
@@ -211,12 +291,8 @@ class Gauge(object):
         if not self.points:
             return None
 
-        ts_list = []
         with self._points_lock:
-            for lv, gp in self.points.items():
-                point = point_module.Point(
-                    self.value_type(gp.value), timestamp)
-                ts_list.append(time_series.TimeSeries(lv, [point], timestamp))
+            ts_list = get_timeseries_list(self.points, timestamp)
         return metric.Metric(self.descriptor, ts_list)
 
     @property
@@ -227,20 +303,130 @@ class Gauge(object):
     def point_type(self):  # pragma: NO COVER
         raise NotImplementedError
 
-    @property
-    def value_type(self):  # pragma: NO COVER
-        raise NotImplementedError
+
+class Gauge(BaseGauge):
+    """A set of mutable, instantaneous measurements of the same type.
+
+    End users should use :class:`LongGauge` or :class:`DoubleGauge` instead of
+    using this class directly.
+
+    The constructor arguments are used to create a
+    :class:`opencensus.metrics.export.metric_descriptor.MetricDescriptor` for
+    converted metrics. See that class for details.
+    """
+
+    def _get_or_create_time_series(self, label_values):
+        with self._points_lock:
+            return self.points.setdefault(
+                tuple(label_values), self.point_type())
+
+    def get_or_create_time_series(self, label_values):
+        """Get a mutable measurement for the given set of label values.
+
+        :type label_values: list(:class:`LabelValue`)
+        :param label_values: The measurement's label values.
+
+        :rtype: :class:`GaugePointLong` or :class:`GaugePointDouble`
+        :return: A mutable point that represents the last value of the
+        measurement.
+        """
+        if label_values is None:
+            raise ValueError
+        if any(lv is None for lv in label_values):
+            raise ValueError
+        if len(label_values) != self._len_label_keys:
+            raise ValueError
+        return self._get_or_create_time_series(label_values)
+
+    def get_or_create_default_time_series(self):
+        """Get the default measurement for this gauge.
+
+        Each gauge has a default point not associated with any specific label
+        values. When this gauge is exported as a metric via `get_metric` the
+        time series associated with this point will have null label values.
+
+        :rtype: :class:`GaugePointLong` or :class:`GaugePointDouble`
+        :return: A mutable point that represents the last value of the
+        measurement.
+        """
+        return self._get_or_create_time_series(self.default_label_values)
 
 
-class LongGauge(Gauge):
-    """Gauge for recording int-valued measurements."""
+class LongGaugeMixin(object):
+    """Type mixin for long-valued gauges."""
     descriptor_type = metric_descriptor.MetricDescriptorType.GAUGE_INT64
     point_type = GaugePointLong
-    value_type = value_module.ValueLong
 
 
-class DoubleGauge(Gauge):
-    """Gauge for recording float-valued measurements."""
+class DoubleGaugeMixin(object):
+    """Type mixin for float-valued gauges."""
     descriptor_type = metric_descriptor.MetricDescriptorType.GAUGE_DOUBLE
     point_type = GaugePointDouble
-    value_type = value_module.ValueDouble
+
+
+class LongGauge(LongGaugeMixin, Gauge):
+    """Gauge for recording int-valued measurements."""
+
+
+class DoubleGauge(DoubleGaugeMixin, Gauge):
+    """Gauge for recording float-valued measurements."""
+
+
+class DerivedGauge(BaseGauge):
+    """Gauge that tracks values of other functions.
+
+    Each of a `DerivedGauge`'s measurements are associated with a function
+    which is called when the gauge is exported.
+
+    End users should use :class:`DerivedLongGauge` or
+    :class:`DerivedDoubleGauge` instead of using this class directly.
+    """
+
+    def _create_time_series(self, label_values, func):
+        with self._points_lock:
+            return self.points.setdefault(
+                tuple(label_values),
+                DerivedGaugePoint(func, self.point_type()))
+
+    def create_time_series(self, label_values, func):
+        """Create a derived measurement to trac `func`.
+
+        :type label_values: list(:class:`LabelValue`)
+        :param label_values: The measurement's label values.
+
+        :type func: function
+        :param func: The function to track.
+
+        :rtype: :class:`DerivedGaugePoint`
+        :return: A read-only measurement that tracks `func`.
+        """
+        if label_values is None:
+            raise ValueError
+        if any(lv is None for lv in label_values):
+            raise ValueError
+        if len(label_values) != self._len_label_keys:
+            raise ValueError
+        if func is None:
+            raise ValueError
+        return self._create_time_series(label_values, func)
+
+    def create_default_time_series(self, func):
+        """Create the default derived measurement for this gauge.
+
+        :type func: function
+        :param func: The function to track.
+
+        :rtype: :class:`DerivedGaugePoint`
+        :return: A read-only measurement that tracks `func`.
+        """
+        if func is None:
+            raise ValueError
+        return self._create_time_series(self.default_label_values, func)
+
+
+class DerivedLongGauge(LongGaugeMixin, DerivedGauge):
+    """Gauge for derived int-valued measurements."""
+
+
+class DerivedDoubleGauge(DoubleGaugeMixin, DerivedGauge):
+    """Gauge for derived float-valued measurements."""

--- a/opencensus/metrics/export/gauge.py
+++ b/opencensus/metrics/export/gauge.py
@@ -1,0 +1,246 @@
+# Copyright 2019, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import OrderedDict
+import six
+import threading
+
+from opencensus.metrics.export import metric
+from opencensus.metrics.export import metric_descriptor
+from opencensus.metrics.export import point as point_module
+from opencensus.metrics.export import time_series
+from opencensus.metrics.export import value as value_module
+
+
+class GaugePointLong(object):
+    """An instantaneous measurement from a LongGauge.
+
+    A GaugePointLong represents the most recent measurement from a
+    :class:`LongGauge` for a given set of label values.
+    """
+
+    def __init__(self):
+        self.value = 0
+        self._value_lock = threading.Lock()
+
+    def __repr__(self):
+        return ("{}({})"
+                .format(
+                    type(self).__name__,
+                    self.value
+                ))
+
+    def add(self, val):
+        """Add `val` to the current value.
+
+        :type val: int
+        :param val: Value to add.
+        """
+        if not isinstance(val, six.integer_types):
+            raise ValueError("GaugePointLong only supports integer types")
+        with self._value_lock:
+            self.value += val
+
+    def set(self, val):
+        """Set the current value to `val`.
+
+        :type val: int
+        :param val: Value to set.
+        """
+        if not isinstance(val, six.integer_types):
+            raise ValueError("GaugePointLong only supports integer types")
+        with self._value_lock:
+            self.value = val
+
+
+class GaugePointDouble(object):
+    """An instantaneous measurement from a DoubleGauge.
+
+    A GaugePointDouble represents the most recent measurement from a
+    :class:`DoubleGauge` for a given set of label values.
+    """
+
+    def __init__(self):
+        self.value = 0.0
+        self._value_lock = threading.Lock()
+
+    def __repr__(self):
+        return ("{}({})"
+                .format(
+                    type(self).__name__,
+                    self.value
+                ))
+
+    def add(self, val):
+        """Add `val` to the current value.
+
+        :type val: float
+        :param val: Value to add.
+        """
+        with self._value_lock:
+            self.value += val
+
+    def set(self, val):
+        """Set the current value to `val`.
+
+        :type val: float
+        :param val: Value to set.
+        """
+        with self._value_lock:
+            self.value = float(val)
+
+
+class Gauge(object):
+    """A set of instantaneous measurements of the same type.
+
+    End users should use :class:`LongGauge` or :class:`DoubleGauge` instead of
+    using this class directly.
+
+    The constructor arguments are used to create a
+    :class:`opencensus.metrics.export.metric_descriptor.MetricDescriptor` for
+    converted metrics. See that class for details.
+    """
+
+    def __init__(self, name, description, unit, label_keys):
+        self._len_label_keys = len(label_keys)
+        self.default_label_values = [None] * self._len_label_keys
+        self.descriptor = metric_descriptor.MetricDescriptor(
+            name, description, unit, self.descriptor_type, label_keys)
+        self.points = OrderedDict()
+        self._points_lock = threading.Lock()
+
+    def __repr__(self):
+        return ('{}(descriptor.name="{}", points={})'
+                .format(
+                    type(self).__name__,
+                    self.descriptor.name,
+                    self.points
+                ))
+
+    def _get_or_create_time_series(self, label_values):
+        with self._points_lock:
+            return self.points.setdefault(
+                tuple(label_values), self.point_type())
+
+    def get_or_create_time_series(self, label_values):
+        """Get a mutable measurement for the given set of label values.
+
+        :type label_values: list(:class:`LabelValue`)
+        :param label_values: The measurement's label values.
+
+        :rtype: :class:`GaugePointLong` or :class:`GaugePointDouble`
+        :return: A mutable point that represents the last value of the
+        measurement.
+        """
+        if label_values is None:
+            raise ValueError
+        if any(lv is None for lv in label_values):
+            raise ValueError
+        if len(label_values) != self._len_label_keys:
+            raise ValueError
+        return self._get_or_create_time_series(label_values)
+
+    def get_or_create_default_time_series(self):
+        """Get the default measurement for this gauge.
+
+        Each gauge has a default point not associated with any specific label
+        values. When this gauge is exported as a metric via `get_metric` the
+        time series associated with this point will have null label values.
+
+        :rtype: :class:`GaugePointLong` or :class:`GaugePointDouble`
+        :return: A mutable point that represents the last value of the
+        measurement.
+        """
+        return self._get_or_create_time_series(self.default_label_values)
+
+    def _remove_time_series(self, label_values):
+        with self._points_lock:
+            try:
+                del self.points[tuple(label_values)]
+            except KeyError:
+                pass
+
+    def remove_time_series(self, label_values):
+        """Remove the time series for specific label values.
+
+        :type label_values: list(:class:`LabelValue`)
+        :param label_values: Label values of the time series to remove.
+        """
+        if label_values is None:
+            raise ValueError
+        if any(lv is None for lv in label_values):
+            raise ValueError
+        if len(label_values) != self._len_label_keys:
+            raise ValueError
+        self._remove_time_series(label_values)
+
+    def remove_default_time_series(self):
+        """Remove the default time series for this gauge."""
+        self._remove_time_series(self.default_label_values)
+
+    def clear(self):
+        """Remove all points from this gauge."""
+        with self._points_lock:
+            self.points = OrderedDict()
+
+    def get_metric(self, timestamp):
+        """Get a metric including all current time series.
+
+        Get a :class:`opencensus.metrics.export.metric.Metric` with one
+        :class:`opencensus.metrics.export.time_series.TimeSeries` for each
+        set of label values with a recorded measurement. Each `TimeSeries`
+        has a single point that represents the last recorded value.
+
+        :type timestamp: :class:`datetime.datetime`
+        :param timestamp: Recording time to report, usually the current time.
+
+        :rtype: :class:`opencensus.metrics.export.metric.Metric` or None
+        :return: A converted metric for all current measurements.
+        """
+        if not self.points:
+            return None
+
+        ts_list = []
+        with self._points_lock:
+            for lv, gp in self.points.items():
+                point = point_module.Point(
+                    self.value_type(gp.value), timestamp)
+                ts_list.append(time_series.TimeSeries(lv, [point], timestamp))
+        return metric.Metric(self.descriptor, ts_list)
+
+    @property
+    def descriptor_type(self):  # pragma: NO COVER
+        raise NotImplementedError
+
+    @property
+    def point_type(self):  # pragma: NO COVER
+        raise NotImplementedError
+
+    @property
+    def value_type(self):  # pragma: NO COVER
+        raise NotImplementedError
+
+
+class LongGauge(Gauge):
+    """Gauge for recording int-valued measurements."""
+    descriptor_type = metric_descriptor.MetricDescriptorType.GAUGE_INT64
+    point_type = GaugePointLong
+    value_type = value_module.ValueLong
+
+
+class DoubleGauge(Gauge):
+    """Gauge for recording float-valued measurements."""
+    descriptor_type = metric_descriptor.MetricDescriptorType.GAUGE_DOUBLE
+    point_type = GaugePointDouble
+    value_type = value_module.ValueDouble

--- a/opencensus/metrics/export/gauge.py
+++ b/opencensus/metrics/export/gauge.py
@@ -25,21 +25,21 @@ from opencensus.metrics.export import value as value_module
 
 
 def get_timeseries_list(points, timestamp):
-    """Get a metric including all current time series.
+    """Convert a list of `GaugePoint`s into a list of `TimeSeries`.
 
-    Get a :class:`opencensus.metrics.export.metric.Metric` with one
-    :class:`opencensus.metrics.export.time_series.TimeSeries` for each
-    set of label values with a recorded measurement. Each `TimeSeries`
-    has a single point that represents the last recorded value.
+    Get a :class:`opencensus.metrics.export.time_series.TimeSeries` for each
+    measurement in `points`. Each series contains a single
+    :class:`opencensus.metrics.export.point.Point` that represents the last
+    recorded value of the measurement.
 
-    :type points: :class:`datetime.datetime`
-    :param points: Recording time to report, usually the current time.
+    :type points: list(:class:`GaugePoint`)
+    :param points: The list of measurements to convert.
 
     :type timestamp: :class:`datetime.datetime`
     :param timestamp: Recording time to report, usually the current time.
 
-    :rtype: :class:`opencensus.metrics.export.metric.Metric` or None
-    :return: A converted metric for all current measurements.
+    :rtype: list(:class:`opencensus.metrics.export.time_series.TimeSeries`)
+    :return: A list of one `TimeSeries` for each point in `points`.
     """
     ts_list = []
     for lv, gp in points.items():

--- a/opencensus/metrics/export/metric.py
+++ b/opencensus/metrics/export/metric.py
@@ -43,10 +43,24 @@ class Metric(object):
         self._check_type()
 
     def __repr__(self):
-        return ('{}(descriptor.name="{}")'
+        # Get a condensed description of a list of time series like:
+        # (k1="v11", k2="v21", [12]), (k1="v21", k2="v22", [34])
+        lks = [lk.key for lk in self.descriptor.label_keys]
+        labeled_pvs = []
+        for ts in self.time_series:
+            labels = ", ".join('{}="{}"'.format(lk, lv)
+                               for lk, lv in zip(lks, ts.label_values))
+            pvs = [point.value.value for point in ts.points]
+            labeled_pvs.append((labels, pvs))
+        short_ts_repr = ", ".join("({}, {})".format(ll, pvs)
+                                  for ll, pvs in labeled_pvs)
+
+        # E.g. 'Metric((k1="v11", k2="v21", [12]), descriptor.name="name")'
+        return ('{}({}, descriptor.name="{}")'
                 .format(
                     type(self).__name__,
-                    self.descriptor.name
+                    short_ts_repr,
+                    self.descriptor.name,
                 ))
 
     @property

--- a/opencensus/metrics/export/metric.py
+++ b/opencensus/metrics/export/metric.py
@@ -50,7 +50,8 @@ class Metric(object):
         for ts in self.time_series:
             labels = ", ".join('{}="{}"'.format(lk, lv)
                                for lk, lv in zip(lks, ts.label_values))
-            pvs = [point.value.value for point in ts.points]
+            pvs = [point.value.value if point.value else None
+                   for point in ts.points]
             labeled_pvs.append((labels, pvs))
         short_ts_repr = ", ".join("({}, {})".format(ll, pvs)
                                   for ll, pvs in labeled_pvs)

--- a/opencensus/metrics/export/time_series.py
+++ b/opencensus/metrics/export/time_series.py
@@ -80,6 +80,7 @@ class TimeSeries(object):
         :return: Whether all points are instances of `type_class`.
         """
         for point in self.points:
-            if not isinstance(point.value, type_class):
+            if (point.value is not None
+                    and not isinstance(point.value, type_class)):
                 return False
         return True

--- a/opencensus/metrics/export/time_series.py
+++ b/opencensus/metrics/export/time_series.py
@@ -47,10 +47,10 @@ class TimeSeries(object):
         self._start_timestamp = start_timestamp
 
     def __repr__(self):
-        return ('{}(points={}, label_values={}, start_timestamp={})'
+        return ('{}({}, label_values={}, start_timestamp={})'
                 .format(
                     type(self).__name__,
-                    self.points,
+                    [point.value.value for point in self.points],
                     self.label_values,
                     self.start_timestamp
                 ))

--- a/opencensus/metrics/export/value.py
+++ b/opencensus/metrics/export/value.py
@@ -97,6 +97,13 @@ class ValueLong(Value):
     def __init__(self, value):
         super(ValueLong, self).__init__(value)
 
+    def __repr__(self):
+        return ("{}({})"
+                .format(
+                    type(self).__name__,
+                    self.value,
+                ))
+
 
 class ValueSummary(Value):
     """Represents a snapshot values calculated over an arbitrary time window.
@@ -107,6 +114,13 @@ class ValueSummary(Value):
 
     def __init__(self, value):
         super(ValueSummary, self).__init__(value)
+
+    def __repr__(self):
+        return ("{}({})"
+                .format(
+                    type(self).__name__,
+                    self.value,
+                ))
 
 
 class Exemplar(object):

--- a/tests/unit/metrics/export/test_gauge.py
+++ b/tests/unit/metrics/export/test_gauge.py
@@ -104,7 +104,7 @@ class TestDerivedGaugePoint(unittest.TestCase):
 
     def test_get_value_gcd(self):
         """Check handling deletion of the underlying func."""
-        get_10 = lambda: 10
+        get_10 = lambda: 10  # noqa
         point = gauge.DerivedGaugePoint(get_10, gauge.GaugePointLong())
 
         value = point.get_value()
@@ -137,7 +137,7 @@ class TestDerivedGaugePoint(unittest.TestCase):
         self.assertEqual(mock_fn.call_count, 2)
 
     def test_get_to_point_value_gcd(self):
-        get_10 = lambda: 10
+        get_10 = lambda: 10  # noqa
         point = gauge.DerivedGaugePoint(get_10, gauge.GaugePointLong())
         del get_10
         gc.collect()

--- a/tests/unit/metrics/export/test_gauge.py
+++ b/tests/unit/metrics/export/test_gauge.py
@@ -17,6 +17,7 @@ try:
 except ImportError:
     from unittest.mock import Mock
 
+import gc
 import unittest
 
 from opencensus.metrics.export import gauge
@@ -48,6 +49,12 @@ class TestGaugePointLong(unittest.TestCase):
         with self.assertRaises(ValueError):
             point.set(10.0)
 
+    def test_get_value(self):
+        point = gauge.GaugePointLong()
+        point.set(10)
+        self.assertEqual(point.value, 10)
+        self.assertEqual(point.get_value(), point.value)
+
 
 class TestGaugePointDouble(unittest.TestCase):
     def test_init(self):
@@ -68,6 +75,74 @@ class TestGaugePointDouble(unittest.TestCase):
         self.assertEqual(point.value, 10.0)
         point.set(-20.2)
         self.assertEqual(point.value, -20.2)
+
+    def test_get_value(self):
+        point = gauge.GaugePointDouble()
+        point.set(10.1)
+        self.assertEqual(point.value, 10.1)
+        self.assertEqual(point.get_value(), point.value)
+
+
+class TestDerivedGaugePoint(unittest.TestCase):
+    def test_get_value(self):
+        mock_fn = Mock()
+        mock_value = Mock(spec=int)
+        mock_fn.return_value = mock_value
+
+        point = gauge.DerivedGaugePoint(mock_fn, gauge.GaugePointLong())
+        mock_fn.assert_not_called()
+
+        value = point.get_value()
+        self.assertEqual(value, mock_value)
+        self.assertEqual(point.gauge_point.value, mock_value)
+        mock_fn.assert_called_once()
+
+        value = point.get_value()
+        self.assertEqual(value, mock_value)
+        self.assertEqual(point.gauge_point.value, mock_value)
+        self.assertEqual(mock_fn.call_count, 2)
+
+    def test_get_value_gcd(self):
+        """Check handling deletion of the underlying func."""
+        get_10 = lambda: 10
+        point = gauge.DerivedGaugePoint(get_10, gauge.GaugePointLong())
+
+        value = point.get_value()
+        self.assertEqual(value, 10)
+        self.assertEqual(point.gauge_point.value, 10)
+
+        del get_10
+        gc.collect()
+        deleted_value = point.get_value()
+        self.assertIsNone(deleted_value)
+        # Check that we don't null out the underlying point value
+        self.assertEqual(point.gauge_point.value, 10)
+
+    def test_get_to_point_value(self):
+        mock_fn = Mock()
+        mock_value = Mock(spec=int)
+        mock_fn.return_value = mock_value
+
+        point = gauge.DerivedGaugePoint(mock_fn, gauge.GaugePointLong())
+        mock_fn.assert_not_called()
+
+        value_long = point.to_point_value()
+        self.assertEqual(value_long.value, mock_value)
+        self.assertEqual(point.gauge_point.value, mock_value)
+        mock_fn.assert_called_once()
+
+        value = point.get_value()
+        self.assertEqual(value, mock_value)
+        self.assertEqual(point.gauge_point.value, mock_value)
+        self.assertEqual(mock_fn.call_count, 2)
+
+    def test_get_to_point_value_gcd(self):
+        get_10 = lambda: 10
+        point = gauge.DerivedGaugePoint(get_10, gauge.GaugePointLong())
+        del get_10
+        gc.collect()
+        deleted_long_value = point.to_point_value()
+        self.assertIsNone(deleted_long_value)
 
 
 class TestLongGauge(unittest.TestCase):
@@ -267,3 +342,85 @@ class TestDoubleGauge(unittest.TestCase):
                               value_module.ValueDouble)
         self.assertEqual(metric.time_series[0].points[0].value.value, 1.2)
         self.assertEqual(metric.time_series[1].points[0].value.value, 2.2)
+
+
+class TestDerivedGauge(unittest.TestCase):
+
+    def test_one(self):
+        name = Mock()
+        description = Mock()
+        unit = Mock()
+        label_keys = [Mock(), Mock]
+        derived_gauge = gauge.DerivedLongGauge(
+            name, description, unit, label_keys)
+        self.assertEqual(derived_gauge.descriptor.name, name)
+        self.assertEqual(derived_gauge.descriptor.description, description)
+        self.assertEqual(derived_gauge.descriptor.unit, unit)
+        self.assertEqual(derived_gauge.descriptor.label_keys, label_keys)
+        self.assertEqual(derived_gauge.descriptor.type,
+                         metric_descriptor.MetricDescriptorType.GAUGE_INT64)
+
+    def test_create_time_series(self):
+        name = Mock()
+        description = Mock()
+        unit = Mock()
+        label_keys = [Mock(), Mock]
+        derived_gauge = gauge.DerivedLongGauge(
+            name, description, unit, label_keys)
+        with self.assertRaises(ValueError):
+            derived_gauge.create_time_series(None, Mock())
+        with self.assertRaises(ValueError):
+            derived_gauge.create_time_series([Mock()], Mock())
+        with self.assertRaises(ValueError):
+            derived_gauge.create_time_series([Mock(), None], Mock())
+        with self.assertRaises(ValueError):
+            derived_gauge.create_time_series([Mock(), Mock()], None)
+
+        mock_fn = Mock()
+        mock_fn.side_effect = range(10, 12)
+        label_values = [Mock(), Mock()]
+        point = derived_gauge.create_time_series(label_values, mock_fn)
+        self.assertIsInstance(point, gauge.DerivedGaugePoint)
+        self.assertIsInstance(point.gauge_point, gauge.GaugePointLong)
+        mock_fn.assert_not_called()
+        self.assertEqual(len(derived_gauge.points.keys()), 1)
+        [key] = derived_gauge.points.keys()
+        self.assertEqual(key, tuple(label_values))
+        self.assertEqual(point.get_value(), 10)
+        mock_fn.assert_called_once()
+        self.assertEqual(point.get_value(), 11)
+        self.assertEqual(mock_fn.call_count, 2)
+
+        unused_mock_fn = Mock()
+        point2 = derived_gauge.create_time_series(label_values, unused_mock_fn)
+        self.assertIs(point, point2)
+        unused_mock_fn.assert_not_called()
+        self.assertEqual(len(derived_gauge.points.keys()), 1)
+
+    def test_create_default_time_series(self):
+        derived_gauge = gauge.DerivedLongGauge(
+            Mock(), Mock(), Mock(), [Mock(), Mock])
+        mock_fn = Mock()
+        mock_fn.side_effect = range(10, 13)
+
+        with self.assertRaises(ValueError):
+            derived_gauge.create_default_time_series(None)
+
+        default_point = derived_gauge.create_default_time_series(mock_fn)
+        self.assertIsInstance(default_point, gauge.DerivedGaugePoint)
+        self.assertIsInstance(default_point.gauge_point, gauge.GaugePointLong)
+        self.assertEqual(default_point.get_value(), 10)
+        self.assertEqual(len(derived_gauge.points.keys()), 1)
+
+        unused_mock_fn = Mock()
+        point2 = derived_gauge.create_default_time_series(unused_mock_fn)
+        self.assertIs(default_point, point2)
+        self.assertEqual(default_point.get_value(), 11)
+        unused_mock_fn.assert_not_called()
+
+        unused_mock_fn2 = Mock()
+        point3 = derived_gauge._create_time_series(
+            derived_gauge.default_label_values, unused_mock_fn)
+        self.assertIs(default_point, point3)
+        self.assertEqual(default_point.get_value(), 12)
+        unused_mock_fn2.assert_not_called()

--- a/tests/unit/metrics/export/test_gauge.py
+++ b/tests/unit/metrics/export/test_gauge.py
@@ -1,0 +1,269 @@
+# Copyright 2019, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+    from mock import Mock
+except ImportError:
+    from unittest.mock import Mock
+
+import unittest
+
+from opencensus.metrics.export import gauge
+from opencensus.metrics.export import metric_descriptor
+from opencensus.metrics.export import value as value_module
+
+
+class TestGaugePointLong(unittest.TestCase):
+    def test_init(self):
+        point = gauge.GaugePointLong()
+        self.assertEqual(point.value, 0)
+        self.assertIsInstance(point.value, int)
+
+    def test_add(self):
+        point = gauge.GaugePointLong()
+        point.add(10)
+        self.assertEqual(point.value, 10)
+        point.add(-20)
+        self.assertEqual(point.value, -10)
+        with self.assertRaises(ValueError):
+            point.add(10.0)
+
+    def test_set(self):
+        point = gauge.GaugePointLong()
+        point.set(10)
+        self.assertEqual(point.value, 10)
+        point.set(-20)
+        self.assertEqual(point.value, -20)
+        with self.assertRaises(ValueError):
+            point.set(10.0)
+
+
+class TestGaugePointDouble(unittest.TestCase):
+    def test_init(self):
+        point = gauge.GaugePointDouble()
+        self.assertEqual(point.value, 0.0)
+        self.assertIsInstance(point.value, float)
+
+    def test_add(self):
+        point = gauge.GaugePointDouble()
+        point.add(10)
+        self.assertEqual(point.value, 10.0)
+        point.add(-20.2)
+        self.assertEqual(point.value, -10.2)
+
+    def test_set(self):
+        point = gauge.GaugePointDouble()
+        point.set(10)
+        self.assertEqual(point.value, 10.0)
+        point.set(-20.2)
+        self.assertEqual(point.value, -20.2)
+
+
+class TestLongGauge(unittest.TestCase):
+    def test_init(self):
+        name = Mock()
+        description = Mock()
+        unit = Mock()
+        label_keys = [Mock(), Mock]
+        long_gauge = gauge.LongGauge(name, description, unit, label_keys)
+        self.assertEqual(long_gauge.descriptor.name, name)
+        self.assertEqual(long_gauge.descriptor.description, description)
+        self.assertEqual(long_gauge.descriptor.unit, unit)
+        self.assertEqual(long_gauge.descriptor.label_keys, label_keys)
+        self.assertEqual(long_gauge.descriptor.type,
+                         metric_descriptor.MetricDescriptorType.GAUGE_INT64)
+
+    def test_get_time_series(self):
+        name = Mock()
+        description = Mock()
+        unit = Mock()
+        label_keys = [Mock(), Mock]
+        long_gauge = gauge.LongGauge(name, description, unit, label_keys)
+        with self.assertRaises(ValueError):
+            long_gauge.get_or_create_time_series(None)
+        with self.assertRaises(ValueError):
+            long_gauge.get_or_create_time_series([Mock()])
+        with self.assertRaises(ValueError):
+            long_gauge.get_or_create_time_series([Mock(), Mock(), Mock()])
+        with self.assertRaises(ValueError):
+            long_gauge.get_or_create_time_series([Mock(), None])
+
+        label_values = [Mock(), Mock()]
+        point = long_gauge.get_or_create_time_series(label_values)
+        self.assertIsInstance(point, gauge.GaugePointLong)
+        self.assertEqual(point.value, 0)
+        self.assertEqual(len(long_gauge.points.keys()), 1)
+        [key] = long_gauge.points.keys()
+        self.assertEqual(key, tuple(label_values))
+        point2 = long_gauge.get_or_create_time_series(label_values)
+        self.assertIs(point, point2)
+        self.assertEqual(len(long_gauge.points.keys()), 1)
+
+    def test_get_default_time_series(self):
+        long_gauge = gauge.LongGauge(Mock(), Mock(), Mock(), [Mock(), Mock])
+        default_point = long_gauge.get_or_create_default_time_series()
+        self.assertIsInstance(default_point, gauge.GaugePointLong)
+        self.assertEqual(default_point.value, 0)
+        self.assertEqual(len(long_gauge.points.keys()), 1)
+
+    def test_remove_time_series(self):
+        long_gauge = gauge.LongGauge(Mock(), Mock(), Mock(), [Mock(), Mock()])
+
+        with self.assertRaises(ValueError):
+            long_gauge.remove_time_series(None)
+        with self.assertRaises(ValueError):
+            long_gauge.remove_time_series([Mock()])
+        with self.assertRaises(ValueError):
+            long_gauge.remove_time_series([Mock(), Mock(), Mock()])
+        with self.assertRaises(ValueError):
+            long_gauge.remove_time_series([Mock(), None])
+
+        lv1 = [Mock(), Mock()]
+        long_gauge.get_or_create_time_series(lv1)
+        lv2 = [Mock(), Mock()]
+        long_gauge.get_or_create_time_series(lv2)
+        self.assertEqual(len(long_gauge.points.keys()), 2)
+
+        # Removing a non-existent point shouldn't fail, or remove anything
+        long_gauge.remove_time_series([Mock(), Mock()])
+        self.assertEqual(len(long_gauge.points.keys()), 2)
+
+        long_gauge.remove_time_series(lv1)
+        self.assertEqual(len(long_gauge.points.keys()), 1)
+        [key] = long_gauge.points.keys()
+        self.assertEqual(key, tuple(lv2))
+
+        long_gauge.remove_time_series(lv2)
+        self.assertEqual(len(long_gauge.points.keys()), 0)
+
+    def test_remove_default_time_series(self):
+        long_gauge = gauge.LongGauge(Mock(), Mock(), Mock(), [Mock(), Mock()])
+
+        # Removing the default point before it exists shouldn't fail
+        long_gauge.remove_default_time_series()
+
+        long_gauge.get_or_create_default_time_series()
+        self.assertEqual(len(long_gauge.points.keys()), 1)
+        long_gauge.remove_default_time_series()
+        self.assertEqual(len(long_gauge.points.keys()), 0)
+
+    def test_clear(self):
+        name = Mock()
+        description = Mock()
+        unit = Mock()
+        label_keys = [Mock(), Mock]
+        long_gauge = gauge.LongGauge(name, description, unit, label_keys)
+
+        label_values = [Mock(), Mock()]
+        point = long_gauge.get_or_create_time_series(label_values)
+        self.assertEqual(len(long_gauge.points.keys()), 1)
+        point.add(1)
+
+        long_gauge.clear()
+        self.assertDictEqual(long_gauge.points, {})
+
+        label_values = [Mock(), Mock()]
+        point2 = long_gauge.get_or_create_time_series(label_values)
+        self.assertEqual(point2.value, 0)
+        self.assertIsNot(point, point2)
+
+    def test_get_metric(self):
+        name = Mock()
+        description = Mock()
+        unit = Mock()
+        label_keys = [Mock(), Mock]
+        long_gauge = gauge.LongGauge(name, description, unit, label_keys)
+
+        timestamp = Mock()
+        null_metric = long_gauge.get_metric(timestamp)
+        self.assertIsNone(null_metric)
+
+        lv1 = [Mock(), Mock()]
+        lv2 = [Mock(), Mock()]
+        point1 = long_gauge.get_or_create_time_series(lv1)
+        point2 = long_gauge.get_or_create_time_series(lv2)
+
+        point1.set(1)
+        point2.set(2)
+        metric = long_gauge.get_metric(timestamp)
+        self.assertEqual(metric.descriptor, long_gauge.descriptor)
+        self.assertEqual(len(metric.time_series), 2)
+        self.assertEqual(len(metric.time_series[0].points), 1)
+        self.assertEqual(len(metric.time_series[1].points), 1)
+        self.assertIsInstance(metric.time_series[0].points[0].value,
+                              value_module.ValueLong)
+        self.assertIsInstance(metric.time_series[1].points[0].value,
+                              value_module.ValueLong)
+        self.assertEqual(metric.time_series[0].points[0].value.value, 1)
+        self.assertEqual(metric.time_series[1].points[0].value.value, 2)
+
+    def test_get_metric_default(self):
+        name = Mock()
+        description = Mock()
+        unit = Mock()
+        label_keys = [Mock(), Mock]
+        long_gauge = gauge.LongGauge(name, description, unit, label_keys)
+
+        default_point = long_gauge.get_or_create_default_time_series()
+        default_point.set(3)
+
+        timestamp = Mock()
+        metric = long_gauge.get_metric(timestamp)
+        self.assertEqual(metric.descriptor, long_gauge.descriptor)
+        self.assertEqual(len(metric.time_series), 1)
+        self.assertEqual(len(metric.time_series[0].points), 1)
+        self.assertIsInstance(metric.time_series[0].points[0].value,
+                              value_module.ValueLong)
+        self.assertEqual(metric.time_series[0].points[0].value.value, 3)
+
+
+class TestDoubleGauge(unittest.TestCase):
+
+    # TestLongGauge does the heavy lifting, this test just checks that
+    # DoubleGauge creates points and metrics of the right type
+    def test_init(self):
+        name = Mock()
+        description = Mock()
+        unit = Mock()
+        label_keys = [Mock(), Mock]
+        double_gauge = gauge.DoubleGauge(name, description, unit, label_keys)
+        self.assertEqual(double_gauge.descriptor.type,
+                         metric_descriptor.MetricDescriptorType.GAUGE_DOUBLE)
+
+    def test_get_time_series(self):
+        double_gauge = gauge.DoubleGauge(Mock(), Mock(), Mock(),
+                                         [Mock(), Mock])
+        point = double_gauge.get_or_create_time_series([Mock(), Mock()])
+        self.assertIsInstance(point, gauge.GaugePointDouble)
+
+    def test_get_metric(self):
+        double_gauge = gauge.DoubleGauge(Mock(), Mock(), Mock(),
+                                         [Mock(), Mock])
+
+        timestamp = Mock()
+
+        lv1 = [Mock(), Mock()]
+        lv2 = [Mock(), Mock()]
+        point1 = double_gauge.get_or_create_time_series(lv1)
+        point2 = double_gauge.get_or_create_time_series(lv2)
+
+        point1.set(1.2)
+        point2.set(2.2)
+        metric = double_gauge.get_metric(timestamp)
+        self.assertIsInstance(metric.time_series[0].points[0].value,
+                              value_module.ValueDouble)
+        self.assertIsInstance(metric.time_series[1].points[0].value,
+                              value_module.ValueDouble)
+        self.assertEqual(metric.time_series[0].points[0].value.value, 1.2)
+        self.assertEqual(metric.time_series[1].points[0].value.value, 2.2)


### PR DESCRIPTION
This PR follows #494 and adds derived gauge classes `DerivedLongGauge`, `DerivedDoubleGauge`, and `DerivedGaugePoint` similar to the [corresponding classes in the java client](https://github.com/census-instrumentation/opencensus-java/tree/master/impl_core/src/main/java/io/opencensus/implcore/metrics). It also changes `TimeSeries` to allow null-valued points to deal with derived gauges tracking functions that have been garbage collected.