### PR TITLE
Improve test process

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,1 @@
+OpenCensus Authors

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,0 @@
-OpenCensus Authors

--- a/contrib/opencensus-ext-ocagent/tests/test_ocagent_utils.py
+++ b/contrib/opencensus-ext-ocagent/tests/test_ocagent_utils.py
@@ -33,23 +33,23 @@ class TestUtils(unittest.TestCase):
 
     def test_datetime_str_to_proto_ts_conversion_none(self):
         proto_ts = utils.proto_ts_from_datetime_str(None)
-        self.assertEquals(proto_ts.seconds, 0)
-        self.assertEquals(proto_ts.nanos, 0)
+        self.assertEqual(proto_ts.seconds, 0)
+        self.assertEqual(proto_ts.nanos, 0)
 
     def test_datetime_str_to_proto_ts_conversion_empty(self):
         proto_ts = utils.proto_ts_from_datetime_str('')
-        self.assertEquals(proto_ts.seconds, 0)
-        self.assertEquals(proto_ts.nanos, 0)
+        self.assertEqual(proto_ts.seconds, 0)
+        self.assertEqual(proto_ts.nanos, 0)
 
     def test_datetime_str_to_proto_ts_conversion_invalid(self):
         proto_ts = utils.proto_ts_from_datetime_str('2018 08 22 T 11:53')
-        self.assertEquals(proto_ts.seconds, 0)
-        self.assertEquals(proto_ts.nanos, 0)
+        self.assertEqual(proto_ts.seconds, 0)
+        self.assertEqual(proto_ts.nanos, 0)
 
     def test_datetime_to_proto_ts_conversion_none(self):
         proto_ts = utils.proto_ts_from_datetime(None)
-        self.assertEquals(proto_ts.seconds, 0)
-        self.assertEquals(proto_ts.nanos, 0)
+        self.assertEqual(proto_ts.seconds, 0)
+        self.assertEqual(proto_ts.nanos, 0)
 
     def test_datetime_to_proto_ts_conversion(self):
         now = datetime.utcnow()

--- a/contrib/opencensus-ext-ocagent/tests/test_stats_exporter.py
+++ b/contrib/opencensus-ext-ocagent/tests/test_stats_exporter.py
@@ -142,7 +142,7 @@ class TestStatsExporter(unittest.TestCase):
 
         handler = mock.Mock(spec=ocagent.ExportRpcHandler)
         ocagent.StatsExporter(handler).export_metrics(view_data)
