### PR TITLE
V0.3.1 ext release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 ## Unreleased
 
+## 0.3.0
+Released 2019-03-11
+
 - Fix gRPC client tracer reuse bug
   ([#539](https://github.com/census-instrumentation/opencensus-python/pull/539))
-- Fix bugs in Prometheus exporter. Use ordered list for histogram buckets.
-  Use `UnknownMetricFamily` for `SumData` instead of `UntypedMetricFamily`.
-  Check if label keys and values match before exporting.
-- Remove min and max from Distribution.
+- Update prometheus client and fix multiple bugs in the exporter
+  ([#492](https://github.com/census-instrumentation/opencensus-python/pull/492))
+- Remove min and max from `Distribution`
+  ([#501](https://github.com/census-instrumentation/opencensus-python/pull/501))
 - Replace stackdriver `gke_container` resources, see the [GKE migration
   notes](https://cloud.google.com/monitoring/kubernetes-engine/migration#incompatible)
   for details

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.3.1
+Released 2019-03-19
+
+- Release 0.1.0 versions of exporter and integration packages
+
 ## 0.3.0
 Released 2019-03-11
 

--- a/contrib/opencensus-correlation/version.py
+++ b/contrib/opencensus-correlation/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.dev0'
+__version__ = '0.3.0'

--- a/contrib/opencensus-correlation/version.py
+++ b/contrib/opencensus-correlation/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.3.0'
+__version__ = '0.1.0'

--- a/contrib/opencensus-ext-dbapi/setup.py
+++ b/contrib/opencensus-ext-dbapi/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-dbapi/version.py
+++ b/contrib/opencensus-ext-dbapi/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.dev0'
+__version__ = '0.1.0'

--- a/contrib/opencensus-ext-django/setup.py
+++ b/contrib/opencensus-ext-django/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'Django >= 1.11.0, <= 1.11.20',
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-django/version.py
+++ b/contrib/opencensus-ext-django/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.dev0'
+__version__ = '0.1.0'

--- a/contrib/opencensus-ext-flask/setup.py
+++ b/contrib/opencensus-ext-flask/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'flask >= 0.12.3, < 2.0.0',
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-flask/version.py
+++ b/contrib/opencensus-ext-flask/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.dev0'
+__version__ = '0.1.0'

--- a/contrib/opencensus-ext-google-cloud-clientlibs/setup.py
+++ b/contrib/opencensus-ext-google-cloud-clientlibs/setup.py
@@ -40,8 +40,8 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'opencensus >= 0.3.0, < 1.0.0',
-        'opencensus-ext-grpc >= 0.1.dev0, < 1.0.0',
-        'opencensus-ext-requests >= 0.1.dev0, < 1.0.0',
+        'opencensus-ext-grpc >= 0.1.0, < 1.0.0',
+        'opencensus-ext-requests >= 0.1.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-google-cloud-clientlibs/setup.py
+++ b/contrib/opencensus-ext-google-cloud-clientlibs/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
         'opencensus-ext-grpc >= 0.1.dev0, < 1.0.0',
         'opencensus-ext-requests >= 0.1.dev0, < 1.0.0',
     ],

--- a/contrib/opencensus-ext-google-cloud-clientlibs/version.py
+++ b/contrib/opencensus-ext-google-cloud-clientlibs/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.dev0'
+__version__ = '0.1.0'

--- a/contrib/opencensus-ext-grpc/setup.py
+++ b/contrib/opencensus-ext-grpc/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'grpcio >= 1.0.0, < 2.0.0',
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-grpc/version.py
+++ b/contrib/opencensus-ext-grpc/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.dev0'
+__version__ = '0.1.0'

--- a/contrib/opencensus-ext-httplib/setup.py
+++ b/contrib/opencensus-ext-httplib/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-httplib/version.py
+++ b/contrib/opencensus-ext-httplib/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.dev0'
+__version__ = '0.1.0'

--- a/contrib/opencensus-ext-jaeger/setup.py
+++ b/contrib/opencensus-ext-jaeger/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-jaeger/version.py
+++ b/contrib/opencensus-ext-jaeger/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.dev0'
+__version__ = '0.1.0'

--- a/contrib/opencensus-ext-mysql/setup.py
+++ b/contrib/opencensus-ext-mysql/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'mysql-connector >= 2.1.6, < 3.0.0',
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
         'opencensus-ext-dbapi >= 0.1.dev0, < 1.0.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-mysql/setup.py
+++ b/contrib/opencensus-ext-mysql/setup.py
@@ -41,7 +41,7 @@ setup(
     install_requires=[
         'mysql-connector >= 2.1.6, < 3.0.0',
         'opencensus >= 0.3.0, < 1.0.0',
-        'opencensus-ext-dbapi >= 0.1.dev0, < 1.0.0',
+        'opencensus-ext-dbapi >= 0.1.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-mysql/version.py
+++ b/contrib/opencensus-ext-mysql/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.dev0'
+__version__ = '0.1.0'

--- a/contrib/opencensus-ext-ocagent/setup.py
+++ b/contrib/opencensus-ext-ocagent/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'grpcio >= 1.0.0, < 2.0.0',
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-ocagent/version.py
+++ b/contrib/opencensus-ext-ocagent/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.dev0'
+__version__ = '0.1.0'

--- a/contrib/opencensus-ext-postgresql/setup.py
+++ b/contrib/opencensus-ext-postgresql/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
         'psycopg2 >= 2.7.3.1',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-postgresql/version.py
+++ b/contrib/opencensus-ext-postgresql/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.dev0'
+__version__ = '0.1.0'

--- a/contrib/opencensus-ext-pymongo/setup.py
+++ b/contrib/opencensus-ext-pymongo/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
         'pymongo >= 3.1.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-pymongo/version.py
+++ b/contrib/opencensus-ext-pymongo/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.dev0'
+__version__ = '0.1.0'

--- a/contrib/opencensus-ext-pymysql/setup.py
+++ b/contrib/opencensus-ext-pymysql/setup.py
@@ -41,7 +41,7 @@ setup(
     install_requires=[
         'PyMySQL >= 0.7.11, < 1.0.0',
         'opencensus >= 0.3.0, < 1.0.0',
-        'opencensus-ext-dbapi >= 0.1.dev0, < 1.0.0',
+        'opencensus-ext-dbapi >= 0.1.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-pymysql/setup.py
+++ b/contrib/opencensus-ext-pymysql/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'PyMySQL >= 0.7.11, < 1.0.0',
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
         'opencensus-ext-dbapi >= 0.1.dev0, < 1.0.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-pymysql/version.py
+++ b/contrib/opencensus-ext-pymysql/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.dev0'
+__version__ = '0.1.0'

--- a/contrib/opencensus-ext-pyramid/setup.py
+++ b/contrib/opencensus-ext-pyramid/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'pyramid >= 1.9.1, < 2.0.0',
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-pyramid/version.py
+++ b/contrib/opencensus-ext-pyramid/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.dev0'
+__version__ = '0.1.0'

--- a/contrib/opencensus-ext-requests/setup.py
+++ b/contrib/opencensus-ext-requests/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
         'wrapt >= 1.0.0, < 2.0.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-requests/version.py
+++ b/contrib/opencensus-ext-requests/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.dev0'
+__version__ = '0.1.0'

--- a/contrib/opencensus-ext-sqlalchemy/setup.py
+++ b/contrib/opencensus-ext-sqlalchemy/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
         'SQLAlchemy >= 1.1.14, < 2.0.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-sqlalchemy/version.py
+++ b/contrib/opencensus-ext-sqlalchemy/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.dev0'
+__version__ = '0.1.0'

--- a/contrib/opencensus-ext-stackdriver/setup.py
+++ b/contrib/opencensus-ext-stackdriver/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'google-cloud-trace >= 0.20.0, < 1.0.0',
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-stackdriver/version.py
+++ b/contrib/opencensus-ext-stackdriver/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.dev0'
+__version__ = '0.1.0'

--- a/contrib/opencensus-ext-threading/setup.py
+++ b/contrib/opencensus-ext-threading/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-threading/version.py
+++ b/contrib/opencensus-ext-threading/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.dev0'
+__version__ = '0.1.0'

--- a/contrib/opencensus-ext-zipkin/setup.py
+++ b/contrib/opencensus-ext-zipkin/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-zipkin/version.py
+++ b/contrib/opencensus-ext-zipkin/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.dev0'
+__version__ = '0.1.0'

--- a/opencensus/common/version/__init__.py
+++ b/opencensus/common/version/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.3.0'
+__version__ = '0.3.1'

--- a/opencensus/common/version/__init__.py
+++ b/opencensus/common/version/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.dev0'
+__version__ = '0.3.0'


### PR DESCRIPTION
Version number updates for ext packages added for #445. Once this PR is merged into the `v0.3.x` branch we can create a `v0.3.1` release for the core library and push the new (`0.1.0`) ext packages to PyPI.

In the long term we need a separate release process for ext packages. See #544 for details.

Fixes #561.