### PR TITLE
Use metrics instead of stats in SD exporter

### DIFF
--- a/contrib/opencensus-ext-ocagent/opencensus/ext/ocagent/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-ocagent/opencensus/ext/ocagent/trace_exporter/__init__.py
@@ -84,7 +84,7 @@ class TraceExporter(base_exporter.Exporter):
                 else host_name,
                 pid=os.getpid(),
                 start_timestamp=utils.proto_ts_from_datetime(
-                    datetime.datetime.now())
+                    datetime.datetime.utcnow())
             ),
             library_info=common_pb2.LibraryInfo(
                 language=common_pb2.LibraryInfo.Language.Value('PYTHON'),

--- a/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/stats_exporter/__init__.py
+++ b/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/stats_exporter/__init__.py
@@ -149,12 +149,11 @@ class StackdriverStatsExporter(object):
     def client(self):
         return self._client
 
-    def export(self, metrics):
+    def export_metrics(self, metrics):
         ts_batches = self.create_batched_time_series(metrics)
         for ts_batch in ts_batches:
             self.client.create_time_series(
-                self.client.project_path(self.options.project_id),
-                ts_batch)
+                self.client.project_path(self.options.project_id), ts_batch)
 
     def create_batched_time_series(self, metrics,
                                    batch_size=MAX_TIME_SERIES_PER_UPLOAD):

--- a/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/stats_exporter/__init__.py
+++ b/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/stats_exporter/__init__.py
@@ -228,8 +228,11 @@ class StackdriverStatsExporter(object):
                 metric.descriptor.type)
             raise TypeError("Unsupported metric type: {}".format(md_type_name))
 
-        start = datetime.strptime(ts.start_timestamp, EPOCH_PATTERN)
         end = point.timestamp
+        if ts.start_timestamp is None:
+            start = end
+        else:
+            start = datetime.strptime(ts.start_timestamp, EPOCH_PATTERN)
 
         timestamp_start = (start - EPOCH_DATETIME).total_seconds()
         timestamp_end = (end - EPOCH_DATETIME).total_seconds()

--- a/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/stats_exporter/__init__.py
+++ b/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/stats_exporter/__init__.py
@@ -163,7 +163,7 @@ class StackdriverStatsExporter(object):
         return list(utils.window(time_series_list, batch_size))
 
     def create_time_series_list(self, metric):
-        if not isinstance(metric, metric_module.Metric):
+        if not isinstance(metric, metric_module.Metric):  # pragma: NO COVER
             raise ValueError
         return [self._convert_series(metric, ts) for ts in metric.time_series]
 

--- a/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/stats_exporter/__init__.py
+++ b/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/stats_exporter/__init__.py
@@ -28,6 +28,7 @@ from opencensus.common import utils
 from opencensus.common.monitored_resource import monitored_resource
 from opencensus.common.transports import async_
 from opencensus.common.version import __version__
+from opencensus.metrics.export import metric as metric_module
 from opencensus.metrics.export import metric_descriptor
 from opencensus.stats import aggregation
 from opencensus.stats import base_exporter
@@ -162,6 +163,8 @@ class StackdriverStatsExporter(object):
         return list(utils.window(time_series_list, batch_size))
 
     def create_time_series_list(self, metric):
+        if not isinstance(metric, metric_module.Metric):
+            raise ValueError
         return [self._convert_series(metric, ts) for ts in metric.time_series]
 
     def _convert_series(self, metric, ts):

--- a/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/stats_exporter/__init__.py
+++ b/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/stats_exporter/__init__.py
@@ -26,13 +26,9 @@ from google.cloud import monitoring_v3
 
 from opencensus.common import utils
 from opencensus.common.monitored_resource import monitored_resource
-from opencensus.common.transports import async_
 from opencensus.common.version import __version__
 from opencensus.metrics.export import metric as metric_module
 from opencensus.metrics.export import metric_descriptor
-from opencensus.stats import aggregation
-from opencensus.stats import base_exporter
-from opencensus.stats import measure
 
 
 MAX_TIME_SERIES_PER_UPLOAD = 200
@@ -190,12 +186,13 @@ class StackdriverStatsExporter(object):
 
     def _convert_point(self, metric, ts, point, sd_point):
         """Convert an OC metric point to a SD point."""
