### PR TITLE
Stats: Remove min and max from Distribution.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix bugs in Prometheus exporter. Use ordered list for histogram buckets.
   Use `UnknownMetricFamily` for `SumData` instead of `UntypedMetricFamily`.
   Check if label keys and values match before exporting.
+- Remove min and max from Distribution.
 
 ## 0.2.0
 Released 2019-01-18

--- a/opencensus/stats/aggregation.py
+++ b/opencensus/stats/aggregation.py
@@ -153,7 +153,7 @@ class DistributionAggregation(BaseAggregation):
         self._boundaries = bucket_boundaries.BucketBoundaries(boundaries)
         self._distribution = distribution or {}
         self.aggregation_data = aggregation_data.DistributionAggregationData(
-            0, 0, float('inf'), float('-inf'), 0, None, boundaries)
+            0, 0, 0, None, boundaries)
 
     @property
     def boundaries(self):

--- a/opencensus/stats/aggregation_data.py
+++ b/opencensus/stats/aggregation_data.py
@@ -147,12 +147,6 @@ class DistributionAggregationData(BaseAggregationData):
     :type count_data: int
     :param count_data: the count value of the distribution
 
-    :type min_: double
-    :param min_: the minimum value of the distribution
-
-    :type max_: double
-    :param max_: the maximum value of the distribution
-
     :type sum_of_sqd_deviations: float
     :param sum_of_sqd_deviations: the sum of the sqd deviations from the mean
 
