### PR TITLE
Add details about aggregation pipelines & avoid get(default) parameter

### DIFF
--- a/contrib/opencensus-ext-pymongo/CHANGELOG.md
+++ b/contrib/opencensus-ext-pymongo/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Include aggregation pipeline in trace attributes
+
 ## 0.1.2
 Released 2019-04-24
 

--- a/contrib/opencensus-ext-pymongo/CHANGELOG.md
+++ b/contrib/opencensus-ext-pymongo/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Include aggregation pipeline in trace attributes
+- Fix support command dictionaries
 
 ## 0.1.2
 Released 2019-04-24

--- a/contrib/opencensus-ext-pymongo/opencensus/ext/pymongo/trace.py
+++ b/contrib/opencensus-ext-pymongo/opencensus/ext/pymongo/trace.py
@@ -51,7 +51,7 @@ class MongoCommandListener(monitoring.CommandListener):
         span.span_kind = span_module.SpanKind.CLIENT
 
         for attr in COMMAND_ATTRIBUTES:
-            _attr = event.command.get(attr, default=None)
+            _attr = event.command.get(attr)
             if _attr is not None:
                 self.tracer.add_attribute_to_current_span(attr, str(_attr))
 

--- a/contrib/opencensus-ext-pymongo/opencensus/ext/pymongo/trace.py
+++ b/contrib/opencensus-ext-pymongo/opencensus/ext/pymongo/trace.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 
 MODULE_NAME = 'pymongo'
 
-COMMAND_ATTRIBUTES = ['filter', 'sort', 'skip', 'limit']
+COMMAND_ATTRIBUTES = ['filter', 'sort', 'skip', 'limit', 'pipeline']
 
 
 def trace_integration(tracer=None):

--- a/contrib/opencensus-ext-pymongo/tests/test_pymongo_trace.py
+++ b/contrib/opencensus-ext-pymongo/tests/test_pymongo_trace.py
@@ -44,6 +44,7 @@ class Test_pymongo_trace(unittest.TestCase):
             'filter': 'filter',
             'sort': 'sort',
             'limit': 'limit',
+            'pipeline': 'pipeline',
             'command_name': 'find'
         }
 
@@ -51,6 +52,7 @@ class Test_pymongo_trace(unittest.TestCase):
             'filter': 'filter',
             'sort': 'sort',
             'limit': 'limit',
+            'pipeline': 'pipeline',
             'request_id': 'request_id',
             'connection_id': 'connection_id'
         }

--- a/contrib/opencensus-ext-pymongo/tests/test_pymongo_trace.py
+++ b/contrib/opencensus-ext-pymongo/tests/test_pymongo_trace.py
@@ -103,9 +103,8 @@ class MockCommand(object):
     def __init__(self, command_attrs):
         self.command_attrs = command_attrs
 
-    def get(self, key, default=None):
-        return self.command_attrs[key] \
-            if key in self.command_attrs else default
+    def get(self, key):
+        return self.command_attrs.get(key)
 
 
 class MockEvent(object):


### PR DESCRIPTION
When issuing aggregations via Pymongo, they store the pipeline as a command attribute.

This PR adds support for storing the pipeline as a trace attribute.

We've also seen the following errors in production with a Mongo `3.6.12` instance an Pymongo `3.6.1`.

```
Traceback (most recent call last): 
  File "<REDACTED>/.virtualenv/lib/python3.7/site-packages/pymongo-3.6.1-py3.7-linux-x86_64.egg/pymongo/monitoring.py", line 739, in publish_command_start 
    subscriber.started(event) 
  File "<REDACTED>/.virtualenv/lib/python3.7/site-packages/opencensus_ext_pymongo-0.1.2-py3.7.egg/opencensus/ext/pymongo/trace.py", line 54, in started 
    _attr = event.command.get(attr, default=None) 
TypeError: get() takes no keyword arguments 
```

It seems like not all `event.command` objects are `SON` instances (https://github.com/mongodb/mongo-python-driver/blob/master/bson/son.py#L32).

Since the `default` keyword argument isn't being used here, the default value is `None`, I opted to remove the use of it.