### PR TITLE
Use third party mock

### DIFF
--- a/tests/unit/common/monitored_resource_util/test_k8s_utils.py
+++ b/tests/unit/common/monitored_resource_util/test_k8s_utils.py
@@ -12,13 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import mock
-except ImportError:
-    from unittest import mock
-
 import os
 import unittest
+
+import mock
 
 from opencensus.common.monitored_resource import k8s_utils
 

--- a/tests/unit/common/monitored_resource_util/test_monitored_resource.py
+++ b/tests/unit/common/monitored_resource_util/test_monitored_resource.py
@@ -16,14 +16,14 @@ from contextlib import contextmanager
 import os
 import sys
 
+import mock
+
 from opencensus.common.monitored_resource import monitored_resource
 
 if sys.version_info < (3,):
     import unittest2 as unittest
-    import mock
 else:
     import unittest
-    from unittest import mock
 
 
 @contextmanager

--- a/tests/unit/common/test_resource.py
+++ b/tests/unit/common/test_resource.py
@@ -14,13 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import mock
-except ImportError:
-    from unittest import mock
-
 import os
 import unittest
+
+import mock
 
 from opencensus.common import resource as resource_module
 from opencensus.common.resource import Resource

--- a/tests/unit/log/test_log.py
+++ b/tests/unit/log/test_log.py
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 from contextlib import contextmanager
 import logging
+import sys
+
+import mock
 
 from opencensus import log
 
 if sys.version_info < (3,):
     import unittest2 as unittest
-    import mock
 else:
     import unittest
-    from unittest import mock
 
 
 @contextmanager

--- a/tests/unit/stats/test_metric_utils.py
+++ b/tests/unit/stats/test_metric_utils.py
@@ -12,13 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import mock
-except ImportError:
-    from unittest import mock
-
 import datetime
 import unittest
+
+import mock
 
 from opencensus.metrics.export import metric_descriptor
 from opencensus.metrics.export import point


### PR DESCRIPTION
Quick follow-up to #635: always use the third party `mock` package instead of `unittest.mock`. This gives us more consistent behavior across python versions.