-        if (metric.descriptor.type ==
-                metric_descriptor.MetricDescriptorType.CUMULATIVE_DISTRIBUTION):
+        if (metric.descriptor.type == metric_descriptor.MetricDescriptorType
+                .CUMULATIVE_DISTRIBUTION):
 
             sd_dist_val = sd_point.value.distribution_value
             sd_dist_val.count = point.value.count
-            sd_dist_val.sum_of_squared_deviation = point.value.sum_of_squared_deviation
+            sd_dist_val.sum_of_squared_deviation =\
+                point.value.sum_of_squared_deviation
 
             assert sd_dist_val.bucket_options.explicit_buckets.bounds == []
             sd_dist_val.bucket_options.explicit_buckets.bounds.extend(
@@ -295,7 +292,8 @@ class StackdriverStatsExporter(object):
                 return self._md_cache[descriptor_type]
             except KeyError:
                 descriptor = self.get_metric_descriptor(oc_md)
-                project_name = self.client.project_path(self.options.project_id)
+                project_name =\
+                    self.client.project_path(self.options.project_id)
                 sd_md = self.client.create_metric_descriptor(
                     project_name, descriptor)
                 self._md_cache[descriptor_type] = sd_md

--- a/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/stats_exporter/__init__.py
+++ b/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/stats_exporter/__init__.py
@@ -246,8 +246,7 @@ class StackdriverStatsExporter(object):
 
         start_time = sd_point.interval.start_time
         start_time.seconds = int(timestamp_start)
-        start_secs = start_time.seconds
-        start_time.nanos = int((timestamp_start - start_secs) * 1e9)
+        start_time.nanos = int((timestamp_start - start_time.seconds) * 1e9)
 
     def get_descriptor_type(self, oc_md):
         """Get a SD descriptor type for an OC metric descriptor."""

--- a/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/stats_exporter/__init__.py
+++ b/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/stats_exporter/__init__.py
@@ -222,6 +222,7 @@ class StackdriverStatsExporter(object):
               metric_descriptor.MetricDescriptorType.GAUGE_DOUBLE):
             sd_point.value.double_value = float(point.value.value)
 
+        # TODO: handle SUMMARY metrics, #567
         else:
             md_type_name = metric_descriptor.MetricDescriptorType.to_name(
                 metric.descriptor.type)