@@ -170,8 +164,6 @@ class DistributionAggregationData(BaseAggregationData):
     def __init__(self,
                  mean_data,
                  count_data,
-                 min_,
-                 max_,
                  sum_of_sqd_deviations,
                  counts_per_bucket=None,
                  bounds=None,
@@ -184,8 +176,6 @@ class DistributionAggregationData(BaseAggregationData):
         super(DistributionAggregationData, self).__init__(mean_data)
         self._mean_data = mean_data
         self._count_data = count_data
-        self._min = min_
-        self._max = max_
         self._sum_of_sqd_deviations = sum_of_sqd_deviations
 
         if bounds is None:
@@ -226,16 +216,6 @@ class DistributionAggregationData(BaseAggregationData):
         return self._count_data
 
     @property
-    def min(self):
-        """The current min value"""
-        return self._min
-
-    @property
-    def max(self):
-        """The current max value"""
-        return self._max
-
-    @property
     def sum_of_sqd_deviations(self):
         """The current sum of squared deviations from the mean"""
         return self._sum_of_sqd_deviations
@@ -269,10 +249,6 @@ class DistributionAggregationData(BaseAggregationData):
 
     def add_sample(self, value, timestamp, attachments):
         """Adding a sample to Distribution Aggregation Data"""
-        if value < self.min:
-            self._min = value
-        if value > self.max:
-            self._max = value
         self._count_data += 1
         bucket = self.increment_bucket_count(value)
 

--- a/tests/unit/stats/exporters/test_stackdriver_stats.py
+++ b/tests/unit/stats/exporters/test_stackdriver_stats.py
@@ -886,8 +886,6 @@ class TestStackdriverStatsExporter(unittest.TestCase):
         dad = aggregation_data_module.DistributionAggregationData(
             mean_data=4.5,
             count_data=100,
-            min_=0,
-            max_=9,
             sum_of_sqd_deviations=825,
             counts_per_bucket=[20, 20, 20, 20, 20],
             bounds=[2, 4, 6, 8],

--- a/tests/unit/stats/test_aggregation.py
+++ b/tests/unit/stats/test_aggregation.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import datetime
 import unittest
 
 from opencensus.stats import aggregation as aggregation_module

--- a/tests/unit/stats/test_aggregation.py
+++ b/tests/unit/stats/test_aggregation.py
@@ -111,18 +111,6 @@ class TestDistributionAggregation(unittest.TestCase):
         self.assertEqual(aggregation_module.Type.DISTRIBUTION,
                          distribution_aggregation.aggregation_type)
 
-    def test_min_max(self):
-        da = aggregation_module.DistributionAggregation([])
-
-        self.assertEqual(da.aggregation_data.min, float('inf'))
-        self.assertEqual(da.aggregation_data.max, float('-inf'))
-
-        for dp in range(-10, 11):
-            da.aggregation_data.add_sample(dp, datetime(1999, 12, 31), {})
-
-        self.assertEqual(da.aggregation_data.min, -10)
-        self.assertEqual(da.aggregation_data.max, 10)
-
     def test_init_bad_boundaries(self):
         """Check that boundaries must be sorted and unique."""
         with self.assertRaises(ValueError):

--- a/tests/unit/stats/test_aggregation_data.py
+++ b/tests/unit/stats/test_aggregation_data.py
@@ -1,4 +1,5 @@
 # Copyright 2018, OpenCensus Authors
+# Copyright 2018, OpenCensus Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -127,8 +128,6 @@ class TestDistributionAggregationData(unittest.TestCase):
     def test_constructor(self):
         mean_data = 1
         count_data = 0
-        _min = 0
-        _max = 1
         sum_of_sqd_deviations = mock.Mock()
         counts_per_bucket = [1, 1, 1]
         bounds = [1.0 / 2.0, 1]
@@ -136,16 +135,12 @@ class TestDistributionAggregationData(unittest.TestCase):
         dist_agg_data = aggregation_data_module.DistributionAggregationData(
             mean_data=mean_data,
             count_data=count_data,
-            min_=_min,
-            max_=_max,
             sum_of_sqd_deviations=sum_of_sqd_deviations,
             counts_per_bucket=counts_per_bucket,
             bounds=bounds)
 
         self.assertEqual(1, dist_agg_data.mean_data)
         self.assertEqual(0, dist_agg_data.count_data)
-        self.assertEqual(0, dist_agg_data.min)
-        self.assertEqual(1, dist_agg_data.max)
         self.assertEqual(sum_of_sqd_deviations,
                          dist_agg_data.sum_of_sqd_deviations)
         self.assertEqual([1, 1, 1], dist_agg_data.counts_per_bucket)
@@ -160,8 +155,6 @@ class TestDistributionAggregationData(unittest.TestCase):
             aggregation_data_module.DistributionAggregationData(
                 mean_data=mock.Mock(),
                 count_data=mock.Mock(),
-                min_=mock.Mock(),
-                max_=mock.Mock(),
                 sum_of_sqd_deviations=mock.Mock(),
                 counts_per_bucket=[0, 0, 0],
                 bounds=[1, 2, 3])
@@ -171,8 +164,6 @@ class TestDistributionAggregationData(unittest.TestCase):
             aggregation_data_module.DistributionAggregationData(
                 mean_data=mock.Mock(),
                 count_data=mock.Mock(),
-                min_=mock.Mock(),
-                max_=mock.Mock(),
                 sum_of_sqd_deviations=mock.Mock(),
                 counts_per_bucket=[0, 2, -2, 0],
                 bounds=[1, 2, 3])
@@ -181,8 +172,6 @@ class TestDistributionAggregationData(unittest.TestCase):
         aggregation_data_module.DistributionAggregationData(
             mean_data=mock.Mock(),
             count_data=mock.Mock(),
-            min_=mock.Mock(),
-            max_=mock.Mock(),
             sum_of_sqd_deviations=mock.Mock(),
             counts_per_bucket=[0, 0, 0, 0],
             bounds=[1, 2, 3])
@@ -193,8 +182,6 @@ class TestDistributionAggregationData(unittest.TestCase):
             aggregation_data_module.DistributionAggregationData(
                 mean_data=mock.Mock(),
                 count_data=mock.Mock(),
-                min_=mock.Mock(),
-                max_=mock.Mock(),
                 sum_of_sqd_deviations=mock.Mock(),
                 counts_per_bucket=[0, 0, 0, 0],
                 bounds=[1, 2, 2])
@@ -204,8 +191,6 @@ class TestDistributionAggregationData(unittest.TestCase):
             aggregation_data_module.DistributionAggregationData(
                 mean_data=mock.Mock(),
                 count_data=mock.Mock(),
-                min_=mock.Mock(),
-                max_=mock.Mock(),
                 sum_of_sqd_deviations=mock.Mock(),
                 counts_per_bucket=[0, 0, 0, 0],
                 bounds=[1, 3, 2])
@@ -215,8 +200,6 @@ class TestDistributionAggregationData(unittest.TestCase):
             aggregation_data_module.DistributionAggregationData(
                 mean_data=mock.Mock(),
                 count_data=mock.Mock(),
-                min_=mock.Mock(),
-                max_=mock.Mock(),
                 sum_of_sqd_deviations=mock.Mock(),
                 counts_per_bucket=[0, 0, 0, 0],
                 bounds=[-1, 1, 2])
@@ -227,8 +210,6 @@ class TestDistributionAggregationData(unittest.TestCase):
             aggregation_data_module.DistributionAggregationData(
                 mean_data=mock.Mock(),
                 count_data=mock.Mock(),
-                min_=mock.Mock(),
-                max_=mock.Mock(),
                 sum_of_sqd_deviations=mock.Mock(),
                 counts_per_bucket=mock.Mock(),
                 bounds=None,
@@ -239,8 +220,6 @@ class TestDistributionAggregationData(unittest.TestCase):
             aggregation_data_module.DistributionAggregationData(
                 mean_data=mock.Mock(),
                 count_data=mock.Mock(),
-                min_=mock.Mock(),
-                max_=mock.Mock(),
                 sum_of_sqd_deviations=mock.Mock(),
                 counts_per_bucket=mock.Mock(),
                 bounds=[0, 1],
@@ -256,8 +235,6 @@ class TestDistributionAggregationData(unittest.TestCase):
         ]
         mean_data = 2.59
         count_data = 3
-        _min = .07
-        _max = 7
         sum_of_sqd_deviations = mock.Mock()
         counts_per_bucket = [1, 1, 1]
         bounds = [1.0 / 2.0, 1]
@@ -265,8 +242,6 @@ class TestDistributionAggregationData(unittest.TestCase):
         dist_agg_data = aggregation_data_module.DistributionAggregationData(
             mean_data=mean_data,
             count_data=count_data,
-            min_=_min,
-            max_=_max,
             sum_of_sqd_deviations=sum_of_sqd_deviations,
             exemplars=exemplars,
             counts_per_bucket=counts_per_bucket,
@@ -274,8 +249,6 @@ class TestDistributionAggregationData(unittest.TestCase):
 
         self.assertEqual(dist_agg_data.mean_data, mean_data)
         self.assertEqual(dist_agg_data.count_data, count_data)
-        self.assertEqual(dist_agg_data.min, _min)
-        self.assertEqual(dist_agg_data.max, _max)
         self.assertEqual(dist_agg_data.sum_of_sqd_deviations,
                          sum_of_sqd_deviations)
         self.assertEqual(dist_agg_data.counts_per_bucket, counts_per_bucket)
@@ -339,16 +312,12 @@ class TestDistributionAggregationData(unittest.TestCase):
     def test_variance(self):
         mean_data = mock.Mock()
         count_data = 0
-        _min = mock.Mock()
-        _max = mock.Mock()
         sum_of_sqd_deviations = mock.Mock()
         counts_per_bucket = [1, 1, 1]
         bounds = [1.0 / 2.0, 1]
         dist_agg_data = aggregation_data_module.DistributionAggregationData(
             mean_data=mean_data,
             count_data=count_data,
-            min_=_min,
-            max_=_max,
             sum_of_sqd_deviations=sum_of_sqd_deviations,
             counts_per_bucket=counts_per_bucket,
             bounds=bounds)
@@ -359,8 +328,6 @@ class TestDistributionAggregationData(unittest.TestCase):
         dist_agg_data = aggregation_data_module.DistributionAggregationData(
             mean_data=mean_data,
             count_data=count_data,
-            min_=_min,
-            max_=_max,
             sum_of_sqd_deviations=sum_of_sqd_deviations,
             counts_per_bucket=counts_per_bucket,
             bounds=bounds)
@@ -369,8 +336,6 @@ class TestDistributionAggregationData(unittest.TestCase):
     def test_add_sample(self):
         mean_data = 1.0
         count_data = 0
-        _min = 0
-        _max = 1
         sum_of_sqd_deviations = 2
         counts_per_bucket = [1, 1, 1, 1]
         bounds = [0.5, 1, 1.5]
@@ -380,15 +345,11 @@ class TestDistributionAggregationData(unittest.TestCase):
         dist_agg_data = aggregation_data_module.DistributionAggregationData(
             mean_data=mean_data,
             count_data=count_data,
-            min_=_min,
-            max_=_max,
             sum_of_sqd_deviations=sum_of_sqd_deviations,
             counts_per_bucket=counts_per_bucket,
             bounds=bounds)
 
         dist_agg_data.add_sample(value, None, None)
-        self.assertEqual(0, dist_agg_data.min)
-        self.assertEqual(3, dist_agg_data.max)
         self.assertEqual(1, dist_agg_data.count_data)
         self.assertEqual(value, dist_agg_data.mean_data)
 
@@ -396,8 +357,6 @@ class TestDistributionAggregationData(unittest.TestCase):
         dist_agg_data = aggregation_data_module.DistributionAggregationData(
             mean_data=mean_data,
             count_data=count_data,
-            min_=_min,
-            max_=_max,
             sum_of_sqd_deviations=sum_of_sqd_deviations,
             counts_per_bucket=counts_per_bucket,
             bounds=bounds)
@@ -408,15 +367,9 @@ class TestDistributionAggregationData(unittest.TestCase):
         self.assertEqual(4.0, dist_agg_data.sum_of_sqd_deviations)
         self.assertIsNot(0, dist_agg_data.count_data)
 
-        value_2 = -1
-        dist_agg_data.add_sample(value_2, None, None)
-        self.assertEqual(value_2, dist_agg_data.min)
-
     def test_add_sample_attachment(self):
         mean_data = 1.0
         count_data = 1
-        _min = 0
-        _max = 1
         sum_of_sqd_deviations = 2
         counts_per_bucket = [1, 1, 1, 1]
         bounds = [0.5, 1, 1.5]
@@ -430,8 +383,6 @@ class TestDistributionAggregationData(unittest.TestCase):
         dist_agg_data = aggregation_data_module.DistributionAggregationData(
             mean_data=mean_data,
             count_data=count_data,
-            min_=_min,
-            max_=_max,
             sum_of_sqd_deviations=sum_of_sqd_deviations,
             counts_per_bucket=counts_per_bucket,
             bounds=bounds,
@@ -440,8 +391,6 @@ class TestDistributionAggregationData(unittest.TestCase):
         self.assertEqual(dist_agg_data.exemplars[3], exemplar_1)
 
         dist_agg_data.add_sample(value, timestamp, attachments)
-        self.assertEqual(0, dist_agg_data.min)
-        self.assertEqual(3, dist_agg_data.max)
         self.assertEqual(2, dist_agg_data.count_data)
         self.assertEqual(2.0, dist_agg_data.mean_data)
         # Check that adding a sample overwrites the bucket's exemplar
@@ -453,8 +402,6 @@ class TestDistributionAggregationData(unittest.TestCase):
         dist_agg_data = aggregation_data_module.DistributionAggregationData(
             mean_data=mean_data,
             count_data=count_data,
-            min_=_min,
-            max_=_max,
             sum_of_sqd_deviations=sum_of_sqd_deviations,
             counts_per_bucket=[2, 1, 2, 1, 1, 1],
             bounds=[1, 2, 3, 4, 5])
@@ -469,8 +416,6 @@ class TestDistributionAggregationData(unittest.TestCase):
     def test_increment_bucket_count(self):
         mean_data = mock.Mock()
         count_data = mock.Mock()
-        _min = 0
-        _max = 1
         sum_of_sqd_deviations = mock.Mock()
         counts_per_bucket = [0]
         bounds = []
@@ -480,8 +425,6 @@ class TestDistributionAggregationData(unittest.TestCase):
         dist_agg_data = aggregation_data_module.DistributionAggregationData(
             mean_data=mean_data,
             count_data=count_data,
-            min_=_min,
-            max_=_max,
             sum_of_sqd_deviations=sum_of_sqd_deviations,
             counts_per_bucket=counts_per_bucket,
             bounds=bounds)
@@ -495,8 +438,6 @@ class TestDistributionAggregationData(unittest.TestCase):
         dist_agg_data = aggregation_data_module.DistributionAggregationData(
             mean_data=mean_data,
             count_data=count_data,
-            min_=_min,
-            max_=_max,
             sum_of_sqd_deviations=sum_of_sqd_deviations,
             counts_per_bucket=counts_per_bucket,
             bounds=bounds)
@@ -509,8 +450,6 @@ class TestDistributionAggregationData(unittest.TestCase):
         dist_agg_data = aggregation_data_module.DistributionAggregationData(
             mean_data=mean_data,
             count_data=count_data,
-            min_=_min,
-            max_=_max,
             sum_of_sqd_deviations=sum_of_sqd_deviations,
             counts_per_bucket=counts_per_bucket,
             bounds=bounds)
@@ -529,8 +468,6 @@ class TestDistributionAggregationData(unittest.TestCase):
         dist_agg_data = aggregation_data_module.DistributionAggregationData(
             mean_data=50,
             count_data=99,
-            min_=1,
-            max_=99,
             sum_of_sqd_deviations=80850.0,
             counts_per_bucket=[0, 9, 90, 0],
             bounds=[1, 10, 100],
@@ -561,8 +498,6 @@ class TestDistributionAggregationData(unittest.TestCase):
         dist_agg_data = aggregation_data_module.DistributionAggregationData(
             mean_data=50,
             count_data=99,
-            min_=1,
-            max_=99,
             sum_of_sqd_deviations=80850.0,
         )
         converted_point = dist_agg_data.to_point(timestamp)

--- a/tests/unit/stats/test_aggregation_data.py
+++ b/tests/unit/stats/test_aggregation_data.py
@@ -1,5 +1,4 @@
 # Copyright 2018, OpenCensus Authors
-# Copyright 2018, OpenCensus Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes https://github.com/census-instrumentation/opencensus-python/issues/411.

`min` and `max` have been removed from `Distribution` in all other languages.