### PR TITLE
Tracing: Add Double/Float64 Attribute.

### DIFF
--- a/opencensus/trace/attributes.py
+++ b/opencensus/trace/attributes.py
@@ -24,6 +24,8 @@ def _format_attribute_value(value):
     elif isinstance(value, six.string_types):
         value_type = 'string_value'
         value = utils._get_truncatable_str(value)
+    elif isinstance(value, float):
+        value_type = 'double_value'
     else:
         return None
 
@@ -36,7 +38,8 @@ class Attributes(object):
     :type attributes: dict
     :param attributes: The set of attributes. Each attribute's key can be up
                        to 128 bytes long. The value can be a string up to 256
-                       bytes, an integer, or the Boolean values true and false.
+                       bytes, an integer, a floating-point number, or the
+                       Boolean values true and false.
     """
     def __init__(self, attributes=None):
         self.attributes = attributes or {}

--- a/opencensus/trace/exporters/jaeger_exporter.py
+++ b/opencensus/trace/exporters/jaeger_exporter.py
@@ -312,6 +312,11 @@ def _convert_attribute_to_tag(key, attr):
             key=key,
             vLong=attr,
             vType=jaeger.TagType.LONG)
+    if isinstance(attr, float):
+        return jaeger.Tag(
+            key=key,
+            vDouble=attr,
+            vType=jaeger.TagType.DOUBLE)
     logging.warn('Could not serialize attribute \
             {}:{} to tag'.format(key, attr))
     return None

--- a/opencensus/trace/exporters/ocagent/utils.py
+++ b/opencensus/trace/exporters/ocagent/utils.py
@@ -224,10 +224,6 @@ def add_proto_attribute_value(
     elif isinstance(attribute_value, str):
         pb_attributes.attribute_map[attribute_key].\
             string_value.value = attribute_value
-    # TODO(songya): uncomment this once the gen-proto files are updated.
-    # elif isinstance(attribute_value, float):
-    #     pb_attributes.attribute_map[attribute_key].\
-    #         double_value.value = attribute_value
     else:
         pb_attributes.attribute_map[attribute_key].\
             string_value.value = str(attribute_value)

--- a/opencensus/trace/exporters/ocagent/utils.py
+++ b/opencensus/trace/exporters/ocagent/utils.py
@@ -201,7 +201,7 @@ def add_proto_attribute_value(
         pb_attributes,
         attribute_key,
         attribute_value):
-    """Sets string, int or boolean value on protobuf
+    """Sets string, int, boolean or float value on protobuf
         span, link or annotation attributes.
 
     :type pb_attributes:
@@ -224,6 +224,10 @@ def add_proto_attribute_value(
     elif isinstance(attribute_value, str):
         pb_attributes.attribute_map[attribute_key].\
             string_value.value = attribute_value
+    # TODO(songya): uncomment this once the gen-proto files are updated.
+    # elif isinstance(attribute_value, float):
+    #     pb_attributes.attribute_map[attribute_key].\
+    #         double_value.value = attribute_value
     else:
         pb_attributes.attribute_map[attribute_key].\
             string_value.value = str(attribute_value)

--- a/opencensus/trace/exporters/zipkin_exporter.py
+++ b/opencensus/trace/exporters/zipkin_exporter.py
@@ -187,7 +187,7 @@ def _extract_tags_from_span(attr):
         return {}
     tags = {}
     for attribute_key, attribute_value in attr.items():
-        if isinstance(attribute_value, (int, bool)):
+        if isinstance(attribute_value, (int, bool, float)):
             value = str(attribute_value)
         elif isinstance(attribute_value, str):
             res, _ = check_str_length(str_to_check=attribute_value)

--- a/tests/unit/trace/exporters/ocagent/test_trace_exporter_utils.py
+++ b/tests/unit/trace/exporters/ocagent/test_trace_exporter_utils.py
@@ -42,7 +42,6 @@ class TestTraceExporterUtils(unittest.TestCase):
                 'test_str_key': 'test_str_value',
                 'test_int_key': 1,
                 'test_bool_key': False
-                # 'test_double_key': 567.89
             },
             start_time='2017-08-15T18:02:26.071158Z',
             end_time='2017-08-15T18:02:36.071158Z',
@@ -76,8 +75,6 @@ class TestTraceExporterUtils(unittest.TestCase):
                          trace_pb2.AttributeValue(int_value=1))
         self.assertEqual(pb_span.attributes.attribute_map['test_bool_key'],
                          trace_pb2.AttributeValue(bool_value=False))
-        # self.assertEqual(pb_span.attributes.attribute_map['test_double_key'],
-        #                  trace_pb2.AttributeValue(double_value=567.89))
 
         self.assertEqual(pb_span.start_time.ToJsonString(),
                          '2017-08-15T18:02:26.071158Z')
@@ -186,7 +183,6 @@ class TestTraceExporterUtils(unittest.TestCase):
                             'test_str_key': 'test_str_value',
                             'test_int_key': 1,
                             'test_bool_key': False
-                            # 'test_double_key': 567.89
                         })),
                 link_module.Link(
                     trace_id='1e0c63257de34c92bf9efcd03927272e',
@@ -252,9 +248,6 @@ class TestTraceExporterUtils(unittest.TestCase):
         self.assertEqual(
             pb_span.links.link[0].attributes.attribute_map['test_bool_key'],
             trace_pb2.AttributeValue(bool_value=False))
-        # self.assertEqual(
-        #     pb_span.links.link[0].attributes.attribute_map['test_double_key'],
-        #     trace_pb2.AttributeValue(double_key=567.89))
 
     def test_translate_time_events(self):
 
@@ -277,8 +270,7 @@ class TestTraceExporterUtils(unittest.TestCase):
                             attributes={
                                 'test_str_key': 'test_str_value',
                                 'test_int_key': 1,
-                                'test_bool_key': False,
-                                # 'test_double_key': 567.89
+                                'test_bool_key': False
                             }))),
                 time_event_module.TimeEvent(
                     timestamp=annotation1_ts,
@@ -351,9 +343,6 @@ class TestTraceExporterUtils(unittest.TestCase):
         self.assertEqual(
             event0.annotation.attributes.attribute_map['test_bool_key'],
             trace_pb2.AttributeValue(bool_value=False))
-        # self.assertEqual(
-        #     event0.annotation.attributes.attribute_map['test_double_key'],
-        #     trace_pb2.AttributeValue(double_value=567.89))
 
         self.assertEqual(event2.message_event.id, 0)
         self.assertEqual(event3.message_event.id, 1)
@@ -486,7 +475,6 @@ class TestTraceExporterUtils(unittest.TestCase):
                     'test_str_key': 'test_str_value',
                     'test_int_key': 1,
                     'test_bool_key': False
-                    # 'test_double_key': 567.89
                 }))
 
         utils.set_proto_annotation(pb_event.annotation, annotation)
@@ -504,9 +492,6 @@ class TestTraceExporterUtils(unittest.TestCase):
         self.assertEqual(
             pb_event.annotation.attributes.attribute_map['test_bool_key'],
             trace_pb2.AttributeValue(bool_value=False))
-        # self.assertEqual(
-        #     pb_event.annotation.attributes.attribute_map['test_double_key'],
-        #     trace_pb2.AttributeValue(double_value=567.89))
 
     def test_set_annotation_without_attributes(self):
         pb_span = trace_pb2.Span()

--- a/tests/unit/trace/exporters/ocagent/test_trace_exporter_utils.py
+++ b/tests/unit/trace/exporters/ocagent/test_trace_exporter_utils.py
@@ -42,6 +42,7 @@ class TestTraceExporterUtils(unittest.TestCase):
                 'test_str_key': 'test_str_value',
                 'test_int_key': 1,
                 'test_bool_key': False
+                # 'test_double_key': 567.89
             },
             start_time='2017-08-15T18:02:26.071158Z',
             end_time='2017-08-15T18:02:36.071158Z',
@@ -75,6 +76,8 @@ class TestTraceExporterUtils(unittest.TestCase):
                          trace_pb2.AttributeValue(int_value=1))
         self.assertEqual(pb_span.attributes.attribute_map['test_bool_key'],
                          trace_pb2.AttributeValue(bool_value=False))
+        # self.assertEqual(pb_span.attributes.attribute_map['test_double_key'],
+        #                  trace_pb2.AttributeValue(double_value=567.89))
 
         self.assertEqual(pb_span.start_time.ToJsonString(),
                          '2017-08-15T18:02:26.071158Z')
@@ -183,6 +186,7 @@ class TestTraceExporterUtils(unittest.TestCase):
                             'test_str_key': 'test_str_value',
                             'test_int_key': 1,
                             'test_bool_key': False
+                            # 'test_double_key': 567.89
                         })),
                 link_module.Link(
                     trace_id='1e0c63257de34c92bf9efcd03927272e',
@@ -248,6 +252,9 @@ class TestTraceExporterUtils(unittest.TestCase):
         self.assertEqual(
             pb_span.links.link[0].attributes.attribute_map['test_bool_key'],
             trace_pb2.AttributeValue(bool_value=False))
+        # self.assertEqual(
+        #     pb_span.links.link[0].attributes.attribute_map['test_double_key'],
+        #     trace_pb2.AttributeValue(double_key=567.89))
 
     def test_translate_time_events(self):
 
@@ -270,7 +277,8 @@ class TestTraceExporterUtils(unittest.TestCase):
                             attributes={
                                 'test_str_key': 'test_str_value',
                                 'test_int_key': 1,
-                                'test_bool_key': False
+                                'test_bool_key': False,
+                                # 'test_double_key': 567.89
                             }))),
                 time_event_module.TimeEvent(
                     timestamp=annotation1_ts,
@@ -343,6 +351,9 @@ class TestTraceExporterUtils(unittest.TestCase):
         self.assertEqual(
             event0.annotation.attributes.attribute_map['test_bool_key'],
             trace_pb2.AttributeValue(bool_value=False))
+        # self.assertEqual(
+        #     event0.annotation.attributes.attribute_map['test_double_key'],
+        #     trace_pb2.AttributeValue(double_value=567.89))
 
         self.assertEqual(event2.message_event.id, 0)
         self.assertEqual(event3.message_event.id, 1)
@@ -475,6 +486,7 @@ class TestTraceExporterUtils(unittest.TestCase):
                     'test_str_key': 'test_str_value',
                     'test_int_key': 1,
                     'test_bool_key': False
+                    # 'test_double_key': 567.89
                 }))
 
         utils.set_proto_annotation(pb_event.annotation, annotation)
@@ -492,6 +504,9 @@ class TestTraceExporterUtils(unittest.TestCase):
         self.assertEqual(
             pb_event.annotation.attributes.attribute_map['test_bool_key'],
             trace_pb2.AttributeValue(bool_value=False))
+        # self.assertEqual(
+        #     pb_event.annotation.attributes.attribute_map['test_double_key'],
+        #     trace_pb2.AttributeValue(double_value=567.89))
 
     def test_set_annotation_without_attributes(self):
         pb_span = trace_pb2.Span()

--- a/tests/unit/trace/exporters/test_jaeger_exporter.py
+++ b/tests/unit/trace/exporters/test_jaeger_exporter.py
@@ -180,7 +180,8 @@ class TestJaegerExporter(unittest.TestCase):
         span_attributes = {
             'key_bool': False,
             'key_string': 'hello_world',
-            'key_int': 3
+            'key_int': 3,
+            'key_double': 111.22
         }
 
         annotation_attributes = {
@@ -320,6 +321,10 @@ class TestJaegerExporter(unittest.TestCase):
                     jaeger.Tag(
                         key='key_int', vType=jaeger.TagType.LONG, vLong=3),
                     jaeger.Tag(
+                        key='key_double',
+                        vType=jaeger.TagType.DOUBLE,
+                        vDouble=111.22),
+                    jaeger.Tag(
                         key='status.code',
                         vType=jaeger.TagType.LONG,
                         vLong=200),
@@ -357,6 +362,10 @@ class TestJaegerExporter(unittest.TestCase):
                                 key='annotation_string',
                                 vType=jaeger.TagType.STRING,
                                 vStr='annotation_test'),
+                            jaeger.Tag(
+                                key='key_float',
+                                vType=jaeger.TagType.DOUBLE,
+                                vDouble=0.3),
                             jaeger.Tag(
                                 key='message',
                                 vType=jaeger.TagType.STRING,

--- a/tests/unit/trace/exporters/test_jaeger_exporter.py
+++ b/tests/unit/trace/exporters/test_jaeger_exporter.py
@@ -181,13 +181,15 @@ class TestJaegerExporter(unittest.TestCase):
             'key_bool': False,
             'key_string': 'hello_world',
             'key_int': 3,
-            'key_double': 111.22
+            'key_double': 111.22,
+            'key_unsupported_type': ()
         }
 
         annotation_attributes = {
             'annotation_bool': True,
             'annotation_string': 'annotation_test',
-            'key_float': .3
+            'key_float': .3,
+            'key_unsupported_type': {}
         }
 
         link_attributes = {'key_bool': True}

--- a/tests/unit/trace/exporters/test_stackdriver_exporter.py
+++ b/tests/unit/trace/exporters/test_stackdriver_exporter.py
@@ -159,6 +159,11 @@ class TestStackdriverExporter(unittest.TestCase):
                         'value': 'value'
                     }
                 },
+                'key_double': {
+                    'double_value': {
+                        'value': 123.45
+                    }
+                },
                 'http.host': {
                     'string_value': {
                         'truncated_byte_count': 0,
@@ -222,6 +227,11 @@ class TestStackdriverExporter(unittest.TestCase):
                         'string_value': {
                             'truncated_byte_count': 0,
                             'value': 'value'
+                        }
+                    },
+                    'key_double': {
+                        'double_value': {
+                            'value': 123.45
                         }
                     },
                     '/http/host': {

--- a/tests/unit/trace/exporters/test_zipkin_exporter.py
+++ b/tests/unit/trace/exporters/test_zipkin_exporter.py
@@ -138,7 +138,6 @@ class TestZipkinExporter(unittest.TestCase):
                 attributes={
                     'test_key': False,
                     'test_key2': 'raw_value',
-                    # these tags are malformed and should be omitted
                     'test_key3': 0.1,
                 },
                 start_time='2017-08-15T18:02:26.071158Z',
@@ -207,7 +206,8 @@ class TestZipkinExporter(unittest.TestCase):
                 'localEndpoint': local_endpoint_ipv6,
                 'tags': {
                     'test_key': 'False',
-                    'test_key2': 'raw_value'
+                    'test_key2': 'raw_value',
+                    'test_key3': '0.1'
                 },
                 'kind': 'SERVER',
                 'annotations': [],
@@ -299,7 +299,6 @@ class TestZipkinExporter(unittest.TestCase):
                 attributes={
                     'test_key': False,
                     'test_key2': 'raw_value',
-                    # these tags are malformed and should be omitted
                     'test_key3': 0.1,
                 },
                 start_time='2017-08-15T18:02:26.071158Z',
@@ -394,7 +393,8 @@ class TestZipkinExporter(unittest.TestCase):
                 local_endpoint_ipv6,
                 'tags': {
                     'test_key': 'False',
-                    'test_key2': 'raw_value'
+                    'test_key2': 'raw_value',
+                    'test_key3': '0.1'
                 },
                 'kind':
                 'SERVER',
@@ -422,7 +422,7 @@ class TestZipkinExporter(unittest.TestCase):
         self.assertEqual(zipkin_spans_ipv6, expected_zipkin_spans_ipv6)
 
     def test_ignore_incorrect_spans(self):
-        attributes = {'float_value': 0.1}
+        attributes = {'unknown_value': {}}
         self.assertEqual(
             zipkin_exporter._extract_tags_from_span(attributes), {})
 

--- a/tests/unit/trace/test_attributes.py
+++ b/tests/unit/trace/test_attributes.py
@@ -59,6 +59,7 @@ class TestAttributes(unittest.TestCase):
             'key1': 'test string',
             'key2': True,
             'key3': 100,
+            'key4': 123.456,
         }
 
         attributes = attributes_module.Attributes(attrs)
@@ -77,6 +78,9 @@ class TestAttributes(unittest.TestCase):
                 },
                 'key3': {
                     'int_value': 100
+                },
+                'key4': {
+                    'double_value': 123.456
                 }
             }
         }


### PR DESCRIPTION
Fixes https://github.com/census-instrumentation/opencensus-python/issues/517.