### PR TITLE
Don't return transport along with SD stats exporter

### DIFF
--- a/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/stats_exporter/__init__.py
+++ b/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/stats_exporter/__init__.py
@@ -390,9 +390,8 @@ def new_stats_exporter(options, interval=None):
     client = monitoring_v3.MetricServiceClient(client_info=ci)
     exporter = StackdriverStatsExporter(client=client, options=options)
 
-    tt = transport.get_exporter_thread(stats.stats, exporter,
-                                       interval=interval)
-    return exporter, tt
+    transport.get_exporter_thread(stats.stats, exporter, interval=interval)
+    return exporter
 
 
 def get_task_value():

--- a/tests/system/stats/stackdriver/stackdriver_stats_test.py
+++ b/tests/system/stats/stackdriver/stackdriver_stats_test.py
@@ -21,6 +21,7 @@ from google.cloud import monitoring_v3
 import mock
 
 from opencensus.ext.stackdriver import stats_exporter as stackdriver
+from opencensus.metrics import transport
 from opencensus.stats import aggregation as aggregation_module
 from opencensus.stats import measure as measure_module
 from opencensus.stats import stats as stats_module
@@ -143,9 +144,8 @@ class TestBasicStats(unittest.TestCase):
         view_manager = stats.view_manager
         stats_recorder = stats.stats_recorder
 
-        exporter, transport = stackdriver.new_stats_exporter(
-            stackdriver.Options(project_id=PROJECT),
-            interval=ASYNC_TEST_INTERVAL)
+        exporter = stackdriver.new_stats_exporter(
+            stackdriver.Options(project_id=PROJECT))
         view_manager.register_exporter(exporter)
 
         # Register view.
@@ -164,7 +164,6 @@ class TestBasicStats(unittest.TestCase):
 
         measure_map.record(tag_map)
         # Give the exporter thread enough time to export exactly once
-        time.sleep(ASYNC_TEST_INTERVAL * 2 - 1)
-        transport.stop()
+        time.sleep(transport.DEFAULT_INTERVAL * 1.5)
 
         self.check_sd_md(exporter, view_description)


### PR DESCRIPTION
This PR reverts a change to [`new_stats_exporter`](https://github.com/census-instrumentation/opencensus-python/blob/922702b6ac61615c8e3674f152c5ee6e25ccc96d/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/stats_exporter/__init__.py#L368-L395) from #593 so that the method returns the exporter only, and not the `PeriodicTask` that it now starts on exporter creation. We need to merge this before releasing `0.4.0` (#604).

Users generally won't need access to the task, but we may still want to return it here. In any case this is a breaking change, and if we consider `new_stats_exporter` to be part of the stats API we shouldn't make this change in the stackdriver exporter until we're ready to do the same for prometheus.