### PR TITLE
Switch SD exporter to polling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ Installation & basic usage
 
         from opencensus.stats import stats as stats_module
 
-        stats = stats_module.Stats()
+        stats = stats_module.stats
         view_manager = stats.view_manager
         stats_recorder = stats.stats_recorder
 

--- a/contrib/opencensus-ext-prometheus/README.rst
+++ b/contrib/opencensus-ext-prometheus/README.rst
@@ -45,7 +45,7 @@ Register the Prometheus exporter
 
     .. code:: python
 
-        stats = stats_module.Stats()
+        stats = stats_module.stats
         view_manager = stats.view_manager
 
         exporter = prometheus.new_stats_exporter(prometheus.Options(namespace="<namespace>"))

--- a/contrib/opencensus-ext-prometheus/examples/prometheus.py
+++ b/contrib/opencensus-ext-prometheus/examples/prometheus.py
@@ -40,7 +40,7 @@ VIDEO_SIZE_VIEW = view_module.View(
 
 
 def main():
-    stats = stats_module.Stats()
+    stats = stats_module.stats
     view_manager = stats.view_manager
     stats_recorder = stats.stats_recorder
 

--- a/contrib/opencensus-ext-prometheus/tests/test_prometheus_stats.py
+++ b/contrib/opencensus-ext-prometheus/tests/test_prometheus_stats.py
@@ -280,7 +280,7 @@ class TestPrometheusStatsExporter(unittest.TestCase):
 
     def test_emit(self):
         options = prometheus.Options(namespace="opencensus", port=9005)
-        stats = stats_module.Stats()
+        stats = stats_module.stats
         view_manager = stats.view_manager
         stats_recorder = stats.stats_recorder
         exporter = prometheus.new_stats_exporter(options)

--- a/contrib/opencensus-ext-stackdriver/README.rst
+++ b/contrib/opencensus-ext-stackdriver/README.rst
@@ -89,7 +89,7 @@ Register the Stackdriver exporter
 
     .. code:: python
 
-        stats = stats_module.Stats()
+        stats = stats_module.stats
         view_manager = stats.view_manager
 
         exporter = stackdriver.new_stats_exporter(stackdriver.Options(project_id="<id_value>"))

--- a/contrib/opencensus-ext-stackdriver/examples/stackdriver.py
+++ b/contrib/opencensus-ext-stackdriver/examples/stackdriver.py
@@ -30,7 +30,7 @@ m_latency_ms = measure_module.MeasureFloat(
     "task_latency", "The task latency in milliseconds", "ms")
 
 # The stats recorder
-stats = stats_module.Stats()
+stats = stats_module.stats
 view_manager = stats.view_manager
 stats_recorder = stats.stats_recorder
 

--- a/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/stats_exporter/__init__.py
+++ b/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/stats_exporter/__init__.py
@@ -27,8 +27,10 @@ from google.cloud import monitoring_v3
 from opencensus.common import utils
 from opencensus.common.monitored_resource import monitored_resource
 from opencensus.common.version import __version__
+from opencensus.metrics import transport
 from opencensus.metrics.export import metric as metric_module
 from opencensus.metrics.export import metric_descriptor
+from opencensus.stats import stats
 
 
 MAX_TIME_SERIES_PER_UPLOAD = 200
@@ -372,7 +374,9 @@ def new_stats_exporter(options):
     ci = client_info.ClientInfo(client_library_version=get_user_agent_slug())
     client = monitoring_v3.MetricServiceClient(client_info=ci)
     exporter = StackdriverStatsExporter(client=client, options=options)
-    return exporter
+
+    tt = transport.get_exporter_thread(stats.Stats(), exporter)
+    return exporter, tt
 
 
 def get_task_value():

--- a/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/stats_exporter/__init__.py
+++ b/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/stats_exporter/__init__.py
@@ -14,7 +14,6 @@
 
 from datetime import datetime
 import itertools
-import logging
 import os
 import platform
 import re
@@ -415,18 +414,6 @@ def new_label_descriptors(defaults, keys):
     label_descriptors.append({"key": OPENCENSUS_TASK,
                               "description": OPENCENSUS_TASK_DESCRIPTION})
     return label_descriptors
-
-
-def set_metric_labels(series, view, tag_values):
-    if len(view.columns) != len(tag_values):
-        logging.warning(
-            "TagKeys and TagValues don't have same size."
-        )  # pragma: NO COVER
-
-    for key, value in zip(view.columns, tag_values):
-        if value is not None:
-            series.metric.labels[sanitize_label(key)] = value
-    series.metric.labels[OPENCENSUS_TASK] = get_task_value()
 
 
 def sanitize_label(text):

--- a/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/stats_exporter/__init__.py
+++ b/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/stats_exporter/__init__.py
@@ -374,7 +374,7 @@ def new_stats_exporter(options):
     client = monitoring_v3.MetricServiceClient(client_info=ci)
     exporter = StackdriverStatsExporter(client=client, options=options)
 
-    tt = transport.get_exporter_thread(stats.Stats(), exporter)
+    tt = transport.get_exporter_thread(stats.stats, exporter)
     return exporter, tt
 
 

--- a/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/stats_exporter/__init__.py
+++ b/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/stats_exporter/__init__.py
@@ -147,6 +147,7 @@ class StackdriverStatsExporter(object):
         return self._client
 
     def export_metrics(self, metrics):
+        metrics = list(metrics)
         for metric in metrics:
             self.register_metric_descriptor(metric.descriptor)
         ts_batches = self.create_batched_time_series(metrics)

--- a/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_stats.py
+++ b/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_stats.py
@@ -212,17 +212,6 @@ class TestStackdriverStatsExporter(unittest.TestCase):
 
         self.assertEqual(registered_exporters, 1)
 
-    def test_set_metric_labels(self):
-        series = monitoring_v3.types.TimeSeries()
-        tag_value = tag_value_module.TagValue("1200")
-        stackdriver.set_metric_labels(series, VIDEO_SIZE_VIEW, [tag_value])
-        self.assertEqual(len(series.metric.labels), 2)
-
-    def test_set_metric_labels_with_None(self):
-        series = monitoring_v3.types.TimeSeries()
-        stackdriver.set_metric_labels(series, VIDEO_SIZE_VIEW, [None])
-        self.assertEqual(len(series.metric.labels), 1)
-
     @mock.patch('os.getpid', return_value=12345)
     @mock.patch(
         'platform.uname',

--- a/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_stats.py
+++ b/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_stats.py
@@ -364,11 +364,11 @@ class TestAsyncStatsExport(unittest.TestCase):
     """Check that metrics are exported using the exporter thread."""
 
     @mock.patch('opencensus.ext.stackdriver.stats_exporter'
-                '.stats.Stats')
+                '.stats.stats')
     def test_export_empty(self, mock_stats, mock_client):
         """Check that we don't attempt to export empty metric sets."""
 
-        mock_stats.return_value.get_metrics.return_value = []
+        mock_stats.get_metrics.return_value = []
 
         with patch_sd_transport():
             exporter, transport = stackdriver.new_stats_exporter(
@@ -382,7 +382,7 @@ class TestAsyncStatsExport(unittest.TestCase):
             transport.stop()
 
     @mock.patch('opencensus.ext.stackdriver.stats_exporter'
-                '.stats.Stats')
+                '.stats.stats')
     def test_export_single_metric(self, mock_stats, mock_client):
         """Check that we can export a set of a single metric."""
 
@@ -405,7 +405,7 @@ class TestAsyncStatsExport(unittest.TestCase):
         )
 
         mm = metric.Metric(descriptor=desc, time_series=ts)
