### PR TITLE
Pin nox-automation, make noxfile explicit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ python:
   - '3.6'
 
 install:
-  - pip install --upgrade nox-automation
+  - pip install nox-automation==0.19.1
 
 script:
-  - nox -s docs
+  - nox -f nox.py -s docs
   - touch docs/.nojekyll
 
 branches:


### PR DESCRIPTION
Travis builds are [failing](https://travis-ci.org/census-instrumentation/opencensus-python/builds/532095229) because it looks like the [`2019.5.13` `nox-automation` release](https://pypi.org/project/nox-automation/2019.5.13/) also installs `nox`, which gives us the wrong executable.
