### PR TITLE
Stats: Make defensive copy and set end time for ViewData when export.

### DIFF
--- a/opencensus/stats/measure_to_view_map.py
+++ b/opencensus/stats/measure_to_view_map.py
@@ -66,7 +66,7 @@ class MeasureToViewMap(object):
         else:
             return None
 
-        return self.copy_view_data(view_data)
+        return self.copy_and_finalize_view_data(view_data)
 
     def filter_exported_views(self, all_views):
         """returns the subset of the given view that should be exported"""
@@ -120,7 +120,8 @@ class MeasureToViewMap(object):
 
     def export(self, view_datas):
         """export view datas to registered exporters"""
-        view_datas_copy = [self.copy_view_data(vd) for vd in view_datas]
+        view_datas_copy = \
+            [self.copy_and_finalize_view_data(vd) for vd in view_datas]
         if len(self.exporters) > 0:
             for e in self.exporters:
                 e.export(view_datas_copy)
@@ -144,7 +145,7 @@ class MeasureToViewMap(object):
                     yield metric
 
     # TODO(issue #470): remove this method once we export immutable stats.
-    def copy_view_data(self, view_data):
+    def copy_and_finalize_view_data(self, view_data):
         view_data_copy = copy.copy(view_data)
         tvdam_copy = copy.deepcopy(view_data.tag_value_aggregation_data_map)
         view_data_copy._tag_value_aggregation_data_map = tvdam_copy

--- a/opencensus/stats/measure_to_view_map.py
+++ b/opencensus/stats/measure_to_view_map.py
@@ -66,11 +66,7 @@ class MeasureToViewMap(object):
         else:
             return None
 
-        view_data_copy = copy.copy(view_data)
-        tvdam_copy = copy.deepcopy(view_data.tag_value_aggregation_data_map)
-        view_data_copy._tag_value_aggregation_data_map = tvdam_copy
-        view_data_copy.end()
-        return view_data_copy
+        return self.copy_view_data(view_data)
 
     def filter_exported_views(self, all_views):
         """returns the subset of the given view that should be exported"""
@@ -124,9 +120,10 @@ class MeasureToViewMap(object):
 
     def export(self, view_datas):
         """export view datas to registered exporters"""
+        view_datas_copy = [self.copy_view_data(vd) for vd in view_datas]
         if len(self.exporters) > 0:
             for e in self.exporters:
-                e.export(view_datas)
+                e.export(view_datas_copy)
 
     def get_metrics(self, timestamp):
         """Get a Metric for each registered view.
@@ -145,3 +142,11 @@ class MeasureToViewMap(object):
                 metric = metric_utils.view_data_to_metric(vd, timestamp)
                 if metric is not None:
                     yield metric
+
+    # TODO(issue #470): remove this method once we export immutable stats.
+    def copy_view_data(self, view_data):
+        view_data_copy = copy.copy(view_data)
+        tvdam_copy = copy.deepcopy(view_data.tag_value_aggregation_data_map)
+        view_data_copy._tag_value_aggregation_data_map = tvdam_copy
+        view_data_copy.end()
+        return view_data_copy

--- a/tests/unit/stats/test_measure_to_view_map.py
+++ b/tests/unit/stats/test_measure_to_view_map.py
@@ -16,11 +16,8 @@ import unittest
 
 import mock
 
-from opencensus.stats import aggregation as aggregation_module
-from opencensus.stats import measure as measure_module
-from opencensus.stats import view as view_module
-from opencensus.stats import view_data as view_data_module
 from opencensus.stats import measure_to_view_map as measure_to_view_map_module
+from opencensus.stats.aggregation import CountAggregation
 from opencensus.stats.measure import BaseMeasure
 from opencensus.stats.measure import MeasureInt
 from opencensus.stats.view import View
@@ -29,11 +26,11 @@ from opencensus.tags import tag_key as tag_key_module
 
 
 METHOD_KEY = tag_key_module.TagKey("method")
-REQUEST_COUNT_MEASURE = measure_module.MeasureInt(
+REQUEST_COUNT_MEASURE = MeasureInt(
     "request_count", "number of requests", "1")
 REQUEST_COUNT_VIEW_NAME = "request_count_view"
-COUNT = aggregation_module.CountAggregation()
-REQUEST_COUNT_VIEW = view_module.View(
+COUNT = CountAggregation()
+REQUEST_COUNT_VIEW = View(
     REQUEST_COUNT_VIEW_NAME,
     "number of requests broken down by methods",
     [METHOD_KEY], REQUEST_COUNT_MEASURE, COUNT)
@@ -404,8 +401,7 @@ class TestMeasureToViewMap(unittest.TestCase):
 
         timestamp1 = mock.Mock()
         timestamp2 = mock.Mock()
-        view_data = view_data_module.ViewData(
-            REQUEST_COUNT_VIEW, timestamp1, timestamp2)
+        view_data = ViewData(REQUEST_COUNT_VIEW, timestamp1, timestamp2)
         mtvm.export([view_data])
         mtvm.export([view_data])
         self.assertEqual(exporter.export.call_count, 2)

--- a/tests/unit/stats/test_measure_to_view_map.py
+++ b/tests/unit/stats/test_measure_to_view_map.py
@@ -378,3 +378,20 @@ class TestMeasureToViewMap(unittest.TestCase):
         measure_to_view_map._registered_measures = {}
         measure_to_view_map.export(view_data)
         self.assertTrue(True)
+
+    def test_export_duplicates_viewdata(self):
+        """Check that we copy view data on export."""
+        mtvm = measure_to_view_map_module.MeasureToViewMap()
+
+        exporter = mock.Mock()
+        mtvm.exporters.append(exporter)
+
+        view_data = mock.Mock(spec=ViewData)
+        mtvm.export([view_data])
+        mtvm.export([view_data])
+        self.assertEqual(exporter.export.call_count, 2)
+
+        exported_call1, exported_call2 = exporter.export.call_args_list
+        exported_vd1 = exported_call1[0][0][0]
+        exported_vd2 = exported_call2[0][0][0]
+        self.assertIsNot(exported_vd1, exported_vd2)


### PR DESCRIPTION
Updates https://github.com/census-instrumentation/opencensus-python/issues/509.