-        mock_stats.return_value.get_metrics.return_value = [mm]
+        mock_stats.get_metrics.return_value = [mm]
 
         with patch_sd_transport():
             exporter, transport = stackdriver.new_stats_exporter(
@@ -443,6 +443,14 @@ class TestAsyncStatsExport(unittest.TestCase):
 
 
 class TestCreateTimeseries(unittest.TestCase):
+
+    def setUp(self):
+        patcher = mock.patch(
+            'opencensus.ext.stackdriver.stats_exporter.stats.stats',
+            stats_module._Stats())
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     def check_labels(self,
                      actual_labels,
                      expected_labels,

--- a/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_stats.py
+++ b/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_stats.py
@@ -199,7 +199,7 @@ class TestStackdriverStatsExporter(unittest.TestCase):
         self.assertEqual(expected_view_name_namespaced, view_name_namespaced)
 
     def test_stackdriver_register_exporter(self):
-        stats = stats_module.Stats()
+        stats = stats_module.stats
         view_manager = stats.view_manager
 
         exporter = mock.Mock()
@@ -541,7 +541,7 @@ class TestCreateTimeseries(unittest.TestCase):
         exporter = stackdriver.StackdriverStatsExporter(
             options=option, client=client)
 
-        stats = stats_module.Stats()
+        stats = stats_module.stats
         view_manager = stats.view_manager
         stats_recorder = stats.stats_recorder
 
@@ -617,7 +617,7 @@ class TestCreateTimeseries(unittest.TestCase):
         exporter = stackdriver.StackdriverStatsExporter(
             options=option, client=client)
 
-        stats = stats_module.Stats()
+        stats = stats_module.stats
         view_manager = stats.view_manager
         stats_recorder = stats.stats_recorder
 
@@ -888,7 +888,7 @@ class TestCreateTimeseries(unittest.TestCase):
         exporter = stackdriver.StackdriverStatsExporter(
             options=option, client=client)
 
-        stats = stats_module.Stats()
+        stats = stats_module.stats
         view_manager = stats.view_manager
         stats_recorder = stats.stats_recorder
 

--- a/examples/stats/helloworld/main.py
+++ b/examples/stats/helloworld/main.py
@@ -39,7 +39,7 @@ VIDEO_SIZE_VIEW = view_module.View(
 
 
 def main():
-    stats = stats_module.Stats()
+    stats = stats_module.stats
     view_manager = stats.view_manager
     stats_recorder = stats.stats_recorder
 

--- a/opencensus/metrics/transport.py
+++ b/opencensus/metrics/transport.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from six.moves import queue
 import logging
-import queue
 import threading
 
 from opencensus.common import utils

--- a/opencensus/metrics/transport.py
+++ b/opencensus/metrics/transport.py
@@ -105,6 +105,7 @@ class ManualTask(threading.Thread):
         ee.wait(GRACE_PERIOD)
 
     def stop(self):
+        self._stopped.set()
         self.qq.put(ManualTask.STOP)
 
 

--- a/opencensus/metrics/transport.py
+++ b/opencensus/metrics/transport.py
@@ -54,10 +54,10 @@ class PeriodicTask(threading.Thread):
             try:
                 self.func()
             except TransportError as ex:
-                logging.exception(ex)
+                logger.exception(ex)
                 self.stop()
             except Exception:
-                logging.exception("Error handling metric export")
+                logger.exception("Error handling metric export")
 
     def stop(self):
         self._stopped.set()
@@ -89,8 +89,11 @@ class ManualTask(threading.Thread):
 
             try:
                 self.func()
+            except TransportError as ex:
+                logger.exception(ex)
+                self.stop()
             except Exception:
-                logging.exception("Error handling metric export")
+                logger.exception("Error handling metric export")
             finally:
                 task.set()
 

--- a/opencensus/metrics/transport.py
+++ b/opencensus/metrics/transport.py
@@ -21,7 +21,7 @@ from opencensus.common import utils
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_INTERVAL = 10
+DEFAULT_INTERVAL = 60
 GRACE_PERIOD = 5
 
 

--- a/opencensus/metrics/transport.py
+++ b/opencensus/metrics/transport.py
@@ -39,6 +39,8 @@ class PeriodicTask(threading.Thread):
     :param interval: Seconds between calls to the function.
     """
 
+    daemon = True
+
     def __init__(self, func, interval=None, **kwargs):
         super(PeriodicTask, self).__init__(**kwargs)
         if interval is None:

--- a/opencensus/metrics/transport.py
+++ b/opencensus/metrics/transport.py
@@ -109,10 +109,6 @@ class ManualTask(threading.Thread):
         self.qq.put(ManualTask.STOP)
 
 
-def get_default_task_class():
-    return PeriodicTask
-
-
 def get_exporter_thread(metric_producer, exporter):
     """Get a running task that periodically exports metrics.
 
@@ -144,6 +140,6 @@ def get_exporter_thread(metric_producer, exporter):
             raise TransportError("Metric exporter is not available")
         export(get())
 
-    tt = get_default_task_class()(export_all)
+    tt = PeriodicTask(export_all)
     tt.start()
     return tt

--- a/opencensus/metrics/transport.py
+++ b/opencensus/metrics/transport.py
@@ -112,8 +112,7 @@ class ManualTask(threading.Thread):
 def get_exporter_thread(metric_producer, exporter):
     """Get a running task that periodically exports metrics.
 
-    Get a `PeriodicTask` (by default, see `get_default_task_class`) that
-    exports periodically calls
+    Get a `PeriodicTask` that exports periodically calls:
 
         exporter.export_metrics(metric_producer.get_metrics())
 

--- a/opencensus/metrics/transport.py
+++ b/opencensus/metrics/transport.py
@@ -1,0 +1,143 @@
+# Copyright 2019, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import queue
+import threading
+
+from opencensus.common import utils
+
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_INTERVAL = 10
+GRACE_PERIOD = 5
+
+
+class TransportError(Exception):
+    pass
+
+
+class PeriodicTask(threading.Thread):
+    """Thread that periodically calls a given function.
+
+    :type func: function
+    :param func: The function to call.
+
+    :type interval: int or float
+    :param interval: Seconds between calls to the function.
+    """
+
+    def __init__(self, func, interval=None, **kwargs):
+        super(PeriodicTask, self).__init__(**kwargs)
+        if interval is None:
+            interval = DEFAULT_INTERVAL
+        self.func = func
+        self.interval = interval
+        self._stopped = threading.Event()
+
+    def run(self):
+        while not self._stopped.wait(self.interval):
+            try:
+                self.func()
+            except TransportError as ex:
+                logging.exception(ex)
+                self.stop()
+            except Exception:
+                logging.exception("Error handling metric export")
+
+    def stop(self):
+        self._stopped.set()
+
+
+class ManualTask(threading.Thread):
+    """Thread that calls a given function on command.
+
+    `ManualTask.go` calls `func` once and blocks until it completes,
+    effectively simulating running `func` in the calling thread.
+
+    :type func: function
+    :param func: The function to call.
+    """
+
+    STOP = object()
+
+    def __init__(self, func, **kwargs):
+        super(ManualTask, self).__init__(**kwargs)
+        self.func = func
+        self.qq = queue.Queue()
+        self._stopped = threading.Event()
+
+    def run(self):
+        while True:
+            task = self.qq.get()
+            if task == ManualTask.STOP:
+                break
+
+            try:
+                self.func()
+            except Exception:
+                logging.exception("Error handling metric export")
+            finally:
+                task.set()
+
+    def go(self):
+        if self._stopped.is_set():
+            raise ValueError("Thread is stopped")
+        ee = threading.Event()
+        self.qq.put(ee)
+        ee.wait(GRACE_PERIOD)
+
+    def stop(self):
+        self.qq.put(ManualTask.STOP)
+
+
+def get_default_task_class():
+    return PeriodicTask
+
+
+def get_exporter_thread(metric_producer, exporter):
+    """Get a running task that periodically exports metrics.
+
+    Get a `PeriodicTask` (by default, see `get_default_task_class`) that
+    exports periodically calls
+
+        exporter.export_metrics(metric_producer.get_metrics())
+
+    :type metric_producer:
+        :class:`opencensus.metrics.export.metric_producer.MetricProducer`
+    :param exporter: The producer to use to get metrics to export.
+
+    :type exporter: :class:`opencensus.stats.base_exporter.MetricsExporter`
+    :param exporter: The exporter to use to export metrics.
+
+    :rtype: :class:`threading.Thread`
+    :return: A running thread responsible calling the exporter.
+
+    """
+    weak_get = utils.get_weakref(metric_producer.get_metrics)
+    weak_export = utils.get_weakref(exporter.export_metrics)
+
+    def export_all():
+        get = weak_get()
+        if get is None:
+            raise TransportError("Metric producer is not available")
+        export = weak_export()
+        if export is None:
+            raise TransportError("Metric exporter is not available")
+        export(get())
+
+    tt = get_default_task_class()(export_all)
+    tt.start()
+    return tt

--- a/opencensus/stats/stats.py
+++ b/opencensus/stats/stats.py
@@ -19,7 +19,7 @@ from opencensus.stats.stats_recorder import StatsRecorder
 from opencensus.stats.view_manager import ViewManager
 
 
-class Stats(MetricProducer):
+class _Stats(MetricProducer):
     """Stats defines a View Manager and a Stats Recorder in order for the
     collection of Stats
     """
@@ -38,3 +38,6 @@ class Stats(MetricProducer):
         """
         return self.view_manager.measure_to_view_map.get_metrics(
             datetime.utcnow())
+
+
+stats = _Stats()

--- a/tests/system/stats/prometheus/prometheus_stats_test.py
+++ b/tests/system/stats/prometheus/prometheus_stats_test.py
@@ -39,7 +39,7 @@ class TestPrometheusStats(unittest.TestCase):
             request_count_view_name,
             "number of requests broken down by methods",
             [method_key], request_count_measure, count_agg)
-        stats = stats_module.Stats()
+        stats = stats_module.stats
         view_manager = stats.view_manager
         stats_recorder = stats.stats_recorder
 

--- a/tests/system/stats/stackdriver/stackdriver_stats_test.py
+++ b/tests/system/stats/stackdriver/stackdriver_stats_test.py
@@ -129,7 +129,7 @@ class TestBasicStats(unittest.TestCase):
         view_manager = stats.view_manager
         stats_recorder = stats.stats_recorder
 
-        exporter = stackdriver.new_stats_exporter(
+        exporter, tt = stackdriver.new_stats_exporter(
             stackdriver.Options(project_id=PROJECT))
         view_manager.register_exporter(exporter)
 
@@ -148,7 +148,8 @@ class TestBasicStats(unittest.TestCase):
         measure_map.measure_int_put(VIDEO_SIZE_MEASURE_ASYNC, 25 * MiB)
 
         measure_map.record(tag_map)
-        exporter.export_metrics(stats_module.Stats().get_metrics())
+        tt.go()
+        tt.stop()
 
         @retry(
             wait_fixed=RETRY_WAIT_PERIOD,

--- a/tests/system/stats/stackdriver/stackdriver_stats_test.py
+++ b/tests/system/stats/stackdriver/stackdriver_stats_test.py
@@ -31,8 +31,10 @@ from opencensus.tags import tag_value as tag_value_module
 
 if sys.version_info < (3,):
     import unittest2 as unittest
+    import mock
 else:
     import unittest
+    from unittest import mock
 
 
 MiB = 1 << 20
@@ -43,6 +45,14 @@ RETRY_MAX_ATTEMPT = 10  # Retry 10 times
 
 
 class TestBasicStats(unittest.TestCase):
+
+    def setUp(self):
+        patcher = mock.patch(
+            'opencensus.ext.stackdriver.stats_exporter.stats.stats',
+            stats_module._Stats())
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     def test_stats_record_sync(self):
         # We are using sufix in order to prevent cached objects
         sufix = str(os.getgid())

--- a/tests/system/stats/stackdriver/stackdriver_stats_test.py
+++ b/tests/system/stats/stackdriver/stackdriver_stats_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from contextlib import contextmanager
 import os
 import random
 import sys
@@ -32,10 +31,8 @@ from opencensus.tags import tag_value as tag_value_module
 
 if sys.version_info < (3,):
     import unittest2 as unittest
-    import mock
 else:
     import unittest
-    from unittest import mock
 
 
 MiB = 1 << 20
@@ -43,14 +40,6 @@ MiB = 1 << 20
 PROJECT = os.environ.get('GCLOUD_PROJECT_PYTHON')
 RETRY_WAIT_PERIOD = 10000  # Wait 10 seconds between each retry
 RETRY_MAX_ATTEMPT = 10  # Retry 10 times
-
-
-@contextmanager
-def patch_sd_transport():
-    with mock.patch('opencensus.metrics.transport'
-                    '.get_default_task_class') as mm:
-        mm.return_value = stackdriver.transport.ManualTask
-        yield
 
 
 class TestBasicStats(unittest.TestCase):
@@ -146,9 +135,8 @@ class TestBasicStats(unittest.TestCase):
         view_manager = stats.view_manager
         stats_recorder = stats.stats_recorder
 
-        with patch_sd_transport():
-            exporter, transport = stackdriver.new_stats_exporter(
-                stackdriver.Options(project_id=PROJECT))
+        exporter, transport = stackdriver.new_stats_exporter(
+            stackdriver.Options(project_id=PROJECT))
         view_manager.register_exporter(exporter)
 
         # Register view.
@@ -180,8 +168,4 @@ class TestBasicStats(unittest.TestCase):
             self.assertEqual(element.description, view_description)
             self.assertEqual(element.unit, "By")
 
-        try:
-            transport.go()
-            get_metric_descriptors(self, exporter, view_description)
-        finally:
-            transport.stop()
+        get_metric_descriptors(self, exporter, view_description)

--- a/tests/system/stats/stackdriver/stackdriver_stats_test.py
+++ b/tests/system/stats/stackdriver/stackdriver_stats_test.py
@@ -74,7 +74,7 @@ class TestBasicStats(unittest.TestCase):
             VIDEO_SIZE_VIEW_NAME, view_description, [FRONTEND_KEY],
             VIDEO_SIZE_MEASURE, VIDEO_SIZE_DISTRIBUTION)
 
-        stats = stats_module.Stats()
+        stats = stats_module.stats
         view_manager = stats.view_manager
         stats_recorder = stats.stats_recorder
 
@@ -99,7 +99,7 @@ class TestBasicStats(unittest.TestCase):
         measure_map.measure_int_put(VIDEO_SIZE_MEASURE, 25 * MiB)
 
         measure_map.record(tag_map)
-        exporter.export_metrics(stats_module.Stats().get_metrics())
+        exporter.export_metrics(stats_module.stats.get_metrics())
 
         # Sleep for [0, 10] milliseconds to fake wait.
         time.sleep(random.randint(1, 10) / 1000.0)
@@ -142,7 +142,7 @@ class TestBasicStats(unittest.TestCase):
             VIDEO_SIZE_VIEW_NAME_ASYNC, view_description, [FRONTEND_KEY_ASYNC],
             VIDEO_SIZE_MEASURE_ASYNC, VIDEO_SIZE_DISTRIBUTION_ASYNC)
 
-        stats = stats_module.Stats()
+        stats = stats_module.stats
         view_manager = stats.view_manager
         stats_recorder = stats.stats_recorder
 

--- a/tests/system/stats/stackdriver/stackdriver_stats_test.py
+++ b/tests/system/stats/stackdriver/stackdriver_stats_test.py
@@ -19,6 +19,7 @@ import time
 
 from google.cloud import monitoring_v3
 from retrying import retry
+import mock
 
 from opencensus.ext.stackdriver import stats_exporter as stackdriver
 from opencensus.stats import aggregation as aggregation_module
@@ -31,10 +32,8 @@ from opencensus.tags import tag_value as tag_value_module
 
 if sys.version_info < (3,):
     import unittest2 as unittest
-    import mock
 else:
     import unittest
-    from unittest import mock
 
 
 MiB = 1 << 20

--- a/tests/unit/metrics/test_transport.py
+++ b/tests/unit/metrics/test_transport.py
@@ -1,0 +1,242 @@
+# Copyright 2019, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from concurrent import futures
+from contextlib import contextmanager
+from functools import partial
+import gc
+import logging
+import sys
+import threading
+import time
+
+from opencensus.metrics import transport
+
+if sys.version_info < (3,):
+    import unittest2 as unittest
+    import mock
+else:
+    import unittest
+    from unittest import mock
+
+
+# Some tests use real time! This is the time to wait between the exporter
+# thread handling tasks, and doesn't account for processing time. If these
+# tests become flaky, try increasing this.
+INTERVAL = .01
+
+class TestPeriodicTask(unittest.TestCase):
+
+    def test_default_constructor(self):
+        mock_func = mock.Mock()
+        task = transport.PeriodicTask(mock_func)
+        self.assertEqual(task.func, mock_func)
+        self.assertEqual(task.interval, transport.DEFAULT_INTERVAL)
+
+    def test_periodic_task_not_started(self):
+        mock_func = mock.Mock()
+        task = transport.PeriodicTask(mock_func, INTERVAL)
+        time.sleep(INTERVAL + INTERVAL / 2.0)
+        mock_func.assert_not_called()
+        task.stop()
+
+    def test_periodic_task(self):
+        mock_func = mock.Mock()
+        task = transport.PeriodicTask(mock_func, INTERVAL)
+        task.start()
+        mock_func.assert_not_called()
+        time.sleep(INTERVAL + INTERVAL / 2.0)
+        self.assertEqual(mock_func.call_count, 1)
+        time.sleep(INTERVAL)
+        self.assertEqual(mock_func.call_count, 2)
+        time.sleep(INTERVAL)
+        self.assertEqual(mock_func.call_count, 3)
+
+    def test_periodic_task_stop(self):
+        mock_func = mock.Mock()
+        task = transport.PeriodicTask(mock_func, INTERVAL)
+        task.start()
+        time.sleep(INTERVAL + INTERVAL / 2.0)
+        self.assertEqual(mock_func.call_count, 1)
+        task.stop()
+        time.sleep(INTERVAL)
+        self.assertEqual(mock_func.call_count, 1)
+
+
+class TestManualTask(unittest.TestCase):
+
+    def test_manual_task(self):
+        mock_func = mock.Mock()
+        task = transport.ManualTask(mock_func)
+        try:
+            task.start()
+            mock_func.assert_not_called()
+            task.go()
+            self.assertEqual(mock_func.call_count, 1)
+            task.go()
+            self.assertEqual(mock_func.call_count, 2)
+        finally:
+            task.stop()
+
+        with self.assertRaises(ValueError):
+            task.go()
+        self.assertEqual(mock_func.call_count, 2)
+
+    def test_manual_task_finish_queue(self):
+        """Check that we finish the work on the queue after stop signal."""
+        count = 0
+        lock = threading.Lock()
+        def sleep_and_inc():
+            time.sleep(INTERVAL)
+            with lock:
+                count += 1
+
+        mock_func = mock.Mock()
+        mock_func.side_effect = partial(time.sleep, INTERVAL)
+
+        task = transport.ManualTask(mock_func)
+        try:
+            task.start()
+
+            num_threads = 5
+            with futures.ThreadPoolExecutor(max_workers=num_threads) as tpe:
+                for _ in range(num_threads):
+                    tpe.submit(task.go)
+
+            self.assertEqual(count, 0)
+        finally:
+            task.stop()
+
+        time.sleep(num_threads * INTERVAL + INTERVAL / 2.0)
+        self.assertEqual(mock_func.call_count, num_threads)
+
+
+@contextmanager
+def patch_get_exporter_thread():
+    with mock.patch('opencensus.metrics.transport'
+                    '.get_default_task_class') as mm:
+        mm.return_value = transport.ManualTask
+        yield
+
+
+class TestGetExporterThreadManual(unittest.TestCase):
+
+    def test_threaded_export(self):
+        with patch_get_exporter_thread():
+            producer = mock.Mock()
+            exporter = mock.Mock()
+            metrics = mock.Mock()
+            producer.get_metrics.return_value = metrics
+            try:
+                task = transport.get_exporter_thread(producer, exporter)
+                producer.get_metrics.assert_not_called()
+                exporter.export_metrics.assert_not_called()
+                task.go()
+                producer.get_metrics.assert_called_once_with()
+                exporter.export_metrics.assert_called_once_with(metrics)
+            finally:
+                task.stop()
+
+    def test_producer_error(self):
+        producer = mock.Mock()
+        exporter = mock.Mock()
+
+        producer.get_metrics.side_effect = ValueError()
+
+        with patch_get_exporter_thread():
+            try:
+                task = transport.get_exporter_thread(producer, exporter)
+                with self.assertLogs('opencensus.metrics.transport',
+                                     level=logging.ERROR):
+                    task.go()
+                self.assertFalse(task._stopped.is_set())
+            finally:
+                task.stop()
+
+    def test_producer_deleted(self):
+        with patch_get_exporter_thread():
+            producer = mock.Mock()
+            exporter = mock.Mock()
+            task = transport.get_exporter_thread(producer, exporter)
+            del producer
+            gc.collect()
+            with self.assertLogs('opencensus.metrics.transport',
+                                 level=logging.ERROR):
+                task.go()
+            self.assertTrue(task._stopped.is_set())
+
+    def test_exporter_deleted(self):
+        with patch_get_exporter_thread():
+            producer = mock.Mock()
+            exporter = mock.Mock()
+            task = transport.get_exporter_thread(producer, exporter)
+            del exporter
+            gc.collect()
+            with self.assertLogs('opencensus.metrics.transport',
+                                 level=logging.ERROR):
+                task.go()
+            self.assertTrue(task._stopped.is_set())
+
+
+@mock.patch('opencensus.metrics.transport.DEFAULT_INTERVAL', INTERVAL)
+class TestGetExporterThreadPeriodic(unittest.TestCase):
+
+    def test_threaded_export(self):
+        producer = mock.Mock()
+        exporter = mock.Mock()
+        metrics = mock.Mock()
+        producer.get_metrics.return_value = metrics
+        try:
+            task = transport.get_exporter_thread(producer, exporter)
+            producer.get_metrics.assert_not_called()
+            exporter.export_metrics.assert_not_called()
+            time.sleep(INTERVAL + INTERVAL / 2.0)
+            producer.get_metrics.assert_called_once_with()
+            exporter.export_metrics.assert_called_once_with(metrics)
+        finally:
+            task.stop()
+
+    def test_producer_error(self):
+        producer = mock.Mock()
+        exporter = mock.Mock()
+
+        producer.get_metrics.side_effect = ValueError()
+
+        task = transport.get_exporter_thread(producer, exporter)
+        with self.assertLogs('opencensus.metrics.transport',
+                             level=logging.ERROR):
+            time.sleep(INTERVAL + INTERVAL / 2.0)
+        self.assertFalse(task._stopped.is_set())
+
+    def test_producer_deleted(self):
+        producer = mock.Mock()
+        exporter = mock.Mock()
+        task = transport.get_exporter_thread(producer, exporter)
+        del producer
+        gc.collect()
+        with self.assertLogs('opencensus.metrics.transport',
+                             level=logging.ERROR):
+            time.sleep(INTERVAL + INTERVAL / 2.0)
+        self.assertTrue(task._stopped.is_set())
+
+    def test_exporter_deleted(self):
+        producer = mock.Mock()
+        exporter = mock.Mock()
+        task = transport.get_exporter_thread(producer, exporter)
+        del exporter
+        gc.collect()
+        with self.assertLogs('opencensus.metrics.transport',
+                             level=logging.ERROR):
+            time.sleep(INTERVAL + INTERVAL / 2.0)
+        self.assertTrue(task._stopped.is_set())

--- a/tests/unit/metrics/test_transport.py
+++ b/tests/unit/metrics/test_transport.py
@@ -15,7 +15,6 @@
 from concurrent import futures
 from contextlib import contextmanager
 import gc
-import logging
 import sys
 import threading
 import time
@@ -158,8 +157,7 @@ class TestGetExporterThreadManual(unittest.TestCase):
         with patch_get_exporter_thread():
             try:
                 task = transport.get_exporter_thread(producer, exporter)
-                with self.assertLogs('opencensus.metrics.transport',
-                                     level=logging.ERROR):
+                with self.assertLogs(transport.logger):
                     task.go()
                 self.assertFalse(task._stopped.is_set())
             finally:
@@ -172,8 +170,7 @@ class TestGetExporterThreadManual(unittest.TestCase):
             task = transport.get_exporter_thread(producer, exporter)
             del producer
             gc.collect()
-            with self.assertLogs('opencensus.metrics.transport',
-                                 level=logging.ERROR):
+            with self.assertLogs(transport.logger):
                 task.go()
             self.assertTrue(task._stopped.is_set())
 
@@ -184,8 +181,7 @@ class TestGetExporterThreadManual(unittest.TestCase):
             task = transport.get_exporter_thread(producer, exporter)
             del exporter
             gc.collect()
-            with self.assertLogs('opencensus.metrics.transport',
-                                 level=logging.ERROR):
+            with self.assertLogs(transport.logger):
                 task.go()
             self.assertTrue(task._stopped.is_set())
 
@@ -215,8 +211,7 @@ class TestGetExporterThreadPeriodic(unittest.TestCase):
         producer.get_metrics.side_effect = ValueError()
 
         task = transport.get_exporter_thread(producer, exporter)
-        with self.assertLogs('opencensus.metrics.transport',
-                             level=logging.ERROR):
+        with self.assertLogs(transport.logger):
             time.sleep(INTERVAL + INTERVAL / 2.0)
         self.assertFalse(task._stopped.is_set())
 
@@ -226,8 +221,7 @@ class TestGetExporterThreadPeriodic(unittest.TestCase):
         task = transport.get_exporter_thread(producer, exporter)
         del producer
         gc.collect()
-        with self.assertLogs('opencensus.metrics.transport',
-                             level=logging.ERROR):
+        with self.assertLogs(transport.logger):
             time.sleep(INTERVAL + INTERVAL / 2.0)
         self.assertTrue(task._stopped.is_set())
 
@@ -237,7 +231,6 @@ class TestGetExporterThreadPeriodic(unittest.TestCase):
         task = transport.get_exporter_thread(producer, exporter)
         del exporter
         gc.collect()
-        with self.assertLogs('opencensus.metrics.transport',
-                             level=logging.ERROR):
+        with self.assertLogs(transport.logger):
             time.sleep(INTERVAL + INTERVAL / 2.0)
         self.assertTrue(task._stopped.is_set())

--- a/tests/unit/metrics/test_transport.py
+++ b/tests/unit/metrics/test_transport.py
@@ -33,7 +33,7 @@ else:
 # Some tests use real time! This is the time to wait between the exporter
 # thread handling tasks, and doesn't account for processing time. If these
 # tests become flaky, try increasing this.
-INTERVAL = .01
+INTERVAL = .05
 
 class TestPeriodicTask(unittest.TestCase):
 

--- a/tests/unit/metrics/test_transport.py
+++ b/tests/unit/metrics/test_transport.py
@@ -35,6 +35,7 @@ else:
 # tests become flaky, try increasing this.
 INTERVAL = .05
 
+
 class TestPeriodicTask(unittest.TestCase):
 
     def test_default_constructor(self):
@@ -96,6 +97,7 @@ class TestManualTask(unittest.TestCase):
         """Check that we finish the work on the queue after stop signal."""
         count = 0
         lock = threading.Lock()
+
         def sleep_and_inc():
             time.sleep(INTERVAL)
             with lock:
@@ -119,7 +121,6 @@ class TestManualTask(unittest.TestCase):
 
             time.sleep(num_threads * INTERVAL + INTERVAL / 2.0)
             self.assertEqual(mock_func.call_count, num_threads)
-
 
 
 @contextmanager

--- a/tests/unit/metrics/test_transport.py
+++ b/tests/unit/metrics/test_transport.py
@@ -95,14 +95,13 @@ class TestManualTask(unittest.TestCase):
 
     def test_manual_task_finish_queue(self):
         """Check that we finish the work on the queue after stop signal."""
-        count = 0
         lock = threading.Lock()
+        count = mock.Mock()
 
         def sleep_and_inc():
             time.sleep(INTERVAL)
             with lock:
-                nonlocal count
-                count += 1  # noqa
+                count()
 
         mock_func = mock.Mock()
         mock_func.side_effect = sleep_and_inc
@@ -115,11 +114,12 @@ class TestManualTask(unittest.TestCase):
             for _ in range(num_threads):
                 tpe.submit(task.go)
 
-            self.assertEqual(count, 0)
+            self.assertEqual(count.call_count, 0)
             # Call stop after work is queued, but not complete
             task.stop()
 
             time.sleep(num_threads * INTERVAL + INTERVAL / 2.0)
+            self.assertEqual(count.call_count, num_threads)
             self.assertEqual(mock_func.call_count, num_threads)
 
 

--- a/tests/unit/metrics/test_transport.py
+++ b/tests/unit/metrics/test_transport.py
@@ -16,14 +16,14 @@ import gc
 import sys
 import time
 
+import mock
+
 from opencensus.metrics import transport
 
 if sys.version_info < (3,):
     import unittest2 as unittest
-    import mock
 else:
     import unittest
-    from unittest import mock
 
 
 # Some tests use real time! This is the time to wait between the exporter

--- a/tests/unit/stats/test_stats.py
+++ b/tests/unit/stats/test_stats.py
@@ -32,7 +32,7 @@ class TestStats(unittest.TestCase):
     def test_get_metrics(self):
         """Test that Stats converts recorded values into metrics."""
 
-        stats = stats_module.Stats()
+        stats = stats_module.stats
 
         # Check that metrics are empty before view registration
         initial_metrics = list(stats.get_metrics())


### PR DESCRIPTION
This PR adds support for polling metrics from the stackdriver exporter. It builds on #560, which removed the ability to _push_ metrics to the exporter via `MeasureToViewMap.record`.

I've added a `PeriodicTask` class (similar to the java client's [`IntervalMetricReader`](https://github.com/census-instrumentation/opencensus-java/blob/b47f0708421c9a6dc352e3e85e2c64d2f22043a8/exporters/metrics/util/src/main/java/io/opencensus/exporter/metrics/util/IntervalMetricReader.java)) that periodically calls `exporter.export(producer.get_metrics())`. To keep the API changes to a minimum I've changed `new_stats_exporter` to create and start the task, but we may want to change this to make the exporter ignorant of the transport instead.
  
@songy23 and @colincadams I'm interested to hear your thoughts on the API changes here.