### PR TITLE
Move logging integration into ext package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -189,6 +189,7 @@ OpenCensus supports integration with popular web frameworks, client libraries an
 -  `Google Cloud Client Libraries`_
 -  `gRPC`_
 -  `httplib`_
+-  `logging`_
 -  `MySQL`_
 -  `PostgreSQL`_
 -  `pymongo`_
@@ -222,6 +223,7 @@ Stats Exporter
 .. _gRPC: https://github.com/census-instrumentation/opencensus-python/tree/master/contrib/opencensus-ext-grpc
 .. _httplib: https://github.com/census-instrumentation/opencensus-python/tree/master/contrib/opencensus-ext-httplib
 .. _Jaeger: https://github.com/census-instrumentation/opencensus-python/tree/master/contrib/opencensus-ext-jaeger
+.. _logging: https://github.com/census-instrumentation/opencensus-python/tree/master/contrib/opencensus-ext-logging
 .. _MySQL: https://github.com/census-instrumentation/opencensus-python/tree/master/contrib/opencensus-ext-mysql
 .. _OCAgent: https://github.com/census-instrumentation/opencensus-python/tree/master/contrib/opencensus-ext-ocagent
 .. _PostgreSQL: https://github.com/census-instrumentation/opencensus-python/tree/master/contrib/opencensus-ext-postgresql

--- a/contrib/opencensus-ext-logging/CHANGELOG.md
+++ b/contrib/opencensus-ext-logging/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## Unreleased
+- Initial version

--- a/contrib/opencensus-ext-logging/README.rst
+++ b/contrib/opencensus-ext-logging/README.rst
@@ -25,7 +25,7 @@ Usage
     from opencensus.trace.tracer import Tracer
 
     config_integration.trace_integrations(['logging'])
-    logging.basicConfig(format='%(asctime)-15s traceId=%(traceId)s spanId=%(spanId)s %(message)s')
+    logging.basicConfig(format='%(asctime)s traceId=%(traceId)s spanId=%(spanId)s %(message)s')
     tracer = Tracer(sampler=AlwaysOffSampler())
 
     logger = logging.getLogger(__name__)

--- a/contrib/opencensus-ext-logging/README.rst
+++ b/contrib/opencensus-ext-logging/README.rst
@@ -1,0 +1,41 @@
+OpenCensus logging Integration
+============================================================================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opencensus-ext-logging.svg
+   :target: https://pypi.org/project/opencensus-ext-logging/
+
+Installation
+------------
+
+::
+
+    pip install opencensus-ext-logging
+
+Usage
+-----
+
+.. code:: python
+
+    import logging
+
+    from opencensus.trace import config_integration
+    from opencensus.trace.samplers import AlwaysOffSampler
+    from opencensus.trace.tracer import Tracer
+
+    config_integration.trace_integrations(['logging'])
+    logging.basicConfig(format='%(asctime)-15s traceId=%(traceId)s spanId=%(spanId)s %(message)s')
+    tracer = Tracer(sampler=AlwaysOffSampler())
+
+    logger = logging.getLogger(__name__)
+    logger.warning('Before the span')
+    with tracer.span(name='hello'):
+        logger.warning('In the span')
+    logger.warning('After the span')
+
+
+References
+----------
+
+* `OpenCensus Project <https://opencensus.io/>`_

--- a/contrib/opencensus-ext-logging/opencensus/__init__.py
+++ b/contrib/opencensus-ext-logging/opencensus/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/contrib/opencensus-ext-logging/opencensus/ext/__init__.py
+++ b/contrib/opencensus-ext-logging/opencensus/ext/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/contrib/opencensus-ext-logging/opencensus/ext/logging/__init__.py
+++ b/contrib/opencensus-ext-logging/opencensus/ext/logging/__init__.py
@@ -12,22 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-import unittest
+from opencensus.ext.logging import trace
 
