### PR TITLE
v0.4.x master version updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 0.4.0
+Released 2019-04-08
+
+- Multiple bugfixes
+- Use separate context package instead of threadlocals for execution context
+  ([#573](https://github.com/census-instrumentation/opencensus-python/pull/573))
+
 ## 0.3.0
 Released 2019-03-11
 

--- a/context/opencensus-context/CHANGELOG.md
+++ b/context/opencensus-context/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.1.0
+Released 2019-04-08
 
-- Add this changelog.
+- Initial version

--- a/context/opencensus-context/version.py
+++ b/context/opencensus-context/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.dev0'
+__version__ = '0.2.dev0'

--- a/contrib/opencensus-ext-dbapi/CHANGELOG.md
+++ b/contrib/opencensus-ext-dbapi/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.1.1
+Released 2019-04-08
+
+- Cosmetic changes
+
 ## 0.1.0
 Released 2019-03-19
 

--- a/contrib/opencensus-ext-dbapi/setup.py
+++ b/contrib/opencensus-ext-dbapi/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.4.dev0, < 1.0.0',
+        'opencensus >= 0.5.dev0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-django/CHANGELOG.md
+++ b/contrib/opencensus-ext-django/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.2.0
+Released 2019-04-08
+
+- Update for package changes in core library
+
 ## 0.1.0
 Released 2019-03-19
 

--- a/contrib/opencensus-ext-django/setup.py
+++ b/contrib/opencensus-ext-django/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'Django >= 1.11.0, <= 1.11.20',
-        'opencensus >= 0.4.dev0, < 1.0.0',
+        'opencensus >= 0.5.dev0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-django/version.py
+++ b/contrib/opencensus-ext-django/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.dev0'
+__version__ = '0.3.dev0'

--- a/contrib/opencensus-ext-flask/CHANGELOG.md
+++ b/contrib/opencensus-ext-flask/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.2.0
+Released 2019-04-08
+
+- Update for package changes in core library
+
 ## 0.1.0
 Released 2019-03-19
 

--- a/contrib/opencensus-ext-flask/setup.py
+++ b/contrib/opencensus-ext-flask/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'flask >= 0.12.3, < 2.0.0',
-        'opencensus >= 0.4.dev0, < 1.0.0',
+        'opencensus >= 0.5.dev0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-flask/version.py
+++ b/contrib/opencensus-ext-flask/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.dev0'
+__version__ = '0.3.dev0'

--- a/contrib/opencensus-ext-google-cloud-clientlibs/CHANGELOG.md
+++ b/contrib/opencensus-ext-google-cloud-clientlibs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.1.1
+Released 2019-04-08
+
+- Cosmetic changes
+
 ## 0.1.0
 Released 2019-03-19
 

--- a/contrib/opencensus-ext-google-cloud-clientlibs/setup.py
+++ b/contrib/opencensus-ext-google-cloud-clientlibs/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.4.dev0, < 1.0.0',
+        'opencensus >= 0.5.dev0, < 1.0.0',
         'opencensus-ext-grpc >= 0.2.dev0, < 1.0.0',
         'opencensus-ext-requests >= 0.2.dev0, < 1.0.0',
     ],

--- a/contrib/opencensus-ext-grpc/CHANGELOG.md
+++ b/contrib/opencensus-ext-grpc/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.1.1
+Released 2019-04-08
+
+- Cosmetic changes
+
 ## 0.1.0
 Released 2019-03-19
 

--- a/contrib/opencensus-ext-grpc/setup.py
+++ b/contrib/opencensus-ext-grpc/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'grpcio >= 1.0.0, < 2.0.0',
-        'opencensus >= 0.4.dev0, < 1.0.0',
+        'opencensus >= 0.5.dev0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-httplib/CHANGELOG.md
+++ b/contrib/opencensus-ext-httplib/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.1.1
+Released 2019-04-08
+
+- Cosmetic changes
+
 ## 0.1.0
 Released 2019-03-19
 

--- a/contrib/opencensus-ext-httplib/setup.py
+++ b/contrib/opencensus-ext-httplib/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.4.dev0, < 1.0.0',
+        'opencensus >= 0.5.dev0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-jaeger/CHANGELOG.md
+++ b/contrib/opencensus-ext-jaeger/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.2.0
+Released 2019-04-08
+
+- Update for package changes in core library
+
 ## 0.1.0
 Released 2019-03-19
 

--- a/contrib/opencensus-ext-jaeger/setup.py
+++ b/contrib/opencensus-ext-jaeger/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.4.dev0, < 1.0.0',
+        'opencensus >= 0.5.dev0, < 1.0.0',
         'thrift >= 0.10.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-jaeger/version.py
+++ b/contrib/opencensus-ext-jaeger/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.dev0'
+__version__ = '0.3.dev0'

--- a/contrib/opencensus-ext-mysql/CHANGELOG.md
+++ b/contrib/opencensus-ext-mysql/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.1.1
+Released 2019-04-08
+
+- Cosmetic changes
+
 ## 0.1.0
 Released 2019-03-19
 

--- a/contrib/opencensus-ext-mysql/setup.py
+++ b/contrib/opencensus-ext-mysql/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'mysql-connector >= 2.1.6, < 3.0.0',
-        'opencensus >= 0.4.dev0, < 1.0.0',
+        'opencensus >= 0.5.dev0, < 1.0.0',
         'opencensus-ext-dbapi >= 0.2.dev0, < 1.0.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-ocagent/CHANGELOG.md
+++ b/contrib/opencensus-ext-ocagent/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 0.2.0
+Released 2019-04-08
+
+- Update for package changes in core library
+- Update generated protos
+- Fix UTC timestamp reporting bug
+
 ## 0.1.0
 Released 2019-03-19
 

--- a/contrib/opencensus-ext-ocagent/setup.py
+++ b/contrib/opencensus-ext-ocagent/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'grpcio >= 1.0.0, < 2.0.0',
-        'opencensus >= 0.4.dev0, < 1.0.0',
+        'opencensus >= 0.5.dev0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-ocagent/version.py
+++ b/contrib/opencensus-ext-ocagent/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.dev0'
+__version__ = '0.3.dev0'

--- a/contrib/opencensus-ext-postgresql/CHANGELOG.md
+++ b/contrib/opencensus-ext-postgresql/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.1.1
+Released 2019-04-08
+
+- Cosmetic changes
+
 ## 0.1.0
 Released 2019-03-19
 

--- a/contrib/opencensus-ext-postgresql/setup.py
+++ b/contrib/opencensus-ext-postgresql/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.4.dev0, < 1.0.0',
+        'opencensus >= 0.5.dev0, < 1.0.0',
         'psycopg2-binary >= 2.7.3.1',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-prometheus/CHANGELOG.md
+++ b/contrib/opencensus-ext-prometheus/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.2.0
+Released 2019-04-08
+
+- Update for package changes in core library
+
 ## 0.1.0
 Released 2019-22-19
 

--- a/contrib/opencensus-ext-prometheus/setup.py
+++ b/contrib/opencensus-ext-prometheus/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.4.dev0, < 1.0.0',
+        'opencensus >= 0.5.dev0, < 1.0.0',
         'prometheus_client >= 0.5.0, < 1.0.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-prometheus/version.py
+++ b/contrib/opencensus-ext-prometheus/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.dev0'
+__version__ = '0.3.dev0'

--- a/contrib/opencensus-ext-pymongo/CHANGELOG.md
+++ b/contrib/opencensus-ext-pymongo/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.1.1
+Released 2019-04-08
+
+- Cosmetic changes
+
 ## 0.1.0
 Released 2019-03-19
 

--- a/contrib/opencensus-ext-pymongo/setup.py
+++ b/contrib/opencensus-ext-pymongo/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.4.dev0, < 1.0.0',
+        'opencensus >= 0.5.dev0, < 1.0.0',
         'pymongo >= 3.1.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-pymysql/CHANGELOG.md
+++ b/contrib/opencensus-ext-pymysql/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.1.1
+Released 2019-04-08
+
+- Cosmetic changes
+
 ## 0.1.0
 Released 2019-03-19
 

--- a/contrib/opencensus-ext-pymysql/setup.py
+++ b/contrib/opencensus-ext-pymysql/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'PyMySQL >= 0.7.11, < 1.0.0',
-        'opencensus >= 0.4.dev0, < 1.0.0',
+        'opencensus >= 0.5.dev0, < 1.0.0',
         'opencensus-ext-dbapi >= 0.2.dev0, < 1.0.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-pyramid/CHANGELOG.md
+++ b/contrib/opencensus-ext-pyramid/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.2.0
+Released 2019-04-08
+
+- Update for package changes in core library
+
 ## 0.1.0
 Released 2019-03-19
 

--- a/contrib/opencensus-ext-pyramid/setup.py
+++ b/contrib/opencensus-ext-pyramid/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'pyramid >= 1.9.1, < 2.0.0',
-        'opencensus >= 0.4.dev0, < 1.0.0',
+        'opencensus >= 0.5.dev0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-pyramid/version.py
+++ b/contrib/opencensus-ext-pyramid/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.dev0'
+__version__ = '0.3.dev0'

--- a/contrib/opencensus-ext-requests/CHANGELOG.md
+++ b/contrib/opencensus-ext-requests/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.1.1
+Released 2019-04-08
+
+- Cosmetic changes
+
 ## 0.1.0
 Released 2019-03-19
 

--- a/contrib/opencensus-ext-requests/setup.py
+++ b/contrib/opencensus-ext-requests/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.4.dev0, < 1.0.0',
+        'opencensus >= 0.5.dev0, < 1.0.0',
         'wrapt >= 1.0.0, < 2.0.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-sqlalchemy/CHANGELOG.md
+++ b/contrib/opencensus-ext-sqlalchemy/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.1.1
+Released 2019-04-08
+
+- Cosmetic changes
+
 ## 0.1.0
 Released 2019-03-19
 

--- a/contrib/opencensus-ext-sqlalchemy/setup.py
+++ b/contrib/opencensus-ext-sqlalchemy/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.4.dev0, < 1.0.0',
+        'opencensus >= 0.5.dev0, < 1.0.0',
         'SQLAlchemy >= 1.1.14, < 2.0.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-stackdriver/CHANGELOG.md
+++ b/contrib/opencensus-ext-stackdriver/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+## 0.2.0
+Released 2019-04-08
+
+- Update for package changes in core library
+- Export metrics periodically from background thread instead of at record time
+- Create metric descriptors lazily instead of on view registration
+- Change return type of `new_stats_exporter` to include exporter task
+  ([#593](https://github.com/census-instrumentation/opencensus-python/pull/593))
+
 ## 0.1.0
 Released 2019-03-19
 

--- a/contrib/opencensus-ext-stackdriver/setup.py
+++ b/contrib/opencensus-ext-stackdriver/setup.py
@@ -41,7 +41,7 @@ setup(
     install_requires=[
         'google-cloud-monitoring >= 0.30.0, < 1.0.0',
         'google-cloud-trace >= 0.20.0, < 1.0.0',
-        'opencensus >= 0.4.dev0, < 1.0.0',
+        'opencensus >= 0.5.dev0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-stackdriver/version.py
+++ b/contrib/opencensus-ext-stackdriver/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.dev0'
+__version__ = '0.3.dev0'

--- a/contrib/opencensus-ext-threading/CHANGELOG.md
+++ b/contrib/opencensus-ext-threading/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.1.1
+Released 2019-04-08
+
+- Cosmetic changes
+
 ## 0.1.0
 Released 2019-03-19
 

--- a/contrib/opencensus-ext-threading/setup.py
+++ b/contrib/opencensus-ext-threading/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.4.dev0, < 1.0.0',
+        'opencensus >= 0.5.dev0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-zipkin/CHANGELOG.md
+++ b/contrib/opencensus-ext-zipkin/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.2.0
+Released 2019-04-08
+
+- Update for package changes in core library
+
 ## 0.1.0
 Released 2019-03-19
 

--- a/contrib/opencensus-ext-zipkin/setup.py
+++ b/contrib/opencensus-ext-zipkin/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.4.dev0, < 1.0.0',
+        'opencensus >= 0.5.dev0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-zipkin/version.py
+++ b/contrib/opencensus-ext-zipkin/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.dev0'
+__version__ = '0.3.dev0'

--- a/opencensus/common/version/__init__.py
+++ b/opencensus/common/version/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.4.dev0'
+__version__ = '0.5.dev0'

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus-context == 0.1.dev0',
+        'opencensus-context == 0.2.dev0',
         'google-api-core >= 1.0.0, < 2.0.0',
     ],
     extras_require={},


### PR DESCRIPTION
This PR includes the version number updates from #604 applied to `master`.

All ext packages require the most recent dev version of `opencensus` (now `0.5.dev0`), even if the most recently released version of the ext package can use an older `opencensus` version. For example, `opencensus-ext-mysql` depends on `opencensus>=0.5.dev0` on this branch even though the released version (i.e. the version on the `v0.4.x` branch) only depends on `opencensus>=0.3.dev0`.

This makes development easy, but means we have to manually set the minimum required `opencensus` version for each ext package on each release instead of just removing "dev" from the required version.

See #555 for a similar set of updates for the `0.3.0` release.