### PR TITLE
Allow to pass x-b3-sampled as string

### DIFF
--- a/opencensus/trace/propagation/b3_format.py
+++ b/opencensus/trace/propagation/b3_format.py
@@ -62,10 +62,10 @@ class B3FormatPropagator(object):
             sampled = headers.get(_SAMPLED_KEY)
 
         if sampled is not None:
-            if len(sampled) != 1:
-                return SpanContext(from_header=False)
-
-            sampled = sampled in ('1', 'd')
+            # The specification encodes an enabled tracing decision as "1".
+            # In the wild pre-standard implementations might still send "true".
+            # "d" is set in the single header case when debugging is enabled.
+            sampled = sampled.lower() in ('1', 'd', 'true')
         else:
             # If there's no incoming sampling decision, it was deferred to us.
             # Even though we set it to False here, we might still sample

--- a/tests/unit/trace/propagation/test_b3_format.py
+++ b/tests/unit/trace/propagation/test_b3_format.py
@@ -30,23 +30,44 @@ class TestB3FormatPropagator(unittest.TestCase):
     def test_from_headers_keys_exist(self):
         test_trace_id = '6e0c63257de34c92bf9efcd03927272e'
         test_span_id = '00f067aa0ba902b7'
-        test_sampled = '1'
 
-        headers = {
-            b3_format._TRACE_ID_KEY: test_trace_id,
-            b3_format._SPAN_ID_KEY: test_span_id,
-            b3_format._SAMPLED_KEY: test_sampled,
-        }
+        for test_sampled in ['1', 'True', 'true', 'd']:
+            headers = {
+                b3_format._TRACE_ID_KEY: test_trace_id,
+                b3_format._SPAN_ID_KEY: test_span_id,
+                b3_format._SAMPLED_KEY: test_sampled,
+            }
 
-        propagator = b3_format.B3FormatPropagator()
-        span_context = propagator.from_headers(headers)
+            propagator = b3_format.B3FormatPropagator()
+            span_context = propagator.from_headers(headers)
 
-        self.assertEqual(span_context.trace_id, test_trace_id)
-        self.assertEqual(span_context.span_id, test_span_id)
-        self.assertEqual(
-            span_context.trace_options.enabled,
-            bool(test_sampled)
-        )
+            self.assertEqual(span_context.trace_id, test_trace_id)
+            self.assertEqual(span_context.span_id, test_span_id)
+            self.assertEqual(
+                span_context.trace_options.enabled,
+                True
+            )
+
+    def test_from_headers_keys_exist_disabled_sampling(self):
+        test_trace_id = '6e0c63257de34c92bf9efcd03927272e'
+        test_span_id = '00f067aa0ba902b7'
+
+        for test_sampled in ['0', 'False', 'false', None]:
+            headers = {
+                b3_format._TRACE_ID_KEY: test_trace_id,
+                b3_format._SPAN_ID_KEY: test_span_id,
+                b3_format._SAMPLED_KEY: test_sampled,
+            }
+
+            propagator = b3_format.B3FormatPropagator()
+            span_context = propagator.from_headers(headers)
+
+            self.assertEqual(span_context.trace_id, test_trace_id)
+            self.assertEqual(span_context.span_id, test_span_id)
+            self.assertEqual(
+                span_context.trace_options.enabled,
+                False
+            )
 
     def test_from_headers_keys_not_exist(self):
         propagator = b3_format.B3FormatPropagator()


### PR DESCRIPTION
While x-b3-sampled should be '0' or '1' some implementations pass a string like 'True' or 'true'.

Others implement this as well, see, e.g. https://github.com/jaegertracing/jaeger-client-go/pull/356