### PR TITLE
Allow empty `MetricDescriptor.label_keys`

### DIFF
--- a/opencensus/metrics/export/metric_descriptor.py
+++ b/opencensus/metrics/export/metric_descriptor.py
@@ -130,8 +130,8 @@ class MetricDescriptor(object):
         if type_ not in MetricDescriptorType:
             raise ValueError("Invalid type")
 
-        if not label_keys:
-            raise ValueError("label_keys must not be empty or null")
+        if label_keys is None:
+            raise ValueError("label_keys must not be None")
 
         if any(key is None for key in label_keys):
             raise ValueError("label_keys must not contain null keys")

--- a/tests/unit/metrics/export/test_metric_descriptor.py
+++ b/tests/unit/metrics/export/test_metric_descriptor.py
@@ -53,6 +53,11 @@ class TestMetricDescriptor(unittest.TestCase):
                 NAME, DESCRIPTION, UNIT,
                 metric_descriptor.MetricDescriptorType.GAUGE_DOUBLE, None)
 
+    def test_empty_label_keys(self):
+        metric_descriptor.MetricDescriptor(
+            NAME, DESCRIPTION, UNIT,
+            metric_descriptor.MetricDescriptorType.GAUGE_DOUBLE, [])
+
     def test_null_label_key_values(self):
         with self.assertRaises(ValueError):
             metric_descriptor.MetricDescriptor(


### PR DESCRIPTION
so metrics without tags can be used. A `View`'s columns are used as the
`MetricDescriptor`'s `label_keys`, and the
[docs](https://opencensus.io/stats/view/) say that they're optional.

This change preserves the behavior when the `label_keys` are `None`, or if
any values are `None`.

This matches the behavior of the [Java
API](https://github.com/census-instrumentation/opencensus-java/blob/08d09c48a40b7dc6b5dba8603795084fc6ea9695/api/src/main/java/io/opencensus/metrics/export/MetricDescriptor.java#L53-L54).

