### PR TITLE
Decouple exporters from Flask integration

### DIFF
--- a/contrib/opencensus-ext-azure/examples/custom.py
+++ b/contrib/opencensus-ext-azure/examples/custom.py
@@ -19,13 +19,15 @@ app = Flask(__name__)
 # TODO:
 # Replace 00000000-0000-0000-0000-000000000000 with your Instrumentation Key
 # https://docs.microsoft.com/en-us/azure/azure-monitor/app/create-new-resource
-app.config['OPENCENSUS_TRACE'] = {
-    'SAMPLER': 'opencensus.trace.samplers.ProbabilitySampler(rate=1)',
-    'EXPORTER': '''opencensus.ext.azure.trace_exporter.AzureExporter(
-        opencensus.ext.azure.common.Options(
-            instrumentation_key="00000000-0000-0000-0000-000000000000",
-            timeout=29.9,
-        ))''',
+app.config['OPENCENSUS'] = {
+    'TRACE': {
+        'SAMPLER': 'opencensus.trace.samplers.ProbabilitySampler(rate=1)',
+        'EXPORTER': '''opencensus.ext.azure.trace_exporter.AzureExporter(
+            opencensus.ext.azure.common.Options(
+                instrumentation_key="00000000-0000-0000-0000-000000000000",
+                timeout=29.9,
+            ))''',
+    },
 }
 middleware = FlaskMiddleware(app)
 

--- a/contrib/opencensus-ext-azure/examples/custom.py
+++ b/contrib/opencensus-ext-azure/examples/custom.py
@@ -1,0 +1,42 @@
+# Copyright 2019, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from flask import Flask
+from opencensus.ext.flask.flask_middleware import FlaskMiddleware
+
+app = Flask(__name__)
+# TODO:
+# Replace 00000000-0000-0000-0000-000000000000 with your Instrumentation Key
+# https://docs.microsoft.com/en-us/azure/azure-monitor/app/create-new-resource
+app.config['OPENCENSUS_TRACE'] = {
+    'SAMPLER': 'opencensus.trace.samplers.ProbabilitySampler(rate=1)',
+    'EXPORTER': '''opencensus.ext.azure.trace_exporter.AzureExporter(
+        opencensus.ext.azure.common.Options(
+            instrumentation_key="00000000-0000-0000-0000-000000000000",
+            timeout=29.9,
+        ))''',
+}
+middleware = FlaskMiddleware(app)
+
+
+@app.route('/')
+def hello():
+    return 'Hello World!'
+
+
+if __name__ == '__main__':
+    import logging
+    logger = logging.getLogger('werkzeug')
+    logger.setLevel(logging.ERROR)
+    app.run(host='localhost', port=8080, threaded=True)

--- a/contrib/opencensus-ext-azure/examples/server.py
+++ b/contrib/opencensus-ext-azure/examples/server.py
@@ -18,15 +18,9 @@ import requests
 from opencensus.trace import config_integration
 from opencensus.ext.azure.trace_exporter import AzureExporter
 from opencensus.ext.flask.flask_middleware import FlaskMiddleware
-from opencensus.trace.propagation.trace_context_http_header_format \
-    import TraceContextPropagator
 
 app = Flask(__name__)
-middleware = FlaskMiddleware(
-    app,
-    exporter=AzureExporter(),
-    propagator=TraceContextPropagator(),
-)
+middleware = FlaskMiddleware(app, exporter=AzureExporter())
 
 
 @app.route('/')

--- a/contrib/opencensus-ext-flask/CHANGELOG.md
+++ b/contrib/opencensus-ext-flask/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Decoupled exporter specific logic from configuration
 
 ## 0.2.0
 Released 2019-04-08

--- a/contrib/opencensus-ext-flask/README.rst
+++ b/contrib/opencensus-ext-flask/README.rst
@@ -37,6 +37,7 @@ Usage
 Additional configuration can be provided:
 
 .. code:: python
+
     app.config['OPENCENSUS_TRACE'] = {
         'SAMPLER': 'opencensus.trace.samplers.ProbabilitySampler(rate=1)',
         'EXPORTER': '''opencensus.ext.ocagent.trace_exporter.TraceExporter(
@@ -44,4 +45,4 @@ Additional configuration can be provided:
         )''',
     }
 
-For a complete reference, please read `Link Customization https://github.com/census-instrumentation/opencensus-python#customization`_
+For a complete reference, please read `Link Customization <https://github.com/census-instrumentation/opencensus-python#customization>`_

--- a/contrib/opencensus-ext-flask/README.rst
+++ b/contrib/opencensus-ext-flask/README.rst
@@ -40,9 +40,11 @@ for a complete reference.
 
 .. code:: python
 
-    app.config['OPENCENSUS_TRACE'] = {
-        'SAMPLER': 'opencensus.trace.samplers.ProbabilitySampler(rate=1)',
-        'EXPORTER': '''opencensus.ext.ocagent.trace_exporter.TraceExporter(
-            service_name='foobar',
-        )''',
+    app.config['OPENCENSUS'] = {
+        'TRACE': {
+            'SAMPLER': 'opencensus.trace.samplers.ProbabilitySampler(rate=1)',
+            'EXPORTER': '''opencensus.ext.ocagent.trace_exporter.TraceExporter(
+                service_name='foobar',
+            )''',
+        }
     }

--- a/contrib/opencensus-ext-flask/README.rst
+++ b/contrib/opencensus-ext-flask/README.rst
@@ -34,7 +34,9 @@ Usage
         logger.setLevel(logging.ERROR)
         app.run(host='localhost', port=8080, threaded=True)
 
-Additional configuration can be provided:
+Additional configuration can be provided, please read
+`Customization <https://github.com/census-instrumentation/opencensus-python#customization>`_
+for a complete reference.
 
 .. code:: python
 
@@ -44,5 +46,3 @@ Additional configuration can be provided:
             service_name='foobar',
         )''',
     }
-
-For a complete reference, please read `Link Customization <https://github.com/census-instrumentation/opencensus-python#customization>`_

--- a/contrib/opencensus-ext-flask/README.rst
+++ b/contrib/opencensus-ext-flask/README.rst
@@ -35,6 +35,7 @@ Usage
         app.run(host='localhost', port=8080, threaded=True)
 
 Additional configuration can be provided:
+
 .. code:: python
     app.config['OPENCENSUS_TRACE'] = {
         'SAMPLER': 'opencensus.trace.samplers.ProbabilitySampler(rate=1)',
@@ -43,6 +44,4 @@ Additional configuration can be provided:
         )''',
     }
 
