### PR TITLE
Fix Metric repr for ValueDistributions

### DIFF
--- a/opencensus/metrics/export/metric.py
+++ b/opencensus/metrics/export/metric.py
@@ -43,24 +43,10 @@ class Metric(object):
         self._check_type()
 
     def __repr__(self):
-        # Get a condensed description of a list of time series like:
-        # (k1="v11", k2="v21", [12]), (k1="v21", k2="v22", [34])
-        lks = [lk.key for lk in self.descriptor.label_keys]
-        labeled_pvs = []
-        for ts in self.time_series:
-            labels = ", ".join('{}="{}"'.format(lk, lv)
-                               for lk, lv in zip(lks, ts.label_values))
-            pvs = [point.value.value if point.value else None
-                   for point in ts.points]
-            labeled_pvs.append((labels, pvs))
-        short_ts_repr = ", ".join("({}, {})".format(ll, pvs)
-                                  for ll, pvs in labeled_pvs)
-
-        # E.g. 'Metric((k1="v11", k2="v21", [12]), descriptor.name="name")'
-        return ('{}({}, descriptor.name="{}")'
+        return ('{}(time_series={}, descriptor.name="{}")'
                 .format(
                     type(self).__name__,
-                    short_ts_repr,
+                    "<{} TimeSeries>".format(len(self.time_series)),
                     self.descriptor.name,
                 ))
 

--- a/opencensus/metrics/export/time_series.py
+++ b/opencensus/metrics/export/time_series.py
@@ -47,11 +47,15 @@ class TimeSeries(object):
         self._start_timestamp = start_timestamp
 
     def __repr__(self):
+        points_repr = '[{}]'.format(
+            ', '.join(repr(point.value) for point in self.points))
+
+        lv_repr = tuple(lv.value for lv in self.label_values)
         return ('{}({}, label_values={}, start_timestamp={})'
                 .format(
                     type(self).__name__,
-                    [point.value.value for point in self.points],
-                    self.label_values,
+                    points_repr,
+                    lv_repr,
                     self.start_timestamp
                 ))
 

--- a/opencensus/metrics/export/value.py
+++ b/opencensus/metrics/export/value.py
@@ -110,6 +110,13 @@ class Exemplar(object):
         self._timestamp = timestamp
         self._attachments = attachments
 
+    def __repr__(self):
+        return ("{}({})"
+                .format(
+                    type(self).__name__,
+                    self.value,
+                ))
+
     @property
     def value(self):
         return self._value
@@ -137,6 +144,13 @@ class Bucket(object):
     def __init__(self, count, exemplar=None):
         self._count = count
         self._exemplar = exemplar
+
+    def __repr__(self):
+        return ("{}({})"
+                .format(
+                    type(self).__name__,
+                    self.count,
+                ))
 
     @property
     def count(self):
@@ -185,6 +199,13 @@ class BucketOptions(object):
 
     def __init__(self, type_=None):
         self._type = type_
+
+    def __repr__(self):
+        return ("{}({})"
+                .format(
+                    type(self).__name__,
+                    self.type_,
+                ))
 
     @property
     def type_(self):
@@ -252,6 +273,18 @@ class ValueDistribution(object):
         self._sum_of_squared_deviation = sum_of_squared_deviation
         self._bucket_options = bucket_options
         self._buckets = buckets
+
+    def __repr__(self):
+        try:
+            bounds = self.bucket_options.type_.bounds,
+        except AttributeError:
+            bounds = None
+
+        return ("{}({})"
+                .format(
+                    type(self).__name__,
+                    bounds
+                ))
 
     @property
     def count(self):


### PR DESCRIPTION
`Metric.__repr__` fails if its time series includes `ValueDistribution`s, which don't have a `value` attr. This PR fixes `Metric` and `TimeSeries`'s reprs, shortens them a bit, and adds a few missing repr methods for other value classes.

Before:
```
Metric((os="LabelValue(android)", lang="LabelValue(en_us)", [49.36]),
  (os="LabelValue(android)", lang="LabelValue(zh_cn)", [56.78]),
  (os="LabelValue(ios)", lang="LabelValue(en_us)", [90.12]),
  (os="LabelValue(ios)", lang="LabelValue(zh_cn)", [34.56]),
  descriptor.name="sum_view_ol")

```

After:
```
Metric(time_series=<4 TimeSeries>, descriptor.name="sum_view_ol")
```

Before:
```
TimeSeries([49.36], label_values=[LabelValue(android), LabelValue(en_us)],
  start_timestamp=2019-03-15T21:28:15.878247Z)

```

After:
```
TimeSeries([ValueDouble(49.36)], label_values=('android', 'en_us'),
  start_timestamp=2019-03-15T21:28:15.878247Z)
```
