### PR TITLE
v0.4.1 and stackdriver v0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## Unreleased
 
 ## 0.4.0
+Released 2019-04-11
+
+- Allow for metrics with empty label keys and values
+  ([#611](https://github.com/census-instrumentation/opencensus-python/pull/611))
+  ([#614](https://github.com/census-instrumentation/opencensus-python/pull/614))
+
+## 0.4.0
 Released 2019-04-08
 
 - Multiple bugfixes

--- a/contrib/opencensus-ext-stackdriver/CHANGELOG.md
+++ b/contrib/opencensus-ext-stackdriver/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Unreleased
 
 ## 0.2.0
+Released 2019-04-11
+- Don't require exporter options, fall back to default GCP auth
+  ([#610](https://github.com/census-instrumentation/opencensus-python/pull/610))
+
+## 0.2.0
 Released 2019-04-08
 
 - Update for package changes in core library

--- a/contrib/opencensus-ext-stackdriver/version.py
+++ b/contrib/opencensus-ext-stackdriver/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'

--- a/opencensus/common/version/__init__.py
+++ b/opencensus/common/version/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.4.0'
+__version__ = '0.4.1'

--- a/opencensus/metrics/export/metric_descriptor.py
+++ b/opencensus/metrics/export/metric_descriptor.py
@@ -130,8 +130,8 @@ class MetricDescriptor(object):
         if type_ not in MetricDescriptorType:
             raise ValueError("Invalid type")
 
-        if not label_keys:
-            raise ValueError("label_keys must not be empty or null")
+        if label_keys is None:
+            raise ValueError("label_keys must not be None")
 
         if any(key is None for key in label_keys):
             raise ValueError("label_keys must not contain null keys")

--- a/opencensus/metrics/export/time_series.py
+++ b/opencensus/metrics/export/time_series.py
@@ -38,8 +38,8 @@ class TimeSeries(object):
     """  # noqa
 
     def __init__(self, label_values, points, start_timestamp):
-        if not label_values:
-            raise ValueError("label_values must not be null or empty")
+        if label_values is None:
+            raise ValueError("label_values must not be None")
         if not points:
             raise ValueError("points must not be null or empty")
         self._label_values = label_values

--- a/opencensus/trace/propagation/b3_format.py
+++ b/opencensus/trace/propagation/b3_format.py
@@ -62,10 +62,10 @@ class B3FormatPropagator(object):
             sampled = headers.get(_SAMPLED_KEY)
 
         if sampled is not None:
-            if len(sampled) != 1:
-                return SpanContext(from_header=False)
-
-            sampled = sampled in ('1', 'd')
+            # The specification encodes an enabled tracing decision as "1".
+            # In the wild pre-standard implementations might still send "true".
+            # "d" is set in the single header case when debugging is enabled.
+            sampled = sampled.lower() in ('1', 'd', 'true')
         else:
             # If there's no incoming sampling decision, it was deferred to us.
             # Even though we set it to False here, we might still sample

--- a/tests/unit/metrics/export/test_metric_descriptor.py
+++ b/tests/unit/metrics/export/test_metric_descriptor.py
@@ -53,6 +53,11 @@ class TestMetricDescriptor(unittest.TestCase):
                 NAME, DESCRIPTION, UNIT,
                 metric_descriptor.MetricDescriptorType.GAUGE_DOUBLE, None)
 
+    def test_empty_label_keys(self):
+        metric_descriptor.MetricDescriptor(
+            NAME, DESCRIPTION, UNIT,
+            metric_descriptor.MetricDescriptorType.GAUGE_DOUBLE, [])
+
     def test_null_label_key_values(self):
         with self.assertRaises(ValueError):
             metric_descriptor.MetricDescriptor(

--- a/tests/unit/metrics/export/test_time_series.py
+++ b/tests/unit/metrics/export/test_time_series.py
@@ -50,8 +50,6 @@ class TestTimeSeries(unittest.TestCase):
         with self.assertRaises(ValueError):
             time_series.TimeSeries(None, POINTS, START_TIMESTAMP)
         with self.assertRaises(ValueError):
-            time_series.TimeSeries([], POINTS, START_TIMESTAMP)
-        with self.assertRaises(ValueError):
             time_series.TimeSeries(LABEL_VALUES, None, START_TIMESTAMP)
         with self.assertRaises(ValueError):
             time_series.TimeSeries(LABEL_VALUES, [], START_TIMESTAMP)

--- a/tests/unit/trace/propagation/test_b3_format.py
+++ b/tests/unit/trace/propagation/test_b3_format.py
@@ -30,23 +30,44 @@ class TestB3FormatPropagator(unittest.TestCase):
     def test_from_headers_keys_exist(self):
         test_trace_id = '6e0c63257de34c92bf9efcd03927272e'
         test_span_id = '00f067aa0ba902b7'
-        test_sampled = '1'
 
-        headers = {
-            b3_format._TRACE_ID_KEY: test_trace_id,
-            b3_format._SPAN_ID_KEY: test_span_id,
-            b3_format._SAMPLED_KEY: test_sampled,
-        }
+        for test_sampled in ['1', 'True', 'true', 'd']:
+            headers = {
+                b3_format._TRACE_ID_KEY: test_trace_id,
+                b3_format._SPAN_ID_KEY: test_span_id,
+                b3_format._SAMPLED_KEY: test_sampled,
+            }
 
-        propagator = b3_format.B3FormatPropagator()
-        span_context = propagator.from_headers(headers)
+            propagator = b3_format.B3FormatPropagator()
+            span_context = propagator.from_headers(headers)
 
-        self.assertEqual(span_context.trace_id, test_trace_id)
-        self.assertEqual(span_context.span_id, test_span_id)
-        self.assertEqual(
-            span_context.trace_options.enabled,
-            bool(test_sampled)
-        )
+            self.assertEqual(span_context.trace_id, test_trace_id)
+            self.assertEqual(span_context.span_id, test_span_id)
+            self.assertEqual(
+                span_context.trace_options.enabled,
+                True
+            )
+
+    def test_from_headers_keys_exist_disabled_sampling(self):
+        test_trace_id = '6e0c63257de34c92bf9efcd03927272e'
+        test_span_id = '00f067aa0ba902b7'
+
+        for test_sampled in ['0', 'False', 'false', None]:
+            headers = {
+                b3_format._TRACE_ID_KEY: test_trace_id,
+                b3_format._SPAN_ID_KEY: test_span_id,
+                b3_format._SAMPLED_KEY: test_sampled,
+            }
+
+            propagator = b3_format.B3FormatPropagator()
+            span_context = propagator.from_headers(headers)
+
+            self.assertEqual(span_context.trace_id, test_trace_id)
+            self.assertEqual(span_context.span_id, test_span_id)
+            self.assertEqual(
+                span_context.trace_options.enabled,
+                False
+            )
 
     def test_from_headers_keys_not_exist(self):
         propagator = b3_format.B3FormatPropagator()


### PR DESCRIPTION
Micro version releases: `opencensus` `0.4.1` and `opencensus-ext-stackdriver` `0.2.1`.

The motivating reason for the release is the fix for metrics without label keys/values in #611 and #614. There were few enough changes (and none of them breaking) on master that this includes everything since the last release.