-        self.assertEquals(
+        self.assertEqual(
             handler.send.call_args[0]
             [0].metrics[0].timeseries[0].label_values[0],
             metrics_pb2.LabelValue(has_value=True, value='test-key'))
@@ -161,7 +161,7 @@ class TestStatsExporter(unittest.TestCase):
 
         handler = mock.Mock(spec=ocagent.ExportRpcHandler)
         ocagent.StatsExporter(handler).export_metrics(view_data)
-        self.assertEquals(
+        self.assertEqual(
             handler.send.call_args[0]
             [0].metrics[0].timeseries[0].points[0].double_value, 2.5)
 
@@ -185,7 +185,7 @@ class TestStatsExporter(unittest.TestCase):
         handler = mock.Mock(spec=ocagent.ExportRpcHandler)
         ocagent.StatsExporter(handler).export_metrics([metric])
 
-        self.assertEquals(
+        self.assertEqual(
             handler.send.call_args[0][0].metrics[0].timeseries[0].points[0].
             distribution_value.buckets[0].exemplar,
             metrics_pb2.DistributionValue.Exemplar(
@@ -323,8 +323,8 @@ class TestExportRpcInterface(unittest.TestCase):
         handler.send(request)
 
         self.assertTrue(event.wait(timeout=1))
-        self.assertEquals(len(initialized), 2)
-        self.assertEquals(len(requests), 2)
+        self.assertEqual(len(initialized), 2)
+        self.assertEqual(len(requests), 2)
 
     @mock.patch('opencensus.metrics.transport.get_exporter_thread')
     def test_create_stats_exporter_initialization(self, mock_transport):
@@ -358,7 +358,7 @@ class TestExportRpcInterface(unittest.TestCase):
     def test_create_stats_exporter_with_default_endpoint(
             self, mock_channel, _):
         ocagent.new_stats_exporter(SERVICE_NAME)
-        self.assertEquals(mock_channel.call_args[0][0], 'localhost:55678')
+        self.assertEqual(mock_channel.call_args[0][0], 'localhost:55678')
 
     def test_export_node(self):
         requests = []

--- a/nox.py
+++ b/nox.py
@@ -45,6 +45,14 @@ def _install_dev_packages(session):
     session.install('-e', 'contrib/opencensus-ext-google-cloud-clientlibs')
 
 
+def _install_test_dependencies(session):
+    session.install('mock')
+    session.install('pytest')
+    session.install('pytest-cov')
+    session.install('retrying')
+    session.install('unittest2')
+
+
 @nox.session
 @nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
 def unit(session, py):
@@ -53,8 +61,8 @@ def unit(session, py):
     # Run unit tests against all supported versions of Python.
     session.interpreter = 'python{}'.format(py)
 
-    # Install all test dependencies.
-    session.install('-r', 'requirements-test.txt')
+    # Install test dependencies.
+    _install_test_dependencies(session)
 
     # Install dev packages.
     _install_dev_packages(session)
@@ -92,8 +100,8 @@ def system(session, py):
     # Set the virtualenv dirname.
     session.virtualenv_dirname = 'sys-' + py
 
-    # Install all test dependencies.
-    session.install('-r', 'requirements-test.txt')
+    # Install test dependencies.
+    _install_test_dependencies(session)
 
     # Install dev packages into the virtualenv's dist-packages.
     _install_dev_packages(session)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,0 @@
-mock==2.0.0
-pytest==3.2.2
-pytest-cov==2.5.1
-retrying==1.3.3
-unittest2==1.1.0

--- a/tests/unit/common/monitored_resource_util/test_aws_identity_doc_utils.py
+++ b/tests/unit/common/monitored_resource_util/test_aws_identity_doc_utils.py
@@ -48,7 +48,7 @@ class TestAwsIdentityDocumentUtils(unittest.TestCase):
         labels_list = aws_identity_doc_utils.AwsIdentityDocumentUtils(
         ).get_aws_metadata()
 
-        self.assertEquals(len(labels_list), 3)
+        self.assertEqual(len(labels_list), 3)
 
         expected_labels = {
             'instance_id': 'i-1234567890abcdef0',
@@ -56,7 +56,7 @@ class TestAwsIdentityDocumentUtils(unittest.TestCase):
             'region': 'us-west-2'
         }
 
-        self.assertEquals(labels_list, expected_labels)
+        self.assertEqual(labels_list, expected_labels)
 
     @mock.patch('opencensus.common.monitored_resource.'
                 'aws_identity_doc_utils.get_request')
@@ -85,14 +85,14 @@ class TestAwsIdentityDocumentUtils(unittest.TestCase):
         labels_list = aws_identity_doc_utils.AwsIdentityDocumentUtils(
         ).get_aws_metadata()
 
-        self.assertEquals(len(labels_list), 2)
+        self.assertEqual(len(labels_list), 2)
 
         expected_labels = {
             'aws_account': '123456789012',
             'region': 'us-west-2'
         }
 
-        self.assertEquals(labels_list, expected_labels)
+        self.assertEqual(labels_list, expected_labels)
 
     @mock.patch('opencensus.common.monitored_resource.'
                 'aws_identity_doc_utils.get_request')
@@ -108,4 +108,4 @@ class TestAwsIdentityDocumentUtils(unittest.TestCase):
         labels_list = aws_identity_doc_utils.AwsIdentityDocumentUtils(
         ).get_aws_metadata()
 
-        self.assertEquals(len(labels_list), 0)
+        self.assertEqual(len(labels_list), 0)

--- a/tests/unit/common/monitored_resource_util/test_gcp_metadata_config.py
+++ b/tests/unit/common/monitored_resource_util/test_gcp_metadata_config.py
@@ -44,7 +44,7 @@ class TestGcpMetadataConfig(unittest.TestCase):
         labels_list = gcp_metadata_config.GcpMetadataConfig().get_gce_metadata(
         )
 
-        self.assertEquals(len(labels_list), 3)
+        self.assertEqual(len(labels_list), 3)
 
         expected_labels = {
             'instance_id': 'my-instance',
@@ -81,7 +81,7 @@ class TestGcpMetadataConfig(unittest.TestCase):
         labels_list = gcp_metadata_config.GcpMetadataConfig().get_gce_metadata(
         )
 
-        self.assertEquals(len(labels_list), 3)
+        self.assertEqual(len(labels_list), 3)
 
         expected_labels = {
             'instance_id': 'my-instance',
@@ -103,5 +103,5 @@ class TestGcpMetadataConfig(unittest.TestCase):
         self.assertFalse(
             gcp_metadata_config.GcpMetadataConfig.is_running_on_gcp())
 
-        self.assertEquals(
+        self.assertEqual(
             len(gcp_metadata_config.GcpMetadataConfig().get_gce_metadata()), 0)

--- a/tests/unit/trace/test_blank_span.py
+++ b/tests/unit/trace/test_blank_span.py
@@ -172,4 +172,4 @@ class TestBlankSpan(unittest.TestCase):
         span_name = 'root_span'
         with self._make_one(span_name) as s:
             self.assertIsNotNone(s)
-            self.assertEquals(s.name, span_name)
+            self.assertEqual(s.name, span_name)

--- a/tox.ini
+++ b/tox.ini
@@ -1,2 +1,0 @@
-[tox]
-envlist = py27


### PR DESCRIPTION
1. Instead of stick with the old version of test packages, always use the latest.
2. Remove tox.ini (still trying to figure out why do we need it).
3. Update test cases to resolve the deprecation warnings.