### PR TITLE
Prepare for 0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 ## Unreleased
 
+## 0.3.0
+Released 2019-03-11
+
 - Fix gRPC client tracer reuse bug
   ([#539](https://github.com/census-instrumentation/opencensus-python/pull/539))
-- Fix bugs in Prometheus exporter. Use ordered list for histogram buckets.
-  Use `UnknownMetricFamily` for `SumData` instead of `UntypedMetricFamily`.
-  Check if label keys and values match before exporting.
-- Remove min and max from Distribution.
+- Update prometheus client and fix multiple bugs in the exporter
+  ([#492](https://github.com/census-instrumentation/opencensus-python/pull/492))
+- Remove min and max from `Distribution`
+  ([#501](https://github.com/census-instrumentation/opencensus-python/pull/501))
 - Replace stackdriver `gke_container` resources, see the [GKE migration
   notes](https://cloud.google.com/monitoring/kubernetes-engine/migration#incompatible)
   for details

--- a/contrib/opencensus-correlation/version.py
+++ b/contrib/opencensus-correlation/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.dev0'
+__version__ = '0.3.0'

--- a/contrib/opencensus-ext-dbapi/setup.py
+++ b/contrib/opencensus-ext-dbapi/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-django/setup.py
+++ b/contrib/opencensus-ext-django/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'Django >= 1.11.0, <= 1.11.20',
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-flask/setup.py
+++ b/contrib/opencensus-ext-flask/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'flask >= 0.12.3, < 2.0.0',
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-google-cloud-clientlibs/setup.py
+++ b/contrib/opencensus-ext-google-cloud-clientlibs/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
         'opencensus-ext-grpc >= 0.1.dev0, < 1.0.0',
         'opencensus-ext-requests >= 0.1.dev0, < 1.0.0',
     ],

--- a/contrib/opencensus-ext-grpc/setup.py
+++ b/contrib/opencensus-ext-grpc/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'grpcio >= 1.0.0, < 2.0.0',
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-httplib/setup.py
+++ b/contrib/opencensus-ext-httplib/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-jaeger/setup.py
+++ b/contrib/opencensus-ext-jaeger/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-mysql/setup.py
+++ b/contrib/opencensus-ext-mysql/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'mysql-connector >= 2.1.6, < 3.0.0',
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
         'opencensus-ext-dbapi >= 0.1.dev0, < 1.0.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-ocagent/setup.py
+++ b/contrib/opencensus-ext-ocagent/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'grpcio >= 1.0.0, < 2.0.0',
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-postgresql/setup.py
+++ b/contrib/opencensus-ext-postgresql/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
         'psycopg2 >= 2.7.3.1',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-pymongo/setup.py
+++ b/contrib/opencensus-ext-pymongo/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
         'pymongo >= 3.1.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-pymysql/setup.py
+++ b/contrib/opencensus-ext-pymysql/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'PyMySQL >= 0.7.11, < 1.0.0',
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
         'opencensus-ext-dbapi >= 0.1.dev0, < 1.0.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-pyramid/setup.py
+++ b/contrib/opencensus-ext-pyramid/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'pyramid >= 1.9.1, < 2.0.0',
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-requests/setup.py
+++ b/contrib/opencensus-ext-requests/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
         'wrapt >= 1.0.0, < 2.0.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-sqlalchemy/setup.py
+++ b/contrib/opencensus-ext-sqlalchemy/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
         'SQLAlchemy >= 1.1.14, < 2.0.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-stackdriver/setup.py
+++ b/contrib/opencensus-ext-stackdriver/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'google-cloud-trace >= 0.20.0, < 1.0.0',
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-threading/setup.py
+++ b/contrib/opencensus-ext-threading/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-zipkin/setup.py
+++ b/contrib/opencensus-ext-zipkin/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/opencensus/common/version/__init__.py
+++ b/opencensus/common/version/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.dev0'
+__version__ = '0.3.0'


### PR DESCRIPTION
This PR creates the `v.3.x` branch. Once it's merged I'll tag the head commit of this branch to create the `0.3.0` release. As in `0.2.0` (see #460), we don't expect to backport bugfixes from master to this branch. 

I changed contrib packages' dependencies to `0.3.0` so devs that check out the release branch won't depend on a development version of the core library. `master` should continue to use dev version numbers.