### PR TITLE
Use utcnow instead of now

### DIFF
--- a/contrib/opencensus-ext-ocagent/opencensus/ext/ocagent/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-ocagent/opencensus/ext/ocagent/trace_exporter/__init__.py
@@ -84,7 +84,7 @@ class TraceExporter(base_exporter.Exporter):
                 else host_name,
                 pid=os.getpid(),
                 start_timestamp=utils.proto_ts_from_datetime(
-                    datetime.datetime.now())
+                    datetime.datetime.utcnow())
             ),
             library_info=common_pb2.LibraryInfo(
                 language=common_pb2.LibraryInfo.Language.Value('PYTHON'),

--- a/opencensus/metrics/export/gauge.py
+++ b/opencensus/metrics/export/gauge.py
@@ -481,7 +481,7 @@ class Registry(metric_producer.MetricProducer):
         :rtype: set(:class:`opencensus.metrics.export.metric.Metric`)
         :return: A set of `Metric`s, one for each registered gauge.
         """
-        now = datetime.now()
+        now = datetime.utcnow()
         metrics = set()
         for gauge in self.gauges.values():
             metrics.add(gauge.get_metric(now))

--- a/opencensus/stats/stats.py
+++ b/opencensus/stats/stats.py
@@ -37,4 +37,4 @@ class Stats(MetricProducer):
         :rtype: Iterator[:class: `opencensus.metrics.export.metric.Metric`]
         """
         return self.view_manager.measure_to_view_map.get_metrics(
-            datetime.now())
+            datetime.utcnow())

--- a/tests/unit/trace/test_blank_span.py
+++ b/tests/unit/trace/test_blank_span.py
@@ -64,7 +64,7 @@ class TestBlankSpan(unittest.TestCase):
         with self.assertRaises(TypeError):
             span.add_time_event(time_event)
 
-        time_event = TimeEvent(datetime.datetime.now())
+        time_event = TimeEvent(datetime.datetime.utcnow())
         span.add_time_event(time_event)
 
         span_iter_list = list(iter(span))

--- a/tests/unit/trace/test_span.py
+++ b/tests/unit/trace/test_span.py
@@ -145,7 +145,7 @@ class TestSpan(unittest.TestCase):
         with self.assertRaises(TypeError):
             span.add_time_event(time_event)
 
-        time_event = TimeEvent(datetime.datetime.now())
+        time_event = TimeEvent(datetime.datetime.utcnow())
         span.add_time_event(time_event)
 
         self.assertEqual(len(span.time_events), 1)
@@ -357,7 +357,7 @@ class Test_format_span_json(unittest.TestCase):
         span.start_time = start_time
         span.end_time = end_time
         span._child_spans = []
-        span.time_events = [TimeEvent(datetime.datetime.now())]
+        span.time_events = [TimeEvent(datetime.datetime.utcnow())]
         span.stack_trace = StackTrace()
         span.status = Status(code='200', message='test')
         span.links = [Link(trace_id, span_id)]


### PR DESCRIPTION
We were using `datetime.now` in stats/metrics conversions, which don't mix with the tz-aware datetimes used in stats. This could result in converted points being utc offset many hours off when exported.

Ultimately all `datetime`s should be removed for #502.