### PR TITLE
Replace Google in copyright boilerplate

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,1 @@
-Google Inc.
+OpenCensus Authors

--- a/opencensus/common/http_handler.py
+++ b/opencensus/common/http_handler.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google Inc.
+# Copyright 2018, OpenCensus Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/opencensus/common/monitored_resource/aws_identity_doc_utils.py
+++ b/opencensus/common/monitored_resource/aws_identity_doc_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google Inc.
+# Copyright 2018, OpenCensus Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/opencensus/common/monitored_resource/gcp_metadata_config.py
+++ b/opencensus/common/monitored_resource/gcp_metadata_config.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google Inc.
+# Copyright 2018, OpenCensus Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/opencensus/common/monitored_resource/monitored_resource.py
+++ b/opencensus/common/monitored_resource/monitored_resource.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google Inc.
+# Copyright 2018, OpenCensus Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/opencensus/common/resource.py
+++ b/opencensus/common/resource.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Google Inc.
+# Copyright 2019, OpenCensus Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/opencensus/trace/exporters/stackdriver_exporter.py
+++ b/opencensus/trace/exporters/stackdriver_exporter.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc.
+# Copyright 2017, OpenCensus Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/opencensus/trace/tracers/__init__.py
+++ b/opencensus/trace/tracers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc.
+# Copyright 2017, OpenCensus Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/common/monitored_resource_util/test_aws_identity_doc_utils.py
+++ b/tests/unit/common/monitored_resource_util/test_aws_identity_doc_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google Inc.
+# Copyright 2018, OpenCensus Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/common/monitored_resource_util/test_gcp_metadata_config.py
+++ b/tests/unit/common/monitored_resource_util/test_gcp_metadata_config.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google Inc.
+# Copyright 2018, OpenCensus Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/common/monitored_resource_util/test_monitored_resource.py
+++ b/tests/unit/common/monitored_resource_util/test_monitored_resource.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google Inc.
+# Copyright 2018, OpenCensus Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/common/test_http_handler.py
+++ b/tests/unit/common/test_http_handler.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google Inc.
+# Copyright 2018, OpenCensus Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/common/test_resource.py
+++ b/tests/unit/common/test_resource.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2019 Google Inc.
+# Copyright 2019, OpenCensus Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/trace/exporters/test_stackdriver_exporter.py
+++ b/tests/unit/trace/exporters/test_stackdriver_exporter.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc.
+# Copyright 2017, OpenCensus Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
I noticed a few files still listed "Google Inc." as the copyright holder in the boilerplate text. This PR changes it to "OpenCensus Authors" and changes `AUTHORS` to match.