### PR TITLE
Drop opencensus-correlation dependency for release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ extras = {
 }
 
 install_requires = [
-    'opencensus-correlation == 0.2.dev0',
     'google-api-core >= 1.0.0, < 2.0.0',
 ]
 


### PR DESCRIPTION
Remove the dependency on `opencensus-correlation` to prepare for the `0.3.0` release. We can add it again once there's a functional dependency on the library (and it's also released to PyPI).