### PR TITLE
Change algorithm for span ID generation

### DIFF
--- a/opencensus/trace/span_context.py
+++ b/opencensus/trace/span_context.py
@@ -17,7 +17,8 @@
 import logging
 import re
 import six
-import uuid
+import random
+import time
 
 from opencensus.trace import trace_options as trace_options_module
 
@@ -156,8 +157,7 @@ def generate_span_id():
     :rtype: str
     :returns: 16 digit randomly generated hex trace id.
     """
-    span_id = uuid.uuid4().hex[:16]
-    return span_id
+    return '{:016x}'.format(random.getrandbits(64))
 
 
 def generate_trace_id():
@@ -167,5 +167,6 @@ def generate_trace_id():
     :rtype: str
     :returns: 32 digit randomly generated hex trace id.
     """
-    trace_id = uuid.uuid4().hex
-    return trace_id
+    t = int(time.time())
+    lower_96 = random.getrandbits(96)
+    return '{:032x}'.format((t << 96) | lower_96)


### PR DESCRIPTION
The span ID is currently generated using `uuid` which calls `/dev/urandom`. This is slow and can cause problems under load. Generating using non-cryptographic random is ~10x faster:

```console
python -m timeit "import uuid; uuid.uuid4().hex[:16]"
50000 loops, best of 5: 4.54 usec per loop
```

```console
> python -m timeit "import random; '{:016x}'.format(random.getrandbits(64))"
500000 loops, best of 5: 657 nsec per loop
```

The code used here to generate the ID is from [Zipkin's Python library](https://github.com/Yelp/py_zipkin/blob/master/py_zipkin/util.py#L7). It meets the standard as defined under the [OpenCensus specification](https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/Span.md#traceid).