### PR TITLE
Value type lint fixes

### DIFF
--- a/opencensus/metrics/export/point.py
+++ b/opencensus/metrics/export/point.py
@@ -16,11 +16,14 @@
 class Point(object):
     """A timestamped measurement of a TimeSeries.
 
-    :type value: Value
-    :param value: the Value of the Point.
+    :type value: :class:`opencensus.metrics.export.value.ValueDouble` or
+        :class:`opencensus.metrics.export.value.ValueLong` or
+        :class:`opencensus.metrics.export.value.ValueSummary` or
+        :class:`opencensus.metrics.export.value.ValueDistribution`
+    :param value: the point value.
 
     :type timestamp: time
-    :param timestamp: the Timestamp when the Point was recorded.
+    :param timestamp: the timestamp when the `Point` was recorded.
     """
 
     def __init__(self, value, timestamp):
@@ -29,12 +32,10 @@ class Point(object):
 
     @property
     def value(self):
-        """Returns the Value"""
         return self._value
 
     @property
     def timestamp(self):
-        """Returns the Timestamp when this Point was recorded."""
         return self._timestamp
 
     def __repr__(self):

--- a/opencensus/metrics/export/value.py
+++ b/opencensus/metrics/export/value.py
@@ -21,55 +21,7 @@ https://github.com/census-instrumentation/opencensus-proto/blob/v0.1.0/src/openc
 from copy import copy
 
 
-class Value(object):
-    """The actual point value for a Point.
-    Currently there are four types of Value:
-     <ul>
-       <li>double
-       <li>long
-       <li>Summary
-       <li>Distribution (TODO(mayurkale): add Distribution class)
-     </ul>
-    Each Point contains exactly one of the four Value types.
-    """
-
-    def __init__(self, value):
-        self._value = value
-
-    @staticmethod
-    def double_value(value):
-        """Returns a double Value
-
-        :type value: float
-        :param value: value in double
-        """
-        return ValueDouble(value)
-
-    @staticmethod
-    def long_value(value):
-        """Returns a long Value
-
-        :type value: long
-        :param value: value in long
-        """
-        return ValueLong(value)
-
-    @staticmethod
-    def summary_value(value):
-        """Returns a summary Value
-
-        :type value: Summary
-        :param value: value in Summary
-        """
-        return ValueSummary(value)
-
-    @property
-    def value(self):
-        """Returns the value."""
-        return self._value
-
-
-class ValueDouble(Value):
+class ValueDouble(object):
     """A 64-bit double-precision floating-point number.
 
     :type value: float
@@ -77,7 +29,7 @@ class ValueDouble(Value):
     """
 
     def __init__(self, value):
-        super(ValueDouble, self).__init__(value)
+        self._value = value
 
     def __repr__(self):
         return ("{}({})"
@@ -86,8 +38,12 @@ class ValueDouble(Value):
                     self.value,
                 ))
 
+    @property
+    def value(self):
+        return self._value
 
-class ValueLong(Value):
+
+class ValueLong(object):
     """A 64-bit integer.
 
     :type value: long
@@ -95,7 +51,7 @@ class ValueLong(Value):
     """
 
     def __init__(self, value):
-        super(ValueLong, self).__init__(value)
+        self._value = value
 
     def __repr__(self):
         return ("{}({})"
@@ -104,8 +60,12 @@ class ValueLong(Value):
                     self.value,
                 ))
 
+    @property
+    def value(self):
+        return self._value
 
-class ValueSummary(Value):
+
+class ValueSummary(object):
     """Represents a snapshot values calculated over an arbitrary time window.
 
     :type value: summary
@@ -113,7 +73,7 @@ class ValueSummary(Value):
     """
 
     def __init__(self, value):
-        super(ValueSummary, self).__init__(value)
+        self._value = value
 
     def __repr__(self):
         return ("{}({})"
@@ -121,6 +81,10 @@ class ValueSummary(Value):
                     type(self).__name__,
                     self.value,
                 ))
+
+    @property
+    def value(self):
+        return self._value
 
 
 class Exemplar(object):
@@ -227,7 +191,7 @@ class BucketOptions(object):
         return self._type
 
 