-from opencensus.trace import config_integration
-
-
-class TestLoggingIntegration(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls._old_logger_class = logging.getLoggerClass()
-
-    @classmethod
-    def tearDownClass(cls):
-        logging.setLoggerClass(cls._old_logger_class)
-
-    def test_integration(self):
-        self.assertEqual(self._old_logger_class, logging.getLoggerClass())
-        config_integration.trace_integrations(['logging'])
-        self.assertNotEqual(self._old_logger_class, logging.getLoggerClass())
+__all__ = ['trace']

--- a/contrib/opencensus-ext-logging/opencensus/ext/logging/trace.py
+++ b/contrib/opencensus-ext-logging/opencensus/ext/logging/trace.py
@@ -1,0 +1,27 @@
+# Copyright 2017, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from opencensus.log import TraceLogger
+
+
+def trace_integration(tracer=None):
+    """Replace the global default logging class with `TraceLogger`.
+
+    Loggers created after the integration will produce `LogRecord`s
+    with extra traceId, spanId, and traceSampled attributes from the opencensus
+    context.
+    """
+    logging.setLoggerClass(TraceLogger)

--- a/contrib/opencensus-ext-logging/setup.cfg
+++ b/contrib/opencensus-ext-logging/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/contrib/opencensus-ext-logging/setup.py
+++ b/contrib/opencensus-ext-logging/setup.py
@@ -1,0 +1,50 @@
+# Copyright 2019, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from setuptools import find_packages
+from setuptools import setup
+from version import __version__
+
+setup(
+    name='opencensus-ext-logging',
+    version=__version__,  # noqa
+    author='OpenCensus Authors',
+    author_email='census-developers@googlegroups.com',
+    classifiers=[
+        'Intended Audience :: Developers',
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+    ],
+    description='OpenCensus logging Integration',
+    include_package_data=True,
+    long_description=open('README.rst').read(),
+    install_requires=[
+        'opencensus >= 0.6.dev0, < 1.0.0',
+    ],
+    extras_require={},
+    license='Apache-2.0',
+    packages=find_packages(exclude=('tests',)),
+    namespace_packages=[],
+    url='https://github.com/census-instrumentation/opencensus-python/tree/master/contrib/opencensus-ext-logging',  # noqa: E501
+    zip_safe=False,
+)

--- a/contrib/opencensus-ext-logging/tests/test_logging_integration.py
+++ b/contrib/opencensus-ext-logging/tests/test_logging_integration.py
@@ -1,0 +1,34 @@
+# Copyright 2017, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import mock
+import unittest
+
+from opencensus.trace import config_integration
+
+
+class TestLoggingIntegration(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._old_logger_class = logging.getLoggerClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        logging.setLoggerClass(cls._old_logger_class)
+
+    def test_integration(self):
+        self.assertEqual(self._old_logger_class, logging.getLoggerClass())
+        config_integration.trace_integrations(['logging'])
+        self.assertNotEqual(self._old_logger_class, logging.getLoggerClass())

--- a/contrib/opencensus-ext-logging/version.py
+++ b/contrib/opencensus-ext-logging/version.py
@@ -1,0 +1,15 @@
+# Copyright 2019, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = '0.1.dev0'

--- a/noxfile.py
+++ b/noxfile.py
@@ -31,6 +31,7 @@ def _install_dev_packages(session):
     session.install('-e', 'contrib/opencensus-ext-grpc')
     session.install('-e', 'contrib/opencensus-ext-httplib')
     session.install('-e', 'contrib/opencensus-ext-jaeger')
+    session.install('-e', 'contrib/opencensus-ext-logging')
     session.install('-e', 'contrib/opencensus-ext-mysql')
     session.install('-e', 'contrib/opencensus-ext-ocagent')
     session.install('-e', 'contrib/opencensus-ext-postgresql')

--- a/opencensus/log/__init__.py
+++ b/opencensus/log/__init__.py
@@ -114,13 +114,3 @@ class TraceLogger(logging.getLoggerClass()):
                 kwargs['extra'] = extra
         _set_extra_attrs(extra)
         return super(TraceLogger, self).makeRecord(*args, **kwargs)
-
-
-def use_oc_logging():
-    """Replace the global default logging class with `TraceLogger`.
-
-    Loggers created after calling `use_oc_logging` will produce `LogRecord`s
-    with extra traceId, spanId, and traceSampled attributes from the opencensus
-    context.
-    """
-    logging.setLoggerClass(TraceLogger)

--- a/tests/unit/log/test_log.py
+++ b/tests/unit/log/test_log.py
@@ -97,7 +97,7 @@ class TestTraceLogger(unittest.TestCase):
     def setUpClass(cls):
         cls._old_logger_names = get_logger_names()
         cls._old_logger_class = logging.getLoggerClass()
-        log.use_oc_logging()
+        logging.setLoggerClass(log.TraceLogger)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
This is part of the #616 effort.

With this change, the integration is more consistent:

```python
config_integration.trace_integrations(['logging'])
```