--- a/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/stats_exporter/__init__.py
+++ b/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/stats_exporter/__init__.py
@@ -366,7 +366,7 @@ def new_stats_exporter(options):
         uploads stats data to Stackdriver Monitoring.
     """
     if str(options.project_id).strip() == "":
-        raise Exception(ERROR_BLANK_PROJECT_ID)
+        raise ValueError(ERROR_BLANK_PROJECT_ID)
 
     ci = client_info.ClientInfo(client_library_version=get_user_agent_slug())
     client = monitoring_v3.MetricServiceClient(client_info=ci)

--- a/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_stats.py
+++ b/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_stats.py
@@ -103,7 +103,8 @@ class TestStackdriverStatsExporter(unittest.TestCase):
         default_labels = {'key1': 'value1'}
         exporter = stackdriver.StackdriverStatsExporter(
             options=stackdriver.Options(
-                project_id=project_id, default_monitoring_labels=default_labels))
+                project_id=project_id,
+                default_monitoring_labels=default_labels))
         self.assertEqual(exporter.options.project_id, project_id)
 
     def test_blank_project(self):
@@ -221,23 +222,26 @@ class TestStackdriverStatsExporter(unittest.TestCase):
         self.assertEqual(len(series.metric.labels), 1)
 
     @mock.patch('os.getpid', return_value=12345)
-    @mock.patch('platform.uname', return_value=('system', 'node', 'release',
-                                                'version', 'machine',
-                                                'processor'))
+    @mock.patch(
+        'platform.uname',
+        return_value=('system', 'node', 'release', 'version', 'machine',
+                      'processor'))
     def test_get_task_value_with_hostname(self, mock_uname, mock_pid):
         self.assertEqual(stackdriver.get_task_value(), "py-12345@node")
 
     @mock.patch('os.getpid', return_value=12345)
-    @mock.patch('platform.uname', return_value=('system', '', 'release',
-                                                'version', 'machine',
-                                                'processor'))
+    @mock.patch(
+        'platform.uname',
+        return_value=('system', '', 'release', 'version', 'machine',
+                      'processor'))
     def test_get_task_value_without_hostname(self, mock_uname, mock_pid):
         self.assertEqual(stackdriver.get_task_value(), "py-12345@localhost")
 
 
 class TestCreateTimeseries(unittest.TestCase):
-
-    def check_labels(self, actual_labels, expected_labels,
+    def check_labels(self,
+                     actual_labels,
+                     expected_labels,
                      include_opencensus=False):
         actual_labels = dict(actual_labels)
         if include_opencensus:
@@ -252,17 +256,17 @@ class TestCreateTimeseries(unittest.TestCase):
     def test_create_batched_time_series(self, monitor_resource_mock):
         client = mock.Mock()
         v_data = view_data_module.ViewData(
-            view=VIDEO_SIZE_VIEW, start_time=TEST_TIME_STR, end_time=TEST_TIME_STR)
-        v_data.record(context=tag_map_module.TagMap(), value=2,
-                      timestamp=None)
+            view=VIDEO_SIZE_VIEW,
+            start_time=TEST_TIME_STR,
+            end_time=TEST_TIME_STR)
+        v_data.record(context=tag_map_module.TagMap(), value=2, timestamp=None)
         view_data = [v_data]
 
         option = stackdriver.Options(project_id="project-test")
         exporter = stackdriver.StackdriverStatsExporter(
             options=option, client=client)
 
-        view_data = [metric_utils.view_data_to_metric(
-            view_data[0], TEST_TIME)]
+        view_data = [metric_utils.view_data_to_metric(view_data[0], TEST_TIME)]
 
         time_series_batches = exporter.create_batched_time_series(view_data, 1)
 
@@ -273,8 +277,8 @@ class TestCreateTimeseries(unittest.TestCase):
         self.assertEqual(
             time_series.metric.type,
             'custom.googleapis.com/opencensus/' + VIDEO_SIZE_VIEW_NAME)
-        self.check_labels(time_series.metric.labels, {},
-                                 include_opencensus=True)
+        self.check_labels(
+            time_series.metric.labels, {}, include_opencensus=True)
 
     @mock.patch('opencensus.ext.stackdriver.stats_exporter.'
                 'monitored_resource.get_instance',
@@ -284,8 +288,8 @@ class TestCreateTimeseries(unittest.TestCase):
 
         # First view with 3
         view_name1 = "view-name1"
-        view1 = view_module.View(view_name1, "test description",
-                                 ['test'], VIDEO_SIZE_MEASURE,
+        view1 = view_module.View(view_name1, "test description", ['test'],
+                                 VIDEO_SIZE_MEASURE,
                                  aggregation_module.LastValueAggregation())
         v_data1 = view_data_module.ViewData(
             view=view1, start_time=TEST_TIME_STR, end_time=TEST_TIME_STR)
@@ -298,8 +302,8 @@ class TestCreateTimeseries(unittest.TestCase):
 
         # Second view with 2
         view_name2 = "view-name2"
-        view2 = view_module.View(view_name2, "test description",
-                                 ['test'], VIDEO_SIZE_MEASURE,
+        view2 = view_module.View(view_name2, "test description", ['test'],
+                                 VIDEO_SIZE_MEASURE,
                                  aggregation_module.LastValueAggregation())
         v_data2 = view_data_module.ViewData(
             view=view2, start_time=TEST_TIME_STR, end_time=TEST_TIME_STR)
@@ -344,7 +348,6 @@ class TestCreateTimeseries(unittest.TestCase):
         view_manager.register_exporter(exporter)
         return view_manager, stats_recorder, exporter
 
-
     @mock.patch('opencensus.ext.stackdriver.stats_exporter.'
                 'monitored_resource.get_instance',
                 return_value=None)
@@ -375,9 +378,9 @@ class TestCreateTimeseries(unittest.TestCase):
         self.assertEqual(
             time_series_list[0].metric.type,
             "custom.googleapis.com/opencensus/my.org/views/video_size_test2")
-        self.check_labels(time_series.metric.labels,
-                                 {FRONTEND_KEY_CLEAN: "1200"},
-                                 include_opencensus=True)
+        self.check_labels(
+            time_series.metric.labels, {FRONTEND_KEY_CLEAN: "1200"},
+            include_opencensus=True)
         self.assertIsNotNone(time_series.resource)
 
         self.assertEqual(len(time_series.points), 1)
@@ -389,9 +392,9 @@ class TestCreateTimeseries(unittest.TestCase):
 
         self.assertEqual(len(time_series_list), 1)
         time_series = time_series_list[0]
-        self.check_labels(time_series.metric.labels,
-                                 {FRONTEND_KEY_CLEAN: "1200"},
-                                 include_opencensus=True)
+        self.check_labels(
+            time_series.metric.labels, {FRONTEND_KEY_CLEAN: "1200"},
+            include_opencensus=True)
         self.assertIsNotNone(time_series.resource)
 
         self.assertEqual(len(time_series.points), 1)
@@ -406,8 +409,7 @@ class TestCreateTimeseries(unittest.TestCase):
         client = mock.Mock()
         execution_context.clear()
 
-        option = stackdriver.Options(
-            project_id="project-test", resource="")
+        option = stackdriver.Options(project_id="project-test", resource="")
         exporter = stackdriver.StackdriverStatsExporter(
             options=option, client=client)
 
@@ -453,11 +455,12 @@ class TestCreateTimeseries(unittest.TestCase):
         self.assertEqual(len(time_series_list), 1)
         time_series = time_series_list[0]
         self.assertEqual(time_series.resource.type, "gce_instance")
-        self.check_labels(time_series.resource.labels, {
-            'instance_id': 'my-instance',
-            'project_id': 'my-project',
-            'zone': 'us-east1',
-        })
+        self.check_labels(
+            time_series.resource.labels, {
+                'instance_id': 'my-instance',
+                'project_id': 'my-project',
+                'zone': 'us-east1',
+            })
         self.assertEqual(
             time_series.metric.type,
             "custom.googleapis.com/opencensus/my.org/views/video_size_test2")
@@ -490,13 +493,14 @@ class TestCreateTimeseries(unittest.TestCase):
         self.assertEqual(len(time_series_list), 1)
         time_series = time_series_list[0]
         self.assertEqual(time_series.resource.type, "k8s_container")
-        self.check_labels(time_series.resource.labels, {
-            'project_id': 'my-project',
-            'location': 'us-east1',
-            'cluster_name': 'cluster',
-            'pod_name': 'localhost',
-            'namespace_name': 'namespace',
-        })
+        self.check_labels(
+            time_series.resource.labels, {
+                'project_id': 'my-project',
+                'location': 'us-east1',
+                'cluster_name': 'cluster',
+                'pod_name': 'localhost',
+                'namespace_name': 'namespace',
+            })
         self.assertEqual(
             time_series.metric.type,
             "custom.googleapis.com/opencensus/my.org/views/video_size_test2")
@@ -518,11 +522,12 @@ class TestCreateTimeseries(unittest.TestCase):
         self.assertEqual(len(time_series_list), 1)
         time_series = time_series_list[0]
         self.assertEqual(time_series.resource.type, "aws_ec2_instance")
-        self.check_labels(time_series.resource.labels, {
-            'instance_id': 'my-instance',
-            'aws_account': 'my-project',
-            'region': 'aws:us-east1',
-        })
+        self.check_labels(
+            time_series.resource.labels, {
+                'instance_id': 'my-instance',
+                'aws_account': 'my-project',
+                'region': 'aws:us-east1',
+            })
         self.assertEqual(
             time_series.metric.type,
             "custom.googleapis.com/opencensus/my.org/views/video_size_test2")
@@ -575,9 +580,9 @@ class TestCreateTimeseries(unittest.TestCase):
         self.assertEqual(len(time_series_list), 1)
         time_series = time_series_list[0]
 
-        self.check_labels(time_series.metric.labels,
-                                 {FRONTEND_KEY_INT_CLEAN: "Abc"},
-                                 include_opencensus=True)
+        self.check_labels(
+            time_series.metric.labels, {FRONTEND_KEY_INT_CLEAN: "Abc"},
+            include_opencensus=True)
         self.assertIsNotNone(time_series.resource)
 
         self.assertEqual(len(time_series.points), 1)
@@ -616,9 +621,9 @@ class TestCreateTimeseries(unittest.TestCase):
         time_series_list = exporter.create_time_series_list(v_data)
         self.assertEqual(len(time_series_list), 1)
         time_series = time_series_list[0]
-        self.check_labels(time_series.metric.labels,
-                                 {FRONTEND_KEY_INT_CLEAN: "Abc"},
-                                 include_opencensus=True)
+        self.check_labels(
+            time_series.metric.labels, {FRONTEND_KEY_INT_CLEAN: "Abc"},
+            include_opencensus=True)
         self.assertIsNotNone(time_series.resource)
 
         self.assertEqual(len(time_series.points), 1)
@@ -657,9 +662,9 @@ class TestCreateTimeseries(unittest.TestCase):
         time_series_list = exporter.create_time_series_list(v_data)
         self.assertEqual(len(time_series_list), 1)
         time_series = time_series_list[0]
-        self.check_labels(time_series.metric.labels,
-                                 {FRONTEND_KEY_FLOAT_CLEAN: "Abc"},
-                                 include_opencensus=True)
+        self.check_labels(
+            time_series.metric.labels, {FRONTEND_KEY_FLOAT_CLEAN: "Abc"},
+            include_opencensus=True)
         self.assertIsNotNone(time_series.resource)
 
         self.assertEqual(len(time_series.points), 1)
@@ -713,9 +718,9 @@ class TestCreateTimeseries(unittest.TestCase):
         [time_series] = time_series_list
         self.assertEqual(time_series.metric.type,
                          "custom.googleapis.com/opencensus/view-name3")
-        self.check_labels(time_series.metric.labels,
-                                 {FRONTEND_KEY_FLOAT_CLEAN: "1200"},
-                                 include_opencensus=True)
+        self.check_labels(
+            time_series.metric.labels, {FRONTEND_KEY_FLOAT_CLEAN: "1200"},
+            include_opencensus=True)
         self.assertIsNotNone(time_series.resource)
 
         self.assertEqual(len(time_series.points), 1)
@@ -755,8 +760,10 @@ class TestCreateTimeseries(unittest.TestCase):
         time_series_list = exporter.create_time_series_list(v_data)
 
         self.assertEqual(len(time_series_list), 2)
-        ts_by_frontend = {ts.metric.labels.get(FRONTEND_KEY_CLEAN): ts
-                          for ts in time_series_list}
+        ts_by_frontend = {
+            ts.metric.labels.get(FRONTEND_KEY_CLEAN): ts
+            for ts in time_series_list
+        }
         self.assertEqual(set(ts_by_frontend.keys()), {"1200", "1400"})
         ts1 = ts_by_frontend["1200"]
         ts2 = ts_by_frontend["1400"]
@@ -822,16 +829,15 @@ class TestCreateTimeseries(unittest.TestCase):
         self.assertEqual(time_series.resource.type, "global")
         self.assertEqual(time_series.metric.type,
                          "custom.googleapis.com/opencensus/" + view_name)
-        self.check_labels(time_series.metric.labels,
-                                 {FRONTEND_KEY_CLEAN: "1200"},
-                                 include_opencensus=True)
+        self.check_labels(
+            time_series.metric.labels, {FRONTEND_KEY_CLEAN: "1200"},
+            include_opencensus=True)
         self.assertIsNotNone(time_series.resource)
 
         self.assertEqual(len(time_series.points), 1)
         expected_value = monitoring_v3.types.TypedValue()
         expected_value.int64_value = 25 * MiB
         self.assertEqual(time_series.points[0].value, expected_value)
-
 
     def test_create_timeseries_from_distribution(self):
         """Check for explicit 0-bound bucket for SD export."""
@@ -870,9 +876,9 @@ class TestCreateTimeseries(unittest.TestCase):
         self.assertEqual(len(time_series_list), 1)
         [time_series] = time_series_list
 
-        self.check_labels(time_series.metric.labels,
-                                 {'tag_key': 'tag_value'},
-                                 include_opencensus=True)
+        self.check_labels(
+            time_series.metric.labels, {'tag_key': 'tag_value'},
+            include_opencensus=True)
         self.assertEqual(len(time_series.points), 1)
         [point] = time_series.points
         dv = point.value.distribution_value

--- a/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_stats.py
+++ b/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_stats.py
@@ -44,9 +44,9 @@ FRONTEND_KEY_FLOAT_CLEAN = "my_org_keys_frontend_FLOAT"
 FRONTEND_KEY_INT_CLEAN = "my_org_keys_frontend_INT"
 FRONTEND_KEY_STR_CLEAN = "my_org_keys_frontend_STR"
 
-VIDEO_SIZE_MEASURE = measure_module.MeasureInt(
+VIDEO_SIZE_MEASURE = measure_module.MeasureFloat(
     "my.org/measure/video_size_test2", "size of processed videos", "By")
-VIDEO_SIZE_MEASURE_2 = measure_module.MeasureInt(
+VIDEO_SIZE_MEASURE_2 = measure_module.MeasureFloat(
     "my.org/measure/video_size_test_2", "size of processed videos", "By")
 
 VIDEO_SIZE_MEASURE_FLOAT = measure_module.MeasureFloat(
@@ -587,7 +587,8 @@ class TestCreateTimeseries(unittest.TestCase):
 
         self.assertEqual(len(time_series.points), 1)
         expected_value = monitoring_v3.types.TypedValue()
-        expected_value.int64_value = 25 * MiB
+        # TODO: #565
+        expected_value.double_value = 25.0 * MiB
         self.assertEqual(time_series.points[0].value, expected_value)
 
     @mock.patch('opencensus.ext.stackdriver.stats_exporter.'
@@ -836,7 +837,8 @@ class TestCreateTimeseries(unittest.TestCase):
 
         self.assertEqual(len(time_series.points), 1)
         expected_value = monitoring_v3.types.TypedValue()
-        expected_value.int64_value = 25 * MiB
+        # TODO: #565
+        expected_value.double_value = 25.0 * MiB
         self.assertEqual(time_series.points[0].value, expected_value)
 
     def test_create_timeseries_from_distribution(self):

--- a/opencensus/metrics/export/gauge.py
+++ b/opencensus/metrics/export/gauge.py
@@ -481,7 +481,7 @@ class Registry(metric_producer.MetricProducer):
         :rtype: set(:class:`opencensus.metrics.export.metric.Metric`)
         :return: A set of `Metric`s, one for each registered gauge.
         """