-class ValueDistribution(Value):
+class ValueDistribution(object):
     """Summary statistics for a population of values.
 
     Distribution contains summary statistics for a population of values. It

--- a/tests/unit/metrics/export/test_point.py
+++ b/tests/unit/metrics/export/test_point.py
@@ -20,14 +20,14 @@ from opencensus.metrics.export import value as value_module
 
 class TestPoint(unittest.TestCase):
     def setUp(self):
-        self.double_value = value_module.Value.double_value(55.5)
-        self.long_value = value_module.Value.long_value(9876543210)
+        self.double_value = value_module.ValueDouble(55.5)
+        self.long_value = value_module.ValueLong(9876543210)
         self.timestamp = '2018-10-06T17:57:57.936475Z'
 
         value_at_percentile = [summary_module.ValueAtPercentile(99.5, 10.2)]
         snapshot = summary_module.Snapshot(10, 87.07, value_at_percentile)
         self.summary = summary_module.Summary(10, 6.6, snapshot)
-        self.summary_value = value_module.Value.summary_value(self.summary)
+        self.summary_value = value_module.ValueSummary(self.summary)
         self.distribution_value = value_module.ValueDistribution(
             100,
             1000.0,

--- a/tests/unit/metrics/export/test_time_series.py
+++ b/tests/unit/metrics/export/test_time_series.py
@@ -26,15 +26,15 @@ LABEL_VALUE1 = label_value.LabelValue('value one')
 LABEL_VALUE2 = label_value.LabelValue('价值二')
 LABEL_VALUES = (LABEL_VALUE1, LABEL_VALUE2)
 POINTS = (point.Point(
-    value.Value.long_value(1), "2018-10-09T23:33:44.012345Z"),
+    value.ValueLong(1), "2018-10-09T23:33:44.012345Z"),
           point.Point(
-              value.Value.long_value(2), "2018-10-10T00:33:44.012345Z"),
+              value.ValueLong(2), "2018-10-10T00:33:44.012345Z"),
           point.Point(
-              value.Value.long_value(3), "2018-10-10T01:33:44.012345Z"),
+              value.ValueLong(3), "2018-10-10T01:33:44.012345Z"),
           point.Point(
-              value.Value.long_value(4), "2018-10-10T02:33:44.012345Z"),
+              value.ValueLong(4), "2018-10-10T02:33:44.012345Z"),
           point.Point(
-              value.Value.long_value(5), "2018-10-10T03:33:44.012345Z"))
+              value.ValueLong(5), "2018-10-10T03:33:44.012345Z"))
 
 
 class TestTimeSeries(unittest.TestCase):
@@ -61,7 +61,7 @@ class TestTimeSeries(unittest.TestCase):
         self.assertTrue(ts.check_points_type(value.ValueLong))
 
         bad_points = POINTS + (point.Point(
-            value.Value.double_value(6.0), "2018-10-10T04:33:44.012345Z"), )
+            value.ValueDouble(6.0), "2018-10-10T04:33:44.012345Z"), )
         bad_time_series = time_series.TimeSeries(LABEL_VALUES, bad_points,
                                                  START_TIMESTAMP)
 

--- a/tests/unit/metrics/export/test_value.py
+++ b/tests/unit/metrics/export/test_value.py
@@ -20,14 +20,14 @@ from opencensus.metrics.export import value as value_module
 
 class TestValue(unittest.TestCase):
     def test_create_double_value(self):
-        double_value = value_module.Value.double_value(-34.56)
+        double_value = value_module.ValueDouble(-34.56)
 
         self.assertIsNotNone(double_value)
         self.assertIsInstance(double_value, value_module.ValueDouble)
         self.assertEqual(double_value.value, -34.56)
 
     def test_create_long_value(self):
-        long_value = value_module.Value.long_value(123456789)
+        long_value = value_module.ValueLong(123456789)
 
         self.assertIsNotNone(long_value)
         self.assertIsInstance(long_value, value_module.ValueLong)
@@ -38,7 +38,7 @@ class TestValue(unittest.TestCase):
         snapshot = summary_module.Snapshot(10, 87.07, value_at_percentile)
         summary = summary_module.Summary(10, 6.6, snapshot)
 
-        summary_value = value_module.Value.summary_value(summary)
+        summary_value = value_module.ValueSummary(summary)
 
         self.assertIsNotNone(summary_value)
         self.assertIsInstance(summary_value, value_module.ValueSummary)


### PR DESCRIPTION
This is a quick fix for `Value` type issues that pylint turned up.

In short: `ValueDistribution` either shouldn't be a `Value` since it doesn't have a `_value` attr or `Value` should be abstract. In either case, as far as I can tell there's no real benefit to having a `Value` class if we're not also using e.g. `Distribution` and `Summary` classes as in the java client.