-For a complete reference, please read `Link Customization
- https://github.com/census-instrumentation/opencensus-python#customization`_
- 
+For a complete reference, please read `Link Customization https://github.com/census-instrumentation/opencensus-python#customization`_

--- a/contrib/opencensus-ext-flask/README.rst
+++ b/contrib/opencensus-ext-flask/README.rst
@@ -20,10 +20,9 @@ Usage
 
     from flask import Flask
     from opencensus.ext.flask.flask_middleware import FlaskMiddleware
-    from opencensus.trace.propagation.trace_context_http_header_format import TraceContextPropagator
     
     app = Flask(__name__)
-    middleware = FlaskMiddleware(app, propagator=TraceContextPropagator(), blacklist_paths=['_ah/health'])
+    middleware = FlaskMiddleware(app, blacklist_paths=['_ah/health'])
     
     @app.route('/')
     def hello():
@@ -34,3 +33,15 @@ Usage
         logger = logging.getLogger('werkzeug')
         logger.setLevel(logging.ERROR)
         app.run(host='localhost', port=8080, threaded=True)
+
+Additional configuration can be provided:
+.. code:: python
+    app.config['OPENCENSUS_TRACE'] = {
+        'SAMPLER': 'opencensus.trace.samplers.ProbabilitySampler(rate=1)',
+        'EXPORTER': '''opencensus.ext.ocagent.trace_exporter.TraceExporter(
+            service_name='foobar',
+        )''',
+    }
+
+For a complete reference, please read `Link Customization
+ https://github.com/census-instrumentation/opencensus-python#customization`_

--- a/contrib/opencensus-ext-flask/README.rst
+++ b/contrib/opencensus-ext-flask/README.rst
@@ -45,3 +45,4 @@ Additional configuration can be provided:
 
 For a complete reference, please read `Link Customization
  https://github.com/census-instrumentation/opencensus-python#customization`_
+ 

--- a/contrib/opencensus-ext-flask/examples/simple.py
+++ b/contrib/opencensus-ext-flask/examples/simple.py
@@ -14,11 +14,9 @@
 
 from flask import Flask
 from opencensus.ext.flask.flask_middleware import FlaskMiddleware
-from opencensus.trace.propagation.trace_context_http_header_format \
-    import TraceContextPropagator
 
 app = Flask(__name__)
-middleware = FlaskMiddleware(app, propagator=TraceContextPropagator())
+middleware = FlaskMiddleware(app)
 
 
 @app.route('/')

--- a/contrib/opencensus-ext-flask/opencensus/ext/flask/flask_middleware.py
+++ b/contrib/opencensus-ext-flask/opencensus/ext/flask/flask_middleware.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import six
 import sys
 
 import flask
@@ -50,20 +51,20 @@ class FlaskMiddleware(object):
     :param blacklist_paths: Paths that do not trace.
 
     :type sampler: :class:`~opencensus.trace.samplers.base.Sampler`
-    :param sampler: Instance of sampler objects. It should extend
-                    from the base :class:`.Sampler` type and implement
+    :param sampler: A sampler. It should extend from the base
+                    :class:`.Sampler` type and implement
                     :meth:`.Sampler.should_sample`. Defaults to
                     :class:`.AlwaysOnSampler`. The rest options are
                     :class:`.AlwaysOffSampler`, :class:`.FixedRateSampler`.
 
     :type exporter: :class:`~opencensus.trace.base_exporter.exporter`
-    :param exporter: Instance of exporter objects. Default to
+    :param exporter: An exporter. Default to
                      :class:`.PrintExporter`. The rest options are
                      :class:`.FileExporter`, :class:`.LoggingExporter` and
                      trace exporter extensions.
 
     :type propagator: :class: 'object'
-    :param propagator: Instance of propagator objects. Default to
+    :param propagator: A propagator. Default to
                        :class:`.TraceContextPropagator`. The rest options
                        are :class:`.BinaryFormatPropagator`,
                        :class:`.GoogleCloudFormatPropagator` and
@@ -85,24 +86,25 @@ class FlaskMiddleware(object):
         self.app = app
 
         # get settings from app config
-        settings = self.app.config.get('OPENCENSUS_TRACE', {})
+        settings = self.app.config.get('OPENCENSUS', {})
+        settings = settings.get('TRACE', {})
 
         if self.sampler is None:
             self.sampler = settings.get('SAMPLER', None) or \
                 always_on.AlwaysOnSampler()