-        now = datetime.now()
+        now = datetime.utcnow()
         metrics = set()
         for gauge in self.gauges.values():
             metrics.add(gauge.get_metric(now))

--- a/opencensus/metrics/export/metric_descriptor.py
+++ b/opencensus/metrics/export/metric_descriptor.py
@@ -90,27 +90,10 @@ class MetricDescriptorType(object):
         SUMMARY: value.ValueSummary
     }
 
-    _name_map = {
-        GAUGE_INT64: 'GAUGE_INT64',
-        GAUGE_DOUBLE: 'GAUGE_DOUBLE',
-        GAUGE_DISTRIBUTION: 'GAUGE_DISTRIBUTION',
-        CUMULATIVE_INT64: 'CUMULATIVE_INT64',
-        CUMULATIVE_DOUBLE: 'CUMULATIVE_DOUBLE',
-        CUMULATIVE_DISTRIBUTION: 'CUMULATIVE_DISTRIBUTION',
-        SUMMARY: 'SUMMARY',
-    }
-
     @classmethod
     def to_type_class(cls, metric_descriptor_type):
         try:
             return cls._type_map[metric_descriptor_type]
-        except KeyError:
-            raise ValueError("Unknown MetricDescriptorType value")
-
-    @classmethod
-    def to_name(cls, metric_descriptor_type):
-        try:
-            return cls._name_map[metric_descriptor_type]
         except KeyError:
             raise ValueError("Unknown MetricDescriptorType value")
 

