### PR TITLE
Bump stackdriver ext to 0.1.1

### DIFF
--- a/contrib/opencensus-ext-stackdriver/version.py
+++ b/contrib/opencensus-ext-stackdriver/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'


### PR DESCRIPTION
Following #581, bump the stackdriver ext package version. `0.1.0` includes trace only, `0.1.1` includes stats.