### PR TITLE
Add contribute message for python versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ information on using pull requests.
 Prerequisites:
 
 * You need to have Python installed.
-* You must have every version of Python that OpenCensus supports installed for testing (see https://pypi.org/project/opencensus/ for which versions are supported).
+* You must have every major version of Python that OpenCensus supports installed for testing (see https://pypi.org/project/opencensus/ for which versions are supported).
 * You need to fork the project in GitHub.
 
 Clone the upstream repo:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ information on using pull requests.
 Prerequisites:
 
 * You need to have Python installed.
+* You must have every version of Python that OpenCensus supports installed for testing (see https://pypi.org/project/opencensus/ for which versions are supported).
 * You need to fork the project in GitHub.
 
 Clone the upstream repo:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,7 @@ information on using pull requests.
 
 Prerequisites:
 
-* You need to have Python installed.
-* You must have every major version of Python that OpenCensus supports installed for testing (see https://pypi.org/project/opencensus/ for which versions are supported).
+* You must have every major version of Python that OpenCensus supports installed (see https://pypi.org/project/opencensus/ for which versions are supported).
 * You need to fork the project in GitHub.
 
 Clone the upstream repo:


### PR DESCRIPTION
nox automation tests will fail if any of the python versions currently supported by OpenCensus is not installed. Currently, these are python 2.7, 3.4, 3.5 and 3.6