--- a/opencensus/metrics/export/metric_descriptor.py
+++ b/opencensus/metrics/export/metric_descriptor.py
@@ -90,10 +90,27 @@ class MetricDescriptorType(object):
         SUMMARY: value.ValueSummary
     }
 
+    _name_map = {
+        GAUGE_INT64: 'GAUGE_INT64',
+        GAUGE_DOUBLE: 'GAUGE_DOUBLE',
+        GAUGE_DISTRIBUTION: 'GAUGE_DISTRIBUTION',
+        CUMULATIVE_INT64: 'CUMULATIVE_INT64',
+        CUMULATIVE_DOUBLE: 'CUMULATIVE_DOUBLE',
+        CUMULATIVE_DISTRIBUTION: 'CUMULATIVE_DISTRIBUTION',
+        SUMMARY: 'SUMMARY',
+    }
+
     @classmethod
     def to_type_class(cls, metric_descriptor_type):
         try:
             return cls._type_map[metric_descriptor_type]
+        except KeyError:
+            raise ValueError("Unknown MetricDescriptorType value")
+
+    @classmethod
+    def to_name(cls, metric_descriptor_type):
+        try:
+            return cls._name_map[metric_descriptor_type]
         except KeyError:
             raise ValueError("Unknown MetricDescriptorType value")
 

