### PR TITLE
Use httplib's host property instead of urllib3's _dns_host

### DIFF
--- a/contrib/opencensus-ext-httplib/opencensus/ext/httplib/trace.py
+++ b/contrib/opencensus-ext-httplib/opencensus/ext/httplib/trace.py
@@ -64,7 +64,7 @@ def wrap_httplib_request(request_func):
         _tracer = execution_context.get_opencensus_tracer()
         blacklist_hostnames = execution_context.get_opencensus_attr(
             'blacklist_hostnames')
-        dest_url = '{}:{}'.format(self._dns_host, self.port)
+        dest_url = '{}:{}'.format(self.host, self.port)
         if utils.disable_tracing_hostname(dest_url, blacklist_hostnames):
             return request_func(self, method, url, body,
                                 headers, *args, **kwargs)

--- a/contrib/opencensus-ext-httplib/tests/test_httplib_trace.py
+++ b/contrib/opencensus-ext-httplib/tests/test_httplib_trace.py
@@ -150,10 +150,10 @@ class Test_httplib_trace(unittest.TestCase):
         wrapped = trace.wrap_httplib_request(mock_request_func)
 
         mock_self = mock.Mock()
-        mock_self._dns_host = 'localhost'
+        mock_self.host = 'localhost'
         mock_self.port = '8080'
         method = 'GET'
-        url = 'http://{}:{}'.format(mock_self._dns_host, mock_self.port)
+        url = 'http://{}:{}'.format(mock_self.host, mock_self.port)
         body = None
         headers = {}
 


### PR DESCRIPTION
The httplib extension references `_dns_host` which is typically used with urllib3, not httplib.  This means `HTTPConnection` mixins that do not implement a `_dns_host` property will fail with an `AttributeError` (encountered this with [boto](https://github.com/boto/botocore/blob/14e0eab5c1e4aec437c3e558e6899de00fd5e98e/botocore/awsrequest.py#L98)).  

From the [urllib3 source code](https://github.com/urllib3/urllib3/blob/master/src/urllib3/connection.py#L137-L144):
> We assume that only urllib3 uses the `_dns_host` attribute; httplib itself only uses `host`, and it seems reasonable that other libraries follow suit.

The urllib3 implementation provides [getters and setters](https://github.com/urllib3/urllib3/blob/master/src/urllib3/connection.py#L117-L144) for `host` that use `_dns_host`, so switching to `host` should have no effect on working integrations.