### PR TITLE
Allow for empty label values

### DIFF
--- a/opencensus/metrics/export/time_series.py
+++ b/opencensus/metrics/export/time_series.py
@@ -38,8 +38,8 @@ class TimeSeries(object):
     """  # noqa
 
     def __init__(self, label_values, points, start_timestamp):
-        if not label_values:
-            raise ValueError("label_values must not be null or empty")
+        if label_values is None:
+            raise ValueError("label_values must not be None")
         if not points:
             raise ValueError("points must not be null or empty")
         self._label_values = label_values

--- a/tests/unit/metrics/export/test_time_series.py
+++ b/tests/unit/metrics/export/test_time_series.py
@@ -50,8 +50,6 @@ class TestTimeSeries(unittest.TestCase):
         with self.assertRaises(ValueError):
             time_series.TimeSeries(None, POINTS, START_TIMESTAMP)
         with self.assertRaises(ValueError):
-            time_series.TimeSeries([], POINTS, START_TIMESTAMP)
-        with self.assertRaises(ValueError):
             time_series.TimeSeries(LABEL_VALUES, None, START_TIMESTAMP)
         with self.assertRaises(ValueError):
             time_series.TimeSeries(LABEL_VALUES, [], START_TIMESTAMP)


### PR DESCRIPTION
Following up on #611, this PR allows `TimeSeries` objs to have empty label values. #611 allowed for metric descriptors to be created for views without tag keys (i.e. columns), but converting view data to metrics would still fail for such views.