--- a/opencensus/stats/measure_to_view_map.py
+++ b/opencensus/stats/measure_to_view_map.py
@@ -73,11 +73,15 @@ class MeasureToViewMap(object):
         views = set(all_views)
         return views
 
+    # TODO: deprecate
     def register_view(self, view, timestamp):
         """registers the view's measure name to View Datas given a view"""
         if len(self.exporters) > 0:
-            for e in self.exporters:
-                e.on_register_view(view)
+            try:
+                for e in self.exporters:
+                    e.on_register_view(view)
+            except AttributeError:
+                pass
 
         self._exported_views = None
         existing_view = self._registered_views.get(view.name)
@@ -118,13 +122,17 @@ class MeasureToViewMap(object):
                     attachments=attachments)
             self.export(view_datas)
 
+    # TODO: deprecate
     def export(self, view_datas):
         """export view datas to registered exporters"""
         view_datas_copy = \
             [self.copy_and_finalize_view_data(vd) for vd in view_datas]
         if len(self.exporters) > 0:
             for e in self.exporters:
-                e.export(view_datas_copy)
+                try:
+                    e.export(view_datas_copy)
+                except AttributeError:
+                    pass
 
     def get_metrics(self, timestamp):
         """Get a Metric for each registered view.

--- a/opencensus/stats/stats.py
+++ b/opencensus/stats/stats.py
@@ -37,4 +37,4 @@ class Stats(MetricProducer):
         :rtype: Iterator[:class: `opencensus.metrics.export.metric.Metric`]
         """
         return self.view_manager.measure_to_view_map.get_metrics(
-            datetime.now())
+            datetime.utcnow())

