### PR TITLE
Prepare for 0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ## 0.5.0
-Released 2019-04-23
+Released 2019-04-24
 
 - Add cumulative API
   ([#626](https://github.com/census-instrumentation/opencensus-python/pull/626))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ## Unreleased
 
+## 0.5.0
+Released 2019-04-23
+
 - Add cumulative API
   ([#626](https://github.com/census-instrumentation/opencensus-python/pull/626))
+- Allow for metrics with empty label keys and values
+  ([#611](https://github.com/census-instrumentation/opencensus-python/pull/611),
+  [#614](https://github.com/census-instrumentation/opencensus-python/pull/614))
 
 ## 0.4.0
 Released 2019-04-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ Released 2019-04-23
 
 - Add cumulative API
   ([#626](https://github.com/census-instrumentation/opencensus-python/pull/626))
-- Allow for metrics with empty label keys and values
+
+## 0.4.1
+Released 2019-04-11
+
+ - Allow for metrics with empty label keys and values
   ([#611](https://github.com/census-instrumentation/opencensus-python/pull/611),
   [#614](https://github.com/census-instrumentation/opencensus-python/pull/614))
 

--- a/README.rst
+++ b/README.rst
@@ -103,113 +103,70 @@ Alternatively, you can explicitly start and end a span:
 Customization
 -------------
 
-Samplers
-~~~~~~~~
+There are several things you can customize in OpenCensus:
 
-You can specify different samplers when initializing a tracer, default
-is using ``AlwaysOnSampler``, the other options are ``AlwaysOffSampler``
-and ``ProbabilitySampler``
+* **Blacklist**, which excludes certain hosts and paths from being tracked.
+  By default, the health check path for the App Engine flexible environment is
+  not tracked, you can turn it on by excluding it from the blacklist setting.
 
-.. code:: python
+* **Exporter**, which sends the traces.
+  By default, the traces are printed to stdout in JSON format. You can choose
+  different exporters to send the traces to. There are three built-in exporters,
+  which are ``PrintExporter``, ``FileExporter`` and ``LoggingExporter``, the
+  other exporters are provided as `extensions <#trace-exporter>`__.
 
-    from opencensus.trace.samplers import probability
-    from opencensus.trace import tracer as tracer_module
+* **Sampler**, which determines how traces are sampled.
+  The default sampler is ``AlwaysOnSampler``, other samplers include the
+  ``AlwaysOffSampler`` and ``ProbabilitySampler``.
 
-    # Sampling the requests at the rate equals 0.5
-    sampler = probability.ProbabilitySampler(rate=0.5)
-    tracer = tracer_module.Tracer(sampler=sampler)
+* **Propagator**, which serializes and deserializes the
+  ``SpanContext`` and its headers. The default propagator is
+  ``TraceContextPropagator``, other propagators include
+  ``BinaryFormatPropagator``, ``GoogleCloudFormatPropagator`` and
+  ``TextFormatPropagator``.
 
-Exporters
-~~~~~~~~~
 
-By default, the traces are printed to stdout in JSON format. You can choose
-different exporters to send the traces to. There are three built-in exporters,
-which are ``opencensus.trace.print_exporter``, ``opencensus.trace.file_exporter``
-and ``opencensus.trace.logging_exporter``, other exporters are provided as
-`extensions <#trace-exporter>`__.
-
-This example shows how to configure OpenCensus to save the traces to a
-file:
-
-.. code:: python
-
-    from opencensus.trace import file_exporter
-    from opencensus.trace.tracers import context_tracer
-
-    exporter = file_exporter.FileExporter(file_name='traces')
-    tracer = context_tracer.ContextTracer(exporter=exporter)
-
-Propagators
-~~~~~~~~~~~
-
-You can specify the propagator type for serializing and deserializing the
-``SpanContext`` and its headers. The default propagator is
-``TraceContextPropagator``, the rest options are ``BinaryFormatPropagator``,
-``GoogleCloudFormatPropagator`` and ``TextFormatPropagator``.
-
-This example shows how to use the ``GoogleCloudFormatPropagator``:
-
-.. code:: python
-
-    from opencensus.trace.propagation import google_cloud_format
-
-    propagator = google_cloud_format.GoogleCloudFormatPropagator()
-
-    # Deserialize
-    span_context = propagator.from_header(header)
-
-    # Serialize
-    header = propagator.to_header(span_context)
-
-This example shows how to use the ``TraceContextPropagator``:
+You can customize while initializing a tracer.
 
 .. code:: python
 
     import requests
 
     from opencensus.trace import config_integration
-    from opencensus.trace.propagation.trace_context_http_header_format import TraceContextPropagator
-    from opencensus.trace.tracer import Tracer
+    from opencensus.trace import file_exporter
+    from opencensus.trace import tracer as tracer_module
+    from opencensus.trace.propagation import google_cloud_format
+    from opencensus.trace.samplers import probability
 
     config_integration.trace_integrations(['httplib'])
-    tracer = Tracer(propagator=TraceContextPropagator())
+
+    tracer = tracer_module.Tracer(
+        exporter=file_exporter.FileExporter(file_name='traces'),
+        propagator=google_cloud_format.GoogleCloudFormatPropagator(),
+        sampler=probability.ProbabilitySampler(rate=0.5),
+    )
 
     with tracer.span(name='parent'):
         with tracer.span(name='child'):
             response = requests.get('http://localhost:5000')
 
-Blacklist Paths
-~~~~~~~~~~~~~~~
-
-You can specify which paths you do not want to trace by configuring the
-blacklist paths.
-
-This example shows how to configure the blacklist to ignore the ``_ah/health`` endpoint
-for a Flask application:
+You can use a configuration file for Flask/Django/Pyramid. For more
+information, please read the
+`individual integration documentation <#integration>`_.
 
 .. code:: python
 
-    from opencensus.trace.ext.flask.flask_middleware import FlaskMiddleware
-
-    app = flask.Flask(__name__)
-
-    blacklist_paths = ['_ah/health']
-    middleware = FlaskMiddleware(app, blacklist_paths=blacklist_paths)
-
-For Django, you can configure the blacklist in the ``OPENCENSUS`` in ``settings.py``:
-
-.. code:: python
-
-    OPENCENSUS: {
+    'OPENCENSUS': {
         'TRACE': {
-            ...
-            'BLACKLIST_PATHS': ['_ah/health',],
+            'BLACKLIST_HOSTNAMES': ['localhost', '127.0.0.1'],
+            'BLACKLIST_PATHS': ['_ah/health'],
+            'SAMPLER': 'opencensus.trace.samplers.ProbabilitySampler(rate=1)',
+            'EXPORTER': '''opencensus.ext.ocagent.trace_exporter.TraceExporter(
+                service_name='foobar',
+            )''',
+            'PROPAGATOR': 'opencensus.trace.propagation.google_cloud_format.GoogleCloudFormatPropagator()',
         }
     }
-
-
-.. note:: By default, the health check path for the App Engine flexible environment is not traced,
-    but you can turn it on by excluding it from the blacklist setting.
 
 ------------
  Extensions

--- a/context/opencensus-context/CHANGELOG.md
+++ b/context/opencensus-context/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 ## 0.1.0
 Released 2019-04-08
 

--- a/context/opencensus-context/README.rst
+++ b/context/opencensus-context/README.rst
@@ -5,3 +5,74 @@ OpenCensus Runtime Context
 
 .. |pypi| image:: https://badge.fury.io/py/opencensus-context.svg
    :target: https://pypi.org/project/opencensus-context/
+
+The **OpenCensus Runtime Context** provides in-process context propagation.
+By default, ``thread local storage`` is used for Python 2.7, 3.4 and 3.5;
+``contextvars`` is used for Python >= 3.6, which provides ``asyncio`` support.
+
+Installation
+------------
+
+This library is installed by default with ``opencensus``, there is no need
+to install it explicitly.
+
+Usage
+-----
+
+In most cases context propagation happens automatically within a process,
+following the control flow of threads and asynchronous coroutines. The runtime
+context is a dictionary stored in a `context variable <https://docs.python.org/3/library/contextvars.html>`_
+when available, and in `thread local storage <https://docs.python.org/2/library/threading.html#threading.local>`_
+otherwise.
+
+There are cases where you may want to propagate the context explicitly:
+
+Explicit Thread Creation
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: python
+
+    from threading import Thread
+    from opencensus.common.runtime_context import RuntimeContext
+
+    def work(name):
+        # here you will get the context from the parent thread
+        print(RuntimeContext)
+
+    thread = Thread(
+        # propagate context explicitly
+        target=RuntimeContext.with_current_context(work),
+        args=('foobar',),
+    )
+    thread.start()
+    thread.join()
+
+Thread Pool
+~~~~~~~~~~~
+
+.. code:: python
+
+    from multiprocessing.dummy import Pool as ThreadPool
+    from opencensus.common.runtime_context import RuntimeContext
+
+    def work(name):
+        # here you will get the context from the parent thread
+        print(RuntimeContext)
+
+    pool = ThreadPool(2)
+    # propagate context explicitly
+    pool.map(RuntimeContext.with_current_context(work), [
+        'bear',
+        'cat',
+        'dog',
+        'horse',
+        'rabbit',
+    ])
+    pool.close()
+    pool.join()
+
+References
+----------
+
+* `Examples <https://github.com/census-instrumentation/opencensus-python/tree/master/context/opencensus-context/examples>`_
+* `OpenCensus Project <https://opencensus.io/>`_

--- a/context/opencensus-context/version.py
+++ b/context/opencensus-context/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.dev0'
+__version__ = '0.1.0'

--- a/contrib/opencensus-correlation/version.py
+++ b/contrib/opencensus-correlation/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.dev0'
+__version__ = '0.1.0'

--- a/contrib/opencensus-ext-azure/CHANGELOG.md
+++ b/contrib/opencensus-ext-azure/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 ## 0.1.0
 Released 2019-04-23
 

--- a/contrib/opencensus-ext-azure/CHANGELOG.md
+++ b/contrib/opencensus-ext-azure/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
 
-## Unreleased
-- Initial project skeleton
+## 0.1.0
+Released 2019-04-23
+
+- Initial release

--- a/contrib/opencensus-ext-azure/CHANGELOG.md
+++ b/contrib/opencensus-ext-azure/CHANGELOG.md
@@ -3,6 +3,6 @@
 ## Unreleased
 
 ## 0.1.0
-Released 2019-04-23
+Released 2019-04-24
 
 - Initial release

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/version.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.dev0'
+__version__ = '0.1.0'

--- a/contrib/opencensus-ext-azure/setup.py
+++ b/contrib/opencensus-ext-azure/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.5.dev0, < 1.0.0',
+        'opencensus >= 0.5.0, < 1.0.0',
         'requests >= 2.19.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-dbapi/CHANGELOG.md
+++ b/contrib/opencensus-ext-dbapi/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.1.2
+Released 2019-04-23
+
+- Updated docs and examples
+
 ## 0.1.1
 Released 2019-04-08
 

--- a/contrib/opencensus-ext-dbapi/CHANGELOG.md
+++ b/contrib/opencensus-ext-dbapi/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ## 0.1.2
-Released 2019-04-23
+Released 2019-04-24
 
 - Updated docs and examples
 

--- a/contrib/opencensus-ext-dbapi/setup.py
+++ b/contrib/opencensus-ext-dbapi/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.5.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-dbapi/setup.py
+++ b/contrib/opencensus-ext-dbapi/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.3.0, < 1.0.0',
+        'opencensus >= 0.5.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-dbapi/version.py
+++ b/contrib/opencensus-ext-dbapi/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.dev0'
+__version__ = '0.1.2'

--- a/contrib/opencensus-ext-django/CHANGELOG.md
+++ b/contrib/opencensus-ext-django/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Changelog
 
 ## Unreleased
+
+## 0.3.0
+Released 2019-04-23
+
 - Decoupled exporter specific logic from configuration
+- Prevent anymonous user error on old django versions
+  ([#603](https://github.com/census-instrumentation/opencensus-python/pull/603))
 
 ## 0.2.0
 Released 2019-04-08

--- a/contrib/opencensus-ext-django/CHANGELOG.md
+++ b/contrib/opencensus-ext-django/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ## 0.3.0
-Released 2019-04-23
+Released 2019-04-24
 
 - Decoupled exporter specific logic from configuration
 - Prevent anymonous user error on old django versions

--- a/contrib/opencensus-ext-django/setup.py
+++ b/contrib/opencensus-ext-django/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'Django >= 1.11.0, <= 1.11.20',
-        'opencensus >= 0.5.dev0, < 1.0.0',
+        'opencensus >= 0.5.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-django/version.py
+++ b/contrib/opencensus-ext-django/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.3.dev0'
+__version__ = '0.3.0'

--- a/contrib/opencensus-ext-flask/CHANGELOG.md
+++ b/contrib/opencensus-ext-flask/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ## 0.3.0
-Released 2019-04-23
+Released 2019-04-24
 
 - Decoupled exporter specific logic from configuration
 

--- a/contrib/opencensus-ext-flask/CHANGELOG.md
+++ b/contrib/opencensus-ext-flask/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+
+## 0.3.0
+Released 2019-04-23
+
 - Decoupled exporter specific logic from configuration
 
 ## 0.2.0

--- a/contrib/opencensus-ext-flask/setup.py
+++ b/contrib/opencensus-ext-flask/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'flask >= 0.12.3, < 2.0.0',
-        'opencensus >= 0.5.dev0, < 1.0.0',
+        'opencensus >= 0.5.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-flask/version.py
+++ b/contrib/opencensus-ext-flask/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.3.dev0'
+__version__ = '0.3.0'

--- a/contrib/opencensus-ext-google-cloud-clientlibs/CHANGELOG.md
+++ b/contrib/opencensus-ext-google-cloud-clientlibs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.1.2
+Released 2019-04-23
+
+- Updated docs and examples
+
 ## 0.1.1
 Released 2019-04-08
 

--- a/contrib/opencensus-ext-google-cloud-clientlibs/CHANGELOG.md
+++ b/contrib/opencensus-ext-google-cloud-clientlibs/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ## 0.1.2
-Released 2019-04-23
+Released 2019-04-24
 
 - Updated docs and examples
 

--- a/contrib/opencensus-ext-google-cloud-clientlibs/setup.py
+++ b/contrib/opencensus-ext-google-cloud-clientlibs/setup.py
@@ -39,9 +39,9 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.5.dev0, < 1.0.0',
-        'opencensus-ext-grpc >= 0.2.dev0, < 1.0.0',
-        'opencensus-ext-requests >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.5.0, < 1.0.0',
+        'opencensus-ext-grpc >= 0.2.0, < 1.0.0',
+        'opencensus-ext-requests >= 0.1.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-google-cloud-clientlibs/version.py
+++ b/contrib/opencensus-ext-google-cloud-clientlibs/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.dev0'
+__version__ = '0.1.2'

--- a/contrib/opencensus-ext-grpc/CHANGELOG.md
+++ b/contrib/opencensus-ext-grpc/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ## 0.2.0
-Released 2019-04-23
+Released 2019-04-24
 
 - Create WrappedResponseIterator for intercepted bi-directional rpc stream.
 

--- a/contrib/opencensus-ext-grpc/CHANGELOG.md
+++ b/contrib/opencensus-ext-grpc/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+
+## 0.2.0
+Released 2019-04-23
+
 - Create WrappedResponseIterator for intercepted bi-directional rpc stream.
 
 ## 0.1.1

--- a/contrib/opencensus-ext-grpc/setup.py
+++ b/contrib/opencensus-ext-grpc/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'grpcio >= 1.0.0, < 2.0.0',
-        'opencensus >= 0.5.dev0, < 1.0.0',
+        'opencensus >= 0.5.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-grpc/version.py
+++ b/contrib/opencensus-ext-grpc/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.dev0'
+__version__ = '0.2.0'

--- a/contrib/opencensus-ext-httplib/CHANGELOG.md
+++ b/contrib/opencensus-ext-httplib/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.1.2
+Released 2019-04-23
+
+- Updated docs and examples
+
 ## 0.1.1
 Released 2019-04-08
 

--- a/contrib/opencensus-ext-httplib/CHANGELOG.md
+++ b/contrib/opencensus-ext-httplib/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ## 0.1.2
-Released 2019-04-23
+Released 2019-04-24
 
 - Updated docs and examples
 

--- a/contrib/opencensus-ext-httplib/setup.py
+++ b/contrib/opencensus-ext-httplib/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.5.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-httplib/setup.py
+++ b/contrib/opencensus-ext-httplib/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.3.0, < 1.0.0',
+        'opencensus >= 0.5.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-httplib/version.py
+++ b/contrib/opencensus-ext-httplib/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.dev0'
+__version__ = '0.1.2'

--- a/contrib/opencensus-ext-jaeger/CHANGELOG.md
+++ b/contrib/opencensus-ext-jaeger/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ## 0.2.1
-Released 2019-04-23
+Released 2019-04-24
 
 - Updated docs and examples
 

--- a/contrib/opencensus-ext-jaeger/CHANGELOG.md
+++ b/contrib/opencensus-ext-jaeger/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.2.1
+Released 2019-04-23
+
+- Updated docs and examples
+
 ## 0.2.0
 Released 2019-04-08
 

--- a/contrib/opencensus-ext-jaeger/setup.py
+++ b/contrib/opencensus-ext-jaeger/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.5.dev0, < 1.0.0',
+        'opencensus >= 0.4.0, < 1.0.0',
         'thrift >= 0.10.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-jaeger/setup.py
+++ b/contrib/opencensus-ext-jaeger/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.4.0, < 1.0.0',
+        'opencensus >= 0.5.0, < 1.0.0',
         'thrift >= 0.10.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-jaeger/version.py
+++ b/contrib/opencensus-ext-jaeger/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.3.dev0'
+__version__ = '0.2.1'

--- a/contrib/opencensus-ext-mysql/CHANGELOG.md
+++ b/contrib/opencensus-ext-mysql/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.1.2
+Released 2019-04-23
+
+- Updated docs and examples
+
 ## 0.1.1
 Released 2019-04-08
 

--- a/contrib/opencensus-ext-mysql/CHANGELOG.md
+++ b/contrib/opencensus-ext-mysql/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ## 0.1.2
-Released 2019-04-23
+Released 2019-04-24
 
 - Updated docs and examples
 

--- a/contrib/opencensus-ext-mysql/setup.py
+++ b/contrib/opencensus-ext-mysql/setup.py
@@ -40,8 +40,8 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'mysql-connector >= 2.1.6, < 3.0.0',
-        'opencensus >= 0.5.dev0, < 1.0.0',
-        'opencensus-ext-dbapi >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
+        'opencensus-ext-dbapi >= 0.1.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-mysql/setup.py
+++ b/contrib/opencensus-ext-mysql/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'mysql-connector >= 2.1.6, < 3.0.0',
-        'opencensus >= 0.3.0, < 1.0.0',
+        'opencensus >= 0.5.0, < 1.0.0',
         'opencensus-ext-dbapi >= 0.1.0, < 1.0.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-mysql/version.py
+++ b/contrib/opencensus-ext-mysql/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.dev0'
+__version__ = '0.1.2'

--- a/contrib/opencensus-ext-ocagent/CHANGELOG.md
+++ b/contrib/opencensus-ext-ocagent/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+
+## 0.3.0
+Released 2019-04-23
+
 - Add stats exporter
 
 ## 0.2.0

--- a/contrib/opencensus-ext-ocagent/CHANGELOG.md
+++ b/contrib/opencensus-ext-ocagent/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ## 0.3.0
-Released 2019-04-23
+Released 2019-04-24
 
 - Add stats exporter
 

--- a/contrib/opencensus-ext-ocagent/setup.py
+++ b/contrib/opencensus-ext-ocagent/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'grpcio >= 1.0.0, < 2.0.0',
-        'opencensus >= 0.5.dev0, < 1.0.0',
+        'opencensus >= 0.5.0, < 1.0.0',
         'opencensus-proto >= 0.1.0, < 1.0.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-ocagent/version.py
+++ b/contrib/opencensus-ext-ocagent/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.3.dev0'
+__version__ = '0.3.0'

--- a/contrib/opencensus-ext-postgresql/CHANGELOG.md
+++ b/contrib/opencensus-ext-postgresql/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.1.2
+Released 2019-04-23
+
+- Updated docs and examples
+
 ## 0.1.1
 Released 2019-04-08
 

--- a/contrib/opencensus-ext-postgresql/CHANGELOG.md
+++ b/contrib/opencensus-ext-postgresql/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ## 0.1.2
-Released 2019-04-23
+Released 2019-04-24
 
 - Updated docs and examples
 

--- a/contrib/opencensus-ext-postgresql/setup.py
+++ b/contrib/opencensus-ext-postgresql/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.5.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
         'psycopg2-binary >= 2.7.3.1',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-postgresql/setup.py
+++ b/contrib/opencensus-ext-postgresql/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.3.0, < 1.0.0',
+        'opencensus >= 0.5.0, < 1.0.0',
         'psycopg2-binary >= 2.7.3.1',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-postgresql/version.py
+++ b/contrib/opencensus-ext-postgresql/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.dev0'
+__version__ = '0.1.2'

--- a/contrib/opencensus-ext-prometheus/CHANGELOG.md
+++ b/contrib/opencensus-ext-prometheus/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ## 0.2.1
-Released 2019-04-23
+Released 2019-04-24
 
 - Updated docs and examples
 

--- a/contrib/opencensus-ext-prometheus/CHANGELOG.md
+++ b/contrib/opencensus-ext-prometheus/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.2.1
+Released 2019-04-23
+
+- Updated docs and examples
+
 ## 0.2.0
 Released 2019-04-08
 

--- a/contrib/opencensus-ext-prometheus/setup.py
+++ b/contrib/opencensus-ext-prometheus/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.5.dev0, < 1.0.0',
+        'opencensus >= 0.4.0, < 1.0.0',
         'prometheus_client >= 0.5.0, < 1.0.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-prometheus/setup.py
+++ b/contrib/opencensus-ext-prometheus/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.4.0, < 1.0.0',
+        'opencensus >= 0.5.0, < 1.0.0',
         'prometheus_client >= 0.5.0, < 1.0.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-prometheus/version.py
+++ b/contrib/opencensus-ext-prometheus/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.3.dev0'
+__version__ = '0.2.1'

--- a/contrib/opencensus-ext-pymongo/CHANGELOG.md
+++ b/contrib/opencensus-ext-pymongo/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.1.2
+Released 2019-04-23
+
+- Updated docs and examples
+
 ## 0.1.1
 Released 2019-04-08
 

--- a/contrib/opencensus-ext-pymongo/CHANGELOG.md
+++ b/contrib/opencensus-ext-pymongo/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ## 0.1.2
-Released 2019-04-23
+Released 2019-04-24
 
 - Updated docs and examples
 

--- a/contrib/opencensus-ext-pymongo/setup.py
+++ b/contrib/opencensus-ext-pymongo/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.3.0, < 1.0.0',
+        'opencensus >= 0.5.0, < 1.0.0',
         'pymongo >= 3.1.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-pymongo/setup.py
+++ b/contrib/opencensus-ext-pymongo/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.5.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
         'pymongo >= 3.1.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-pymongo/version.py
+++ b/contrib/opencensus-ext-pymongo/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.dev0'
+__version__ = '0.1.2'

--- a/contrib/opencensus-ext-pymysql/CHANGELOG.md
+++ b/contrib/opencensus-ext-pymysql/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.1.2
+Released 2019-04-23
+
+- Updated docs and examples
+
 ## 0.1.1
 Released 2019-04-08
 

--- a/contrib/opencensus-ext-pymysql/CHANGELOG.md
+++ b/contrib/opencensus-ext-pymysql/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ## 0.1.2
-Released 2019-04-23
+Released 2019-04-24
 
 - Updated docs and examples
 

--- a/contrib/opencensus-ext-pymysql/setup.py
+++ b/contrib/opencensus-ext-pymysql/setup.py
@@ -40,8 +40,8 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'PyMySQL >= 0.7.11, < 1.0.0',
-        'opencensus >= 0.5.dev0, < 1.0.0',
-        'opencensus-ext-dbapi >= 0.2.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
+        'opencensus-ext-dbapi >= 0.1.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-pymysql/setup.py
+++ b/contrib/opencensus-ext-pymysql/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'PyMySQL >= 0.7.11, < 1.0.0',
-        'opencensus >= 0.3.0, < 1.0.0',
+        'opencensus >= 0.5.0, < 1.0.0',
         'opencensus-ext-dbapi >= 0.1.0, < 1.0.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-pymysql/version.py
+++ b/contrib/opencensus-ext-pymysql/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.dev0'
+__version__ = '0.1.2'

--- a/contrib/opencensus-ext-pyramid/CHANGELOG.md
+++ b/contrib/opencensus-ext-pyramid/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+
+## 0.3.0
+Released 2019-04-23
+
 - Refactor configuration, keep consistent with Flask/Django
 - Use W3C TraceContext propagation by default
 

--- a/contrib/opencensus-ext-pyramid/CHANGELOG.md
+++ b/contrib/opencensus-ext-pyramid/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ## 0.3.0
-Released 2019-04-23
+Released 2019-04-24
 
 - Refactor configuration, keep consistent with Flask/Django
 - Use W3C TraceContext propagation by default

--- a/contrib/opencensus-ext-pyramid/setup.py
+++ b/contrib/opencensus-ext-pyramid/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'pyramid >= 1.9.1, < 2.0.0',
-        'opencensus >= 0.5.dev0, < 1.0.0',
+        'opencensus >= 0.5.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-pyramid/version.py
+++ b/contrib/opencensus-ext-pyramid/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.3.dev0'
+__version__ = '0.3.0'

--- a/contrib/opencensus-ext-requests/CHANGELOG.md
+++ b/contrib/opencensus-ext-requests/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.1.2
+Released 2019-04-23
+
+- Updated docs and examples
+
 ## 0.1.1
 Released 2019-04-08
 

--- a/contrib/opencensus-ext-requests/CHANGELOG.md
+++ b/contrib/opencensus-ext-requests/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ## 0.1.2
-Released 2019-04-23
+Released 2019-04-24
 
 - Updated docs and examples
 

--- a/contrib/opencensus-ext-requests/setup.py
+++ b/contrib/opencensus-ext-requests/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.3.0, < 1.0.0',
+        'opencensus >= 0.5.0, < 1.0.0',
         'wrapt >= 1.0.0, < 2.0.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-requests/setup.py
+++ b/contrib/opencensus-ext-requests/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.5.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
         'wrapt >= 1.0.0, < 2.0.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-requests/version.py
+++ b/contrib/opencensus-ext-requests/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.dev0'
+__version__ = '0.1.2'

--- a/contrib/opencensus-ext-sqlalchemy/CHANGELOG.md
+++ b/contrib/opencensus-ext-sqlalchemy/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.1.2
+Released 2019-04-23
+
+- Updated docs and examples
+
 ## 0.1.1
 Released 2019-04-08
 

--- a/contrib/opencensus-ext-sqlalchemy/CHANGELOG.md
+++ b/contrib/opencensus-ext-sqlalchemy/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ## 0.1.2
-Released 2019-04-23
+Released 2019-04-24
 
 - Updated docs and examples
 

--- a/contrib/opencensus-ext-sqlalchemy/setup.py
+++ b/contrib/opencensus-ext-sqlalchemy/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.3.0, < 1.0.0',
+        'opencensus >= 0.5.0, < 1.0.0',
         'SQLAlchemy >= 1.1.14, < 2.0.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-sqlalchemy/setup.py
+++ b/contrib/opencensus-ext-sqlalchemy/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.5.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
         'SQLAlchemy >= 1.1.14, < 2.0.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-sqlalchemy/version.py
+++ b/contrib/opencensus-ext-sqlalchemy/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.dev0'
+__version__ = '0.1.2'

--- a/contrib/opencensus-ext-stackdriver/CHANGELOG.md
+++ b/contrib/opencensus-ext-stackdriver/CHANGELOG.md
@@ -5,7 +5,11 @@
 ## 0.3.0
 Released 2019-04-23
 
-- Use default GCP auth for stats exporter
+- Multiple changes to stats exporter API
+
+## 0.2.1
+Released 2019-04-11
+- Don't require exporter options, fall back to default GCP auth
   ([#610](https://github.com/census-instrumentation/opencensus-python/pull/610))
 
 ## 0.2.0

--- a/contrib/opencensus-ext-stackdriver/CHANGELOG.md
+++ b/contrib/opencensus-ext-stackdriver/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.3.0
+Released 2019-04-23
+
+- Use default GCP auth for stats exporter
+  ([#610](https://github.com/census-instrumentation/opencensus-python/pull/610))
+
 ## 0.2.0
 Released 2019-04-08
 

--- a/contrib/opencensus-ext-stackdriver/CHANGELOG.md
+++ b/contrib/opencensus-ext-stackdriver/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ## 0.3.0
-Released 2019-04-23
+Released 2019-04-24
 
 - Multiple changes to stats exporter API
 

--- a/contrib/opencensus-ext-stackdriver/setup.py
+++ b/contrib/opencensus-ext-stackdriver/setup.py
@@ -41,7 +41,7 @@ setup(
     install_requires=[
         'google-cloud-monitoring >= 0.30.0, < 1.0.0',
         'google-cloud-trace >= 0.20.0, < 1.0.0',
-        'opencensus >= 0.5.dev0, < 1.0.0',
+        'opencensus >= 0.5.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-stackdriver/version.py
+++ b/contrib/opencensus-ext-stackdriver/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.3.dev0'
+__version__ = '0.3.0'

--- a/contrib/opencensus-ext-threading/CHANGELOG.md
+++ b/contrib/opencensus-ext-threading/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.1.2
+Released 2019-04-23
+
+- Updated docs and examples
+
 ## 0.1.1
 Released 2019-04-08
 

--- a/contrib/opencensus-ext-threading/CHANGELOG.md
+++ b/contrib/opencensus-ext-threading/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ## 0.1.2
-Released 2019-04-23
+Released 2019-04-24
 
 - Updated docs and examples
 

--- a/contrib/opencensus-ext-threading/setup.py
+++ b/contrib/opencensus-ext-threading/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.5.dev0, < 1.0.0',
+        'opencensus >= 0.3.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-threading/setup.py
+++ b/contrib/opencensus-ext-threading/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.3.0, < 1.0.0',
+        'opencensus >= 0.5.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-threading/version.py
+++ b/contrib/opencensus-ext-threading/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.dev0'
+__version__ = '0.1.2'

--- a/contrib/opencensus-ext-zipkin/CHANGELOG.md
+++ b/contrib/opencensus-ext-zipkin/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ## 0.2.1
-Released 2019-04-23
+Released 2019-04-24
 
 - Updated docs and examples
 

--- a/contrib/opencensus-ext-zipkin/CHANGELOG.md
+++ b/contrib/opencensus-ext-zipkin/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.2.1
+Released 2019-04-23
+
+- Updated docs and examples
+
 ## 0.2.0
 Released 2019-04-08
 

--- a/contrib/opencensus-ext-zipkin/setup.py
+++ b/contrib/opencensus-ext-zipkin/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.4.0, < 1.0.0',
+        'opencensus >= 0.5.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-zipkin/setup.py
+++ b/contrib/opencensus-ext-zipkin/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.5.dev0, < 1.0.0',
+        'opencensus >= 0.4.0, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-zipkin/version.py
+++ b/contrib/opencensus-ext-zipkin/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.3.dev0'
+__version__ = '0.2.1'

--- a/opencensus/common/version/__init__.py
+++ b/opencensus/common/version/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.5.dev0'
+__version__ = '0.5.0'

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus-context == 0.2.dev0',
+        'opencensus-context == 0.1.0',
         'google-api-core >= 1.0.0, < 2.0.0',
     ],
     extras_require={},


### PR DESCRIPTION
Update versions and changelogs for the `0.5.0` release of `opencensus` and new releases of most ext packages.

Most ext packages got a micro version update for the docs changes in #625, packages affected by the config changes in #621 and #624 got a minor version update.

See [the diff against the `v0.4.x` branch](https://github.com/census-instrumentation/opencensus-python/compare/v0.4.x...c24t:v0.5.x?expand=1) for the full set of files changed since the last release. 