### PR TITLE
Exporter/OcAgent: Support double attribute.

### DIFF
--- a/opencensus/trace/exporters/ocagent/utils.py
+++ b/opencensus/trace/exporters/ocagent/utils.py
@@ -211,7 +211,7 @@ def add_proto_attribute_value(
     :type attribute_key: str
     :param attribute_key: attribute key to set
 
-    :type attribute_value: str or int or bool
+    :type attribute_value: str or int or bool or float
     :param attribute_value: attribute value
     """
 
@@ -224,6 +224,9 @@ def add_proto_attribute_value(
     elif isinstance(attribute_value, str):
         pb_attributes.attribute_map[attribute_key].\
             string_value.value = attribute_value
+    elif isinstance(attribute_value, float):
+        pb_attributes.attribute_map[attribute_key].\
+            double_value = attribute_value
     else:
         pb_attributes.attribute_map[attribute_key].\
             string_value.value = str(attribute_value)

--- a/tests/unit/trace/exporters/ocagent/test_trace_exporter_utils.py
+++ b/tests/unit/trace/exporters/ocagent/test_trace_exporter_utils.py
@@ -41,7 +41,8 @@ class TestTraceExporterUtils(unittest.TestCase):
             attributes={
                 'test_str_key': 'test_str_value',
                 'test_int_key': 1,
-                'test_bool_key': False
+                'test_bool_key': False,
+                'test_double_key': 567.89
             },
             start_time='2017-08-15T18:02:26.071158Z',
             end_time='2017-08-15T18:02:36.071158Z',
@@ -64,7 +65,7 @@ class TestTraceExporterUtils(unittest.TestCase):
             hex_encoder(pb_span.parent_span_id)[0], b'6e0c63257de34c93')
         self.assertEqual(pb_span.kind, 0)
 
-        self.assertEqual(len(pb_span.attributes.attribute_map), 3)
+        self.assertEqual(len(pb_span.attributes.attribute_map), 4)
         self.assertEqual(
             pb_span.attributes.attribute_map['test_str_key'],
             trace_pb2.AttributeValue(
@@ -75,6 +76,8 @@ class TestTraceExporterUtils(unittest.TestCase):
                          trace_pb2.AttributeValue(int_value=1))
         self.assertEqual(pb_span.attributes.attribute_map['test_bool_key'],
                          trace_pb2.AttributeValue(bool_value=False))
+        self.assertEqual(pb_span.attributes.attribute_map['test_double_key'],
+                         trace_pb2.AttributeValue(double_value=567.89))
 
         self.assertEqual(pb_span.start_time.ToJsonString(),
                          '2017-08-15T18:02:26.071158Z')
@@ -182,7 +185,8 @@ class TestTraceExporterUtils(unittest.TestCase):
                         attributes={
                             'test_str_key': 'test_str_value',
                             'test_int_key': 1,
-                            'test_bool_key': False
+                            'test_bool_key': False,
+                            'test_double_key': 567.89
                         })),
                 link_module.Link(
                     trace_id='1e0c63257de34c92bf9efcd03927272e',
@@ -230,7 +234,7 @@ class TestTraceExporterUtils(unittest.TestCase):
         self.assertEqual(pb_span.links.link[2].type, 2)
 
         self.assertEqual(
-            len(pb_span.links.link[0].attributes.attribute_map), 3)
+            len(pb_span.links.link[0].attributes.attribute_map), 4)
         self.assertEqual(
             len(pb_span.links.link[1].attributes.attribute_map), 0)
         self.assertEqual(
@@ -248,6 +252,9 @@ class TestTraceExporterUtils(unittest.TestCase):
         self.assertEqual(
             pb_span.links.link[0].attributes.attribute_map['test_bool_key'],
             trace_pb2.AttributeValue(bool_value=False))
+        self.assertEqual(
+            pb_span.links.link[0].attributes.attribute_map['test_double_key'],
+            trace_pb2.AttributeValue(double_value=567.89))
 
     def test_translate_time_events(self):
 
@@ -270,7 +277,8 @@ class TestTraceExporterUtils(unittest.TestCase):
                             attributes={
                                 'test_str_key': 'test_str_value',
                                 'test_int_key': 1,
-                                'test_bool_key': False
+                                'test_bool_key': False,
+                                'test_double_key': 567.89
                             }))),
                 time_event_module.TimeEvent(
                     timestamp=annotation1_ts,
@@ -328,7 +336,7 @@ class TestTraceExporterUtils(unittest.TestCase):
         self.assertEqual(event0.annotation.description.value, "hi there0")
         self.assertEqual(event1.annotation.description.value, "hi there1")
 
-        self.assertEqual(len(event0.annotation.attributes.attribute_map), 3)
+        self.assertEqual(len(event0.annotation.attributes.attribute_map), 4)
         self.assertEqual(len(event1.annotation.attributes.attribute_map), 0)
 
         self.assertEqual(
@@ -343,6 +351,9 @@ class TestTraceExporterUtils(unittest.TestCase):
         self.assertEqual(
             event0.annotation.attributes.attribute_map['test_bool_key'],
             trace_pb2.AttributeValue(bool_value=False))
+        self.assertEqual(
+            event0.annotation.attributes.attribute_map['test_double_key'],
+            trace_pb2.AttributeValue(double_value=567.89))
 
         self.assertEqual(event2.message_event.id, 0)
         self.assertEqual(event3.message_event.id, 1)
@@ -474,13 +485,14 @@ class TestTraceExporterUtils(unittest.TestCase):
                 attributes={
                     'test_str_key': 'test_str_value',
                     'test_int_key': 1,
-                    'test_bool_key': False
+                    'test_bool_key': False,
+                    'test_double_key': 567.89
                 }))
 
         utils.set_proto_annotation(pb_event.annotation, annotation)
 
         self.assertEqual(pb_event.annotation.description.value, "hi there")
-        self.assertEqual(len(pb_event.annotation.attributes.attribute_map), 3)
+        self.assertEqual(len(pb_event.annotation.attributes.attribute_map), 4)
         self.assertEqual(
             pb_event.annotation.attributes.attribute_map['test_str_key'],
             trace_pb2.AttributeValue(
@@ -492,6 +504,9 @@ class TestTraceExporterUtils(unittest.TestCase):
         self.assertEqual(
             pb_event.annotation.attributes.attribute_map['test_bool_key'],
             trace_pb2.AttributeValue(bool_value=False))
+        self.assertEqual(
+            pb_event.annotation.attributes.attribute_map['test_double_key'],
+            trace_pb2.AttributeValue(double_value=567.89))
 
     def test_set_annotation_without_attributes(self):
         pb_span = trace_pb2.Span()


### PR DESCRIPTION
As a follow-up of https://github.com/census-instrumentation/opencensus-python/pull/518#pullrequestreview-207608423.