--- a/tests/unit/trace/test_blank_span.py
+++ b/tests/unit/trace/test_blank_span.py
@@ -64,7 +64,7 @@ class TestBlankSpan(unittest.TestCase):
         with self.assertRaises(TypeError):
             span.add_time_event(time_event)
 
-        time_event = TimeEvent(datetime.datetime.now())
+        time_event = TimeEvent(datetime.datetime.utcnow())
         span.add_time_event(time_event)
 
         span_iter_list = list(iter(span))

--- a/tests/unit/trace/test_span.py
+++ b/tests/unit/trace/test_span.py
@@ -145,7 +145,7 @@ class TestSpan(unittest.TestCase):
         with self.assertRaises(TypeError):
             span.add_time_event(time_event)
 
-        time_event = TimeEvent(datetime.datetime.now())
+        time_event = TimeEvent(datetime.datetime.utcnow())
         span.add_time_event(time_event)
 
         self.assertEqual(len(span.time_events), 1)
@@ -357,7 +357,7 @@ class Test_format_span_json(unittest.TestCase):
         span.start_time = start_time
         span.end_time = end_time
         span._child_spans = []
-        span.time_events = [TimeEvent(datetime.datetime.now())]
+        span.time_events = [TimeEvent(datetime.datetime.utcnow())]
         span.stack_trace = StackTrace()
         span.status = Status(code='200', message='test')
         span.links = [Link(trace_id, span_id)]


### PR DESCRIPTION
This is the first of several breaking changes to replace the stats data model (`ViewData`,  `AggregationData`, etc.) with metrics in stats/metrics exporters. 

This PR changes `StackdriverStatsExporter` to:
 - use `Metric` instead of `ViewData` internally
 - remove `on_register_view` hook, lazily register metric descriptors with stackdriver at export time instead of on view creation
 - prepare to move from push to poll model by removing transports, `emit`, etc.

The meat of this PR is in `create_time_series_list`, which now takes a list of `Metric`s.

cc @colincadams 

Addresses #454.