-            if isinstance(self.sampler, str):
+            if isinstance(self.sampler, six.string_types):
                 self.sampler = configuration.load(self.sampler)
 
         if self.exporter is None:
             self.exporter = settings.get('EXPORTER', None) or \
                 print_exporter.PrintExporter()
-            if isinstance(self.exporter, str):
+            if isinstance(self.exporter, six.string_types):
                 self.exporter = configuration.load(self.exporter)
 
         if self.propagator is None:
             self.propagator = settings.get('PROPAGATOR', None) or \
                 trace_context_http_header_format.TraceContextPropagator()
-            if isinstance(self.propagator, str):
+            if isinstance(self.propagator, six.string_types):
                 self.propagator = configuration.load(self.propagator)
 
         self.blacklist_paths = settings.get(BLACKLIST_PATHS,

--- a/contrib/opencensus-ext-flask/opencensus/ext/flask/flask_middleware.py
+++ b/contrib/opencensus-ext-flask/opencensus/ext/flask/flask_middleware.py
@@ -12,14 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import inspect
 import logging
 import sys
 
 import flask
 from google.rpc import code_pb2
 
-from opencensus.common.transports import sync
+from opencensus.common import configuration
 from opencensus.trace import attributes_helper
 from opencensus.trace import execution_context
 from opencensus.trace import print_exporter
@@ -28,38 +27,20 @@ from opencensus.trace import stack_trace
 from opencensus.trace import status
 from opencensus.trace import tracer as tracer_module
 from opencensus.trace import utils
-from opencensus.trace.propagation import google_cloud_format
-from opencensus.trace.samplers import always_on, probability
+from opencensus.trace.propagation import trace_context_http_header_format
+from opencensus.trace.samplers import always_on
 
 HTTP_METHOD = attributes_helper.COMMON_ATTRIBUTES['HTTP_METHOD']
 HTTP_URL = attributes_helper.COMMON_ATTRIBUTES['HTTP_URL']
 HTTP_STATUS_CODE = attributes_helper.COMMON_ATTRIBUTES['HTTP_STATUS_CODE']
 
 BLACKLIST_PATHS = 'BLACKLIST_PATHS'
-GCP_EXPORTER_PROJECT = 'GCP_EXPORTER_PROJECT'
-SAMPLING_RATE = 'SAMPLING_RATE'
-TRANSPORT = 'TRANSPORT'
-SERVICE_NAME = 'SERVICE_NAME'
-ZIPKIN_EXPORTER_SERVICE_NAME = 'ZIPKIN_EXPORTER_SERVICE_NAME'
-ZIPKIN_EXPORTER_HOST_NAME = 'ZIPKIN_EXPORTER_HOST_NAME'
-ZIPKIN_EXPORTER_PORT = 'ZIPKIN_EXPORTER_PORT'
-ZIPKIN_EXPORTER_PROTOCOL = 'ZIPKIN_EXPORTER_PROTOCOL'
-JAEGER_EXPORTER_HOST_NAME = 'JAEGER_EXPORTER_HOST_NAME'
-JAEGER_EXPORTER_PORT = 'JAEGER_EXPORTER_PORT'
-JAEGER_EXPORTER_AGENT_HOST_NAME = 'JAEGER_EXPORTER_AGENT_HOST_NAME'
-JAEGER_EXPORTER_AGENT_PORT = 'JAEGER_EXPORTER_AGENT_PORT'
-JAEGER_EXPORTER_SERVICE_NAME = 'JAEGER_EXPORTER_SERVICE_NAME'
-OCAGENT_TRACE_EXPORTER_ENDPOINT = 'OCAGENT_TRACE_EXPORTER_ENDPOINT'
 BLACKLIST_HOSTNAMES = 'BLACKLIST_HOSTNAMES'
 
 log = logging.getLogger(__name__)
 
 
 class FlaskMiddleware(object):
-    DEFAULT_SAMPLER = always_on.AlwaysOnSampler
-    DEFAULT_EXPORTER = print_exporter.PrintExporter
-    DEFAULT_PROPAGATOR = google_cloud_format.GoogleCloudFormatPropagator
-
     """Flask middleware to automatically trace requests.
 
     :type app: :class: `~flask.Flask`
@@ -68,24 +49,25 @@ class FlaskMiddleware(object):
     :type blacklist_paths: list
     :param blacklist_paths: Paths that do not trace.
 
-    :type sampler: :class: `type`
-    :param sampler: Class for creating new Sampler objects. It should extend
+    :type sampler: :class:`~opencensus.trace.samplers.base.Sampler`
+    :param sampler: Instance of sampler objects. It should extend
                     from the base :class:`.Sampler` type and implement
                     :meth:`.Sampler.should_sample`. Defaults to
                     :class:`.AlwaysOnSampler`. The rest options are
                     :class:`.AlwaysOffSampler`, :class:`.FixedRateSampler`.
 
-    :type exporter: :class: `type`
-    :param exporter: Class for creating new exporter objects. Default to
-                     :class:`.PrintExporter`. The rest option is
-                     :class:`.FileExporter`.
+    :type exporter: :class:`~opencensus.trace.base_exporter.exporter`
+    :param exporter: Instance of exporter objects. Default to
+                     :class:`.PrintExporter`. The rest options are
+                     :class:`.FileExporter`, :class:`.LoggingExporter` and
+                     trace exporter extensions.
 
-    :type propagator: :class: 'type'
-    :param propagator: Class for creating new propagator objects. Default to
-                       :class:`.GoogleCloudFormatPropagator`. The rest option
+    :type propagator: :class: 'object'
+    :param propagator: Instance of propagator objects. Default to
+                       :class:`.TraceContextPropagator`. The rest options
                        are :class:`.BinaryFormatPropagator`,
-                       :class:`.TextFormatPropagator` and
-                       :class:`.TraceContextPropagator`.
+                       :class:`.GoogleCloudFormatPropagator` and
+                       :class:`.TextFormatPropagator`.
     """
 
     def __init__(self, app=None, blacklist_paths=None, sampler=None,
@@ -105,90 +87,28 @@ class FlaskMiddleware(object):
         # get settings from app config
         settings = self.app.config.get('OPENCENSUS_TRACE', {})
 
-        self.sampler = (self.sampler
-                        or settings.get('SAMPLER',
-                                        self.DEFAULT_SAMPLER))
-        self.exporter = (self.exporter
-                         or settings.get('EXPORTER',
-                                         self.DEFAULT_EXPORTER))
-        self.propagator = (self.propagator
-                           or settings.get('PROPAGATOR',
-                                           self.DEFAULT_PROPAGATOR))
+        if self.sampler is None:
+            self.sampler = settings.get('SAMPLER', None) or \
+                always_on.AlwaysOnSampler()
+            if isinstance(self.sampler, str):
+                self.sampler = configuration.load(self.sampler)
 
-        # get params from app config
-        params = self.app.config.get('OPENCENSUS_TRACE_PARAMS', {})
+        if self.exporter is None:
+            self.exporter = settings.get('EXPORTER', None) or \
+                print_exporter.PrintExporter()
+            if isinstance(self.exporter, str):
+                self.exporter = configuration.load(self.exporter)
 
-        self.blacklist_paths = params.get(BLACKLIST_PATHS,
-                                          self.blacklist_paths)
+        if self.propagator is None:
+            self.propagator = settings.get('PROPAGATOR', None) or \
+                trace_context_http_header_format.TraceContextPropagator()
+            if isinstance(self.propagator, str):
+                self.propagator = configuration.load(self.propagator)
 
-        # Initialize the sampler
-        if not inspect.isclass(self.sampler):
-            pass  # handling of instantiated sampler
-        elif self.sampler.__name__ == 'ProbabilitySampler':
-            _rate = params.get(SAMPLING_RATE,
-                               probability.DEFAULT_SAMPLING_RATE)
-            self.sampler = self.sampler(_rate)
-        else:
-            self.sampler = self.sampler()
+        self.blacklist_paths = settings.get(BLACKLIST_PATHS,
+                                            self.blacklist_paths)
 
-        transport = params.get(TRANSPORT, sync.SyncTransport)
-
-        # Initialize the exporter
-        if not inspect.isclass(self.exporter):
-            pass  # handling of instantiated exporter
-        elif self.exporter.__name__ == 'StackdriverExporter':
-            _project_id = params.get(GCP_EXPORTER_PROJECT, None)
-            self.exporter = self.exporter(
-                project_id=_project_id,
-                transport=transport)
-        elif self.exporter.__name__ == 'JaegerExporter':
-            _service_name = params.get(
-                JAEGER_EXPORTER_SERVICE_NAME,
-                self._get_service_name(params))
-            _jaeger_host_name = params.get(
-                JAEGER_EXPORTER_HOST_NAME, None)
-            _jaeger_port = params.get(
-                JAEGER_EXPORTER_PORT, None)
-            _jaeger_agent_host_name = params.get(
-                JAEGER_EXPORTER_AGENT_HOST_NAME, 'localhost')
-            _jaeger_agent_port = params.get(
-                JAEGER_EXPORTER_AGENT_PORT, 6831)
-            self.exporter = self.exporter(
-                service_name=_service_name,
-                host_name=_jaeger_host_name,
-                port=_jaeger_port,
-                agent_host_name=_jaeger_agent_host_name,
-                agent_port=_jaeger_agent_port,
-                transport=transport)
-        elif self.exporter.__name__ == 'ZipkinExporter':
-            _service_name = self._get_service_name(params)
-            _zipkin_host_name = params.get(
-                ZIPKIN_EXPORTER_HOST_NAME, 'localhost')
-            _zipkin_port = params.get(
-                ZIPKIN_EXPORTER_PORT, 9411)
-            _zipkin_protocol = params.get(
-                ZIPKIN_EXPORTER_PROTOCOL, 'http')
-            self.exporter = self.exporter(
-                service_name=_service_name,
-                host_name=_zipkin_host_name,
-                port=_zipkin_port,
-                protocol=_zipkin_protocol,
-                transport=transport)
-        elif self.exporter.__name__ == 'TraceExporter':
-            _service_name = self._get_service_name(params)
-            _endpoint = params.get(
-                OCAGENT_TRACE_EXPORTER_ENDPOINT, None)
-            self.exporter = self.exporter(
-                service_name=_service_name,
-                endpoint=_endpoint,
-                transport=transport)
-        else:
-            self.exporter = self.exporter(transport=transport)
-
-        self.blacklist_hostnames = params.get(BLACKLIST_HOSTNAMES, None)
-        # Initialize the propagator
-        if inspect.isclass(self.propagator):
-            self.propagator = self.propagator()
+        self.blacklist_hostnames = settings.get(BLACKLIST_HOSTNAMES, None)
 
         self.setup_trace()
 
@@ -280,13 +200,3 @@ class FlaskMiddleware(object):
             tracer.finish()
         except Exception:  # pragma: NO COVER
             log.error('Failed to trace request', exc_info=True)
-
-    def _get_service_name(self, params):
-        _service_name = params.get(
-            SERVICE_NAME, None)
-
-        if _service_name is None:
-            _service_name = params.get(
-                ZIPKIN_EXPORTER_SERVICE_NAME, 'my_service')
-
-        return _service_name

--- a/contrib/opencensus-ext-flask/tests/test_flask_middleware.py
+++ b/contrib/opencensus-ext-flask/tests/test_flask_middleware.py
@@ -22,10 +22,6 @@ import flask
 import mock
 
 from opencensus.ext.flask import flask_middleware
-from opencensus.ext.jaeger import trace_exporter as jaeger_exporter
-from opencensus.ext.ocagent import trace_exporter as ocagent_exporter
-from opencensus.ext.stackdriver import trace_exporter as stackdriver_exporter
-from opencensus.ext.zipkin import trace_exporter as zipkin_exporter
 from opencensus.trace import execution_context
 from opencensus.trace import print_exporter
 from opencensus.trace import span as span_module
@@ -33,8 +29,8 @@ from opencensus.trace import span_data
 from opencensus.trace import stack_trace
 from opencensus.trace import status
 from opencensus.trace.blank_span import BlankSpan
-from opencensus.trace.propagation import google_cloud_format
-from opencensus.trace.samplers import always_off, always_on, ProbabilitySampler
+from opencensus.trace.propagation import trace_context_http_header_format
+from opencensus.trace.samplers import always_off, always_on
 from opencensus.trace.span_context import SpanContext
 from opencensus.trace.trace_options import TraceOptions
 from opencensus.trace.tracers import base
@@ -81,7 +77,7 @@ class TestFlaskMiddleware(unittest.TestCase):
         assert isinstance(middleware.exporter, print_exporter.PrintExporter)
         assert isinstance(
             middleware.propagator,
-            google_cloud_format.GoogleCloudFormatPropagator)
+            trace_context_http_header_format.TraceContextPropagator)
 
     def test_constructor_explicit(self):
         app = mock.Mock(config={})
@@ -102,6 +98,24 @@ class TestFlaskMiddleware(unittest.TestCase):
         self.assertTrue(app.before_request.called)
         self.assertTrue(app.after_request.called)
 
+    def test_init_app_config(self):
+        app = mock.Mock()
+        app.config = {
+            'OPENCENSUS_TRACE': {
+                'SAMPLER': 'opencensus.trace.samplers.ProbabilitySampler()',
+                'EXPORTER': 'opencensus.trace.print_exporter.PrintExporter()',
+            }
+        }
+
+        middleware = flask_middleware.FlaskMiddleware()
+        middleware.init_app(app)
+
+        self.assertIs(middleware.app, app)
+        assert isinstance(middleware.exporter, print_exporter.PrintExporter)
+
+        self.assertTrue(app.before_request.called)
+        self.assertTrue(app.after_request.called)
+
     def test_init_app(self):
         app = mock.Mock()
 
@@ -112,188 +126,13 @@ class TestFlaskMiddleware(unittest.TestCase):
         self.assertTrue(app.before_request.called)
         self.assertTrue(app.after_request.called)
 
-    def test_init_app_config_stackdriver_exporter(self):
-        app = mock.Mock()
-        app.config = {
-            'OPENCENSUS_TRACE': {
-                'SAMPLER': ProbabilitySampler,
-                'EXPORTER': stackdriver_exporter.StackdriverExporter,
-                'PROPAGATOR': google_cloud_format.GoogleCloudFormatPropagator,
-            },
-            'OPENCENSUS_TRACE_PARAMS': {
-                'BLACKLIST_PATHS': ['/_ah/health'],
-                'GCP_EXPORTER_PROJECT': None,
-                'SAMPLING_RATE': 0.5,
-                'ZIPKIN_EXPORTER_SERVICE_NAME': 'my_service',
-                'ZIPKIN_EXPORTER_HOST_NAME': 'localhost',
-                'ZIPKIN_EXPORTER_PORT': 9411,
-                'ZIPKIN_EXPORTER_PROTOCOL': 'http',
-            },
-        }
-
-        class StackdriverExporter(object):
-            def __init__(self, *args, **kwargs):
-                pass
-
-        middleware = flask_middleware.FlaskMiddleware(
-            exporter=StackdriverExporter
-        )
-        middleware.init_app(app)
-
-        self.assertIs(middleware.app, app)
-        self.assertTrue(app.before_request.called)
-        self.assertTrue(app.after_request.called)
-
-    def test_init_app_config_zipkin_exporter(self):
-
-        service_name = 'foo'
-        host_name = 'localhost'
-        port = 1234
-        app = mock.Mock()
-        app.config = {
-            'OPENCENSUS_TRACE': {
-                'SAMPLER': ProbabilitySampler,
-                'EXPORTER': zipkin_exporter.ZipkinExporter,
-                'PROPAGATOR': google_cloud_format.GoogleCloudFormatPropagator,
-            },
-            'OPENCENSUS_TRACE_PARAMS': {
-                'ZIPKIN_EXPORTER_SERVICE_NAME': service_name,
-                'ZIPKIN_EXPORTER_HOST_NAME': host_name,
-                'ZIPKIN_EXPORTER_PORT': port,
-                'ZIPKIN_EXPORTER_PROTOCOL': 'http',
-            },
-        }
-
-        middleware = flask_middleware.FlaskMiddleware()
-        middleware.init_app(app)
-
-        self.assertIs(middleware.app, app)
-        self.assertTrue(app.before_request.called)
-        self.assertTrue(app.after_request.called)
-
-        assert isinstance(
-            middleware.exporter, zipkin_exporter.ZipkinExporter)
-        self.assertEqual(middleware.exporter.service_name, service_name)
-        self.assertEqual(middleware.exporter.host_name, host_name)
-        self.assertEqual(middleware.exporter.port, port)
-
-    def test_init_app_config_zipkin_exporter_service_name_param(self):
-
-        service_name = 'foo'
-        host_name = 'localhost'
-        port = 1234
-        app = mock.Mock()
-        app.config = {
-            'OPENCENSUS_TRACE': {
-                'SAMPLER': ProbabilitySampler,
-                'EXPORTER': zipkin_exporter.ZipkinExporter,
-                'PROPAGATOR': google_cloud_format.GoogleCloudFormatPropagator,
-            },
-            'OPENCENSUS_TRACE_PARAMS': {
-                'SERVICE_NAME': service_name,
-                'ZIPKIN_EXPORTER_HOST_NAME': host_name,
-                'ZIPKIN_EXPORTER_PORT': port,
-                'ZIPKIN_EXPORTER_PROTOCOL': 'http',
-            },
-        }
-
-        middleware = flask_middleware.FlaskMiddleware()
-        middleware.init_app(app)
-
-        self.assertIs(middleware.app, app)
-        self.assertTrue(app.before_request.called)
-        self.assertTrue(app.after_request.called)
-
-        assert isinstance(
-            middleware.exporter, zipkin_exporter.ZipkinExporter)
-        self.assertEqual(middleware.exporter.service_name, service_name)
-        self.assertEqual(middleware.exporter.host_name, host_name)
-        self.assertEqual(middleware.exporter.port, port)
-
-    def test_init_app_config_jaeger_exporter(self):
-        service_name = 'foo'
-        app = mock.Mock()
-        app.config = {
-            'OPENCENSUS_TRACE': {
-                'SAMPLER': ProbabilitySampler,
-                'EXPORTER': jaeger_exporter.JaegerExporter,
-                'PROPAGATOR': google_cloud_format.GoogleCloudFormatPropagator,
-            },
-            'OPENCENSUS_TRACE_PARAMS': {
-                'SERVICE_NAME': service_name,
-            },
-        }
-
-        middleware = flask_middleware.FlaskMiddleware()
-        middleware.init_app(app)
-
-        self.assertIs(middleware.app, app)
-        self.assertTrue(app.before_request.called)
-        self.assertTrue(app.after_request.called)
-
-        assert isinstance(
-            middleware.exporter, jaeger_exporter.JaegerExporter)
-        self.assertEqual(middleware.exporter.service_name, service_name)
-
-    def test_init_app_config_ocagent_trace_exporter(self):
-        app = mock.Mock()
-        app.config = {
-            'OPENCENSUS_TRACE': {
-                'SAMPLER': ProbabilitySampler,
-                'EXPORTER': ocagent_exporter.TraceExporter,
-                'PROPAGATOR': google_cloud_format.GoogleCloudFormatPropagator,
-            },
-            'OPENCENSUS_TRACE_PARAMS': {
-                'SERVICE_NAME': 'foo',
-                'OCAGENT_TRACE_EXPORTER_ENDPOINT': 'localhost:50001'
-            }
-        }
-
-        middleware = flask_middleware.FlaskMiddleware()
-        middleware.init_app(app)
-
-        self.assertIs(middleware.app, app)
-        assert isinstance(
-            middleware.exporter, ocagent_exporter.TraceExporter)
-        self.assertEqual(middleware.exporter.service_name, 'foo')
-        self.assertEqual(middleware.exporter.endpoint, 'localhost:50001')
-
-        self.assertTrue(app.before_request.called)
-        self.assertTrue(app.after_request.called)
-
-    def test_init_app_config_ocagent_trace_exporter_default_endpoint(self):
-        app = mock.Mock()
-        app.config = {
-            'OPENCENSUS_TRACE': {
-                'SAMPLER': ProbabilitySampler,
-                'EXPORTER': ocagent_exporter.TraceExporter,
-                'PROPAGATOR': google_cloud_format.GoogleCloudFormatPropagator,
-            },
-            'OPENCENSUS_TRACE_PARAMS': {
-                'SERVICE_NAME': 'foo'
-            }
-        }
-
-        middleware = flask_middleware.FlaskMiddleware()
-        middleware.init_app(app)
-
-        self.assertIs(middleware.app, app)
-        assert isinstance(
-            middleware.exporter, ocagent_exporter.TraceExporter)
-        self.assertEqual(middleware.exporter.service_name, 'foo')
-        self.assertEqual(middleware.exporter.endpoint,
-                         ocagent_exporter.DEFAULT_ENDPOINT)
-
-        self.assertTrue(app.before_request.called)
-        self.assertTrue(app.after_request.called)
-
     def test__before_request(self):
         from opencensus.trace import execution_context
 
-        flask_trace_header = 'X-Cloud-Trace-Context'
+        flask_trace_header = 'traceparent'
         trace_id = '2dd43a1d6b2549c6bc2a1a54c2fc0b05'
         span_id = '6e0c63257de34c92'
-        flask_trace_id = '{}/{}'.format(trace_id, span_id)
+        flask_trace_id = '00-{}-{}-00'.format(trace_id, span_id)
 
         app = self.create_app()
         flask_middleware.FlaskMiddleware(app=app)
@@ -321,10 +160,10 @@ class TestFlaskMiddleware(unittest.TestCase):
             self.assertEqual(span_context.trace_id, trace_id)
 
     def test__before_request_blacklist(self):
-        flask_trace_header = 'X-Cloud-Trace-Context'
+        flask_trace_header = 'traceparent'
         trace_id = '2dd43a1d6b2549c6bc2a1a54c2fc0b05'
         span_id = '6e0c63257de34c92'
-        flask_trace_id = '{}/{}'.format(trace_id, span_id)
+        flask_trace_id = '00-{}-{}-00'.format(trace_id, span_id)
 
         app = self.create_app()
         flask_middleware.FlaskMiddleware(app=app)
@@ -348,10 +187,10 @@ class TestFlaskMiddleware(unittest.TestCase):
         # in SpanContext because it cannot match the pattern for trace_id,
         # And a new trace_id will generate for the context.
 
-        flask_trace_header = 'X-Cloud-Trace-Context'
+        flask_trace_header = 'traceparent'
         trace_id = "你好"
         span_id = '6e0c63257de34c92'
-        flask_trace_id = '{}/{}'.format(trace_id, span_id)
+        flask_trace_id = '00-{}-{}-00'.format(trace_id, span_id)
 
         app = self.create_app()
         flask_middleware.FlaskMiddleware(app=app)
@@ -399,10 +238,10 @@ class TestFlaskMiddleware(unittest.TestCase):
             assert isinstance(span.parent_span, base.NullContextManager)
 
     def test__after_request_not_sampled(self):
-        flask_trace_header = 'X-Cloud-Trace-Context'
+        flask_trace_header = 'traceparent'
         trace_id = '2dd43a1d6b2549c6bc2a1a54c2fc0b05'
         span_id = '6e0c63257de34c92'
-        flask_trace_id = '{}/{}'.format(trace_id, span_id)
+        flask_trace_id = '00-{}-{}-00'.format(trace_id, span_id)
         sampler = always_off.AlwaysOffSampler()
 
         app = self.create_app()
@@ -415,10 +254,10 @@ class TestFlaskMiddleware(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test__after_request_sampled(self):
-        flask_trace_header = 'X-Cloud-Trace-Context'
+        flask_trace_header = 'traceparent'
         trace_id = '2dd43a1d6b2549c6bc2a1a54c2fc0b05'
         span_id = '6e0c63257de34c92'
-        flask_trace_id = '{}/{}'.format(trace_id, span_id)
+        flask_trace_id = '00-{}-{}-00'.format(trace_id, span_id)
 
         app = self.create_app()
         flask_middleware.FlaskMiddleware(app=app)
@@ -430,10 +269,10 @@ class TestFlaskMiddleware(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test__after_request_blacklist(self):
-        flask_trace_header = 'X-Cloud-Trace-Context'
+        flask_trace_header = 'traceparent'
         trace_id = '2dd43a1d6b2549c6bc2a1a54c2fc0b05'
         span_id = '6e0c63257de34c92'
-        flask_trace_id = '{}/{}'.format(trace_id, span_id)
+        flask_trace_id = '00-{}-{}-00'.format(trace_id, span_id)
 
         app = self.create_app()
         flask_middleware.FlaskMiddleware(app=app)

--- a/contrib/opencensus-ext-flask/tests/test_flask_middleware.py
+++ b/contrib/opencensus-ext-flask/tests/test_flask_middleware.py
@@ -101,10 +101,12 @@ class TestFlaskMiddleware(unittest.TestCase):
     def test_init_app_config(self):
         app = mock.Mock()
         app.config = {
-            'OPENCENSUS_TRACE': {
-                'SAMPLER': 'opencensus.trace.samplers.ProbabilitySampler()',
-                'EXPORTER': 'opencensus.trace.print_exporter.PrintExporter()',
-                'PROPAGATOR': 'opencensus.trace.propagation.trace_context_http_header_format.TraceContextPropagator()',  # noqa
+            'OPENCENSUS': {
+                'TRACE': {
+                    'SAMPLER': 'opencensus.trace.samplers.ProbabilitySampler()',  # noqa
+                    'EXPORTER': 'opencensus.trace.print_exporter.PrintExporter()',  # noqa
+                    'PROPAGATOR': 'opencensus.trace.propagation.trace_context_http_header_format.TraceContextPropagator()',  # noqa
+                }
             }
         }
 

--- a/contrib/opencensus-ext-flask/tests/test_flask_middleware.py
+++ b/contrib/opencensus-ext-flask/tests/test_flask_middleware.py
@@ -104,6 +104,7 @@ class TestFlaskMiddleware(unittest.TestCase):
             'OPENCENSUS_TRACE': {
                 'SAMPLER': 'opencensus.trace.samplers.ProbabilitySampler()',
                 'EXPORTER': 'opencensus.trace.print_exporter.PrintExporter()',
+                'PROPAGATOR': 'opencensus.trace.propagation.trace_context_http_header_format.TraceContextPropagator()',  # noqa
             }
         }
 

--- a/opencensus/common/configuration/__init__.py
+++ b/opencensus/common/configuration/__init__.py
@@ -1,0 +1,43 @@
+# Copyright 2019, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+
+__all__ = ['Namespace', 'eval']
+
+
+class Namespace(object):
+    def __init__(self, name, parent=None):
+        self.parent = parent
+        self.name = name
+
+    def __getattr__(self, name):
+        return type(self)(name, self)
+
+    def __str__(self):
+        if self.parent is None:
+            return self.name
+        return '{!s}.{}'.format(self.parent, self.name)
+
+    def __call__(self, *args, **kwargs):
+        ctor = getattr(importlib.import_module(str(self.parent)), self.name)
+        return ctor(*args, **kwargs)
+
+    @classmethod
+    def eval(cls, expr):
+        return eval(expr, {}, {'opencensus': cls('opencensus')})
+
+
+def load(expr):
+    return Namespace.eval(expr)

--- a/opencensus/common/configuration/__init__.py
+++ b/opencensus/common/configuration/__init__.py
@@ -14,7 +14,7 @@
 
 import importlib
 
-__all__ = ['Namespace', 'eval']
+__all__ = ['Namespace', 'load']
 
 
 class Namespace(object):

--- a/opencensus/common/configuration/__init__.py
+++ b/opencensus/common/configuration/__init__.py
@@ -40,4 +40,7 @@ class Namespace(object):
 
 
 def load(expr):
+    """Dynamically import OpenCensus components and evaluate the provided
+    configuration expression.
+    """
     return Namespace.eval(expr)

--- a/tests/system/trace/flask/main.py
+++ b/tests/system/trace/flask/main.py
@@ -23,6 +23,7 @@ from opencensus.common.transports import async_
 from opencensus.ext.flask.flask_middleware import FlaskMiddleware
 from opencensus.ext.stackdriver import trace_exporter as stackdriver_exporter
 from opencensus.trace import config_integration
+from opencensus.trace.propagation import google_cloud_format
 
 INTEGRATIONS = ['mysql', 'postgresql', 'sqlalchemy']
 
@@ -41,10 +42,11 @@ app = flask.Flask(__name__)
 # Enable tracing, send traces to Stackdriver Trace using background thread
 # transport.  This is intentionally different from the Django system test which
 # is using sync transport to test both.
-exporter = stackdriver_exporter.StackdriverExporter(
-    transport=async_.AsyncTransport)
-
-middleware = FlaskMiddleware(app, exporter=exporter)
+middleware = FlaskMiddleware(app,
+    exporter=stackdriver_exporter.StackdriverExporter(
+        transport=async_.AsyncTransport),
+    propagator=google_cloud_format.GoogleCloudFormatPropagator(),
+)
 config_integration.trace_integrations(INTEGRATIONS)
 
 

--- a/tests/system/trace/flask/main.py
+++ b/tests/system/trace/flask/main.py
@@ -42,9 +42,10 @@ app = flask.Flask(__name__)
 # Enable tracing, send traces to Stackdriver Trace using background thread
 # transport.  This is intentionally different from the Django system test which
 # is using sync transport to test both.
-middleware = FlaskMiddleware(app,
+middleware = FlaskMiddleware(
+    app,
     exporter=stackdriver_exporter.StackdriverExporter(
-        transport=async_.AsyncTransport),
+                 transport=async_.AsyncTransport),
     propagator=google_cloud_format.GoogleCloudFormatPropagator(),
 )
 config_integration.trace_integrations(INTEGRATIONS)

--- a/tests/system/trace/flask/main.py
+++ b/tests/system/trace/flask/main.py
@@ -45,7 +45,8 @@ app = flask.Flask(__name__)
 middleware = FlaskMiddleware(
     app,
     exporter=stackdriver_exporter.StackdriverExporter(
-                 transport=async_.AsyncTransport),
+        transport=async_.AsyncTransport,
+    ),
     propagator=google_cloud_format.GoogleCloudFormatPropagator(),
 )
 config_integration.trace_integrations(INTEGRATIONS)

--- a/tests/unit/common/test_configuration.py
+++ b/tests/unit/common/test_configuration.py
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import mock
-except ImportError:
-    from unittest import mock
-
 import unittest
 
 from opencensus.common import configuration

--- a/tests/unit/common/test_configuration.py
+++ b/tests/unit/common/test_configuration.py
@@ -1,0 +1,40 @@
+# Copyright 2019, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+import unittest
+
+from opencensus.common import configuration
+
+
+class TestConfiguration(unittest.TestCase):
+    def test_load_import_error(self):
+        with self.assertRaises(ImportError):
+            configuration.load('opencensus.nonexist.foo()')
+
+    def test_load_name_error(self):
+        with self.assertRaises(NameError):
+            configuration.load('nonexist.foo()')
+
+    def test_load_syntax_error(self):
+        with self.assertRaises(SyntaxError):
+            configuration.load(')')
+
+    def test_load(self):
+        ns = configuration.load('opencensus.common.configuration.Namespace("foo")')
+        self.assertEqual(ns.name, 'foo')

--- a/tests/unit/common/test_configuration.py
+++ b/tests/unit/common/test_configuration.py
@@ -31,5 +31,7 @@ class TestConfiguration(unittest.TestCase):
             configuration.load(')')
 
     def test_load(self):
-        ns = configuration.load('opencensus.common.configuration.Namespace("foo")')
+        ns = configuration.load(
+            'opencensus.common.configuration.Namespace("foo")'
+        )
         self.assertEqual(ns.name, 'foo')


### PR DESCRIPTION
This is part of the effort for #394.
1. Introduced a generic configuration evaluation class.
2. Decouple Flask integration and extension exporters.
3. Use W3C TraceContext as the default propagator. Following https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/HTTP.md#propagation

_If user doesn't set any propagation methods explicitly, TraceContext is used._

@c24 @songy23 please take a brief look and see if you're okay with the direction.
Once I got okay from you on the direction, I'll work on Django and Pyramid as well.