### PR TITLE
Add Python 3.7 for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 dist: xenial
+
 language: python
 
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: xenial
-
 language: python
 
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 
 python:
@@ -5,6 +6,7 @@ python:
   - '3.4'
   - '3.5'
   - '3.6'
+  - '3.7'
 
 install:
   - pip install tox-travis
@@ -16,12 +18,3 @@ script:
 branches:
   only:
     - master
-
-deploy:
-  provider: pages
-  local_dir: docs
-  skip_cleanup: true
-  email: yanhuil@google.com # To satisfy the CLA check, replace this with bot email.
-  github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
-  on:
-    branch: master

--- a/tox.ini
+++ b/tox.ini
@@ -1,55 +1,55 @@
 [tox]
-envlist = py{27,34,35,36}-unit, py36-lint, py36-setup, py{27,34,35,36}-cover, py36-docs
+envlist = py{27,34,35,36,37}-unit, py37-lint, py37-setup, py{27,34,35,36,37}-cover, py37-docs
 
 [testenv]
 install_command = python -m pip install {opts} {packages}
 
 deps = 
-  py{27,34,35,36}-unit,py36-lint: mock
-  py{27,34,35,36}-unit,py36-lint: pytest
-  py{27,34,35,36}-unit,py36-lint: pytest-cov
-  py{27,34,35,36}-unit,py36-lint: retrying
-  py{27,34,35,36}-unit,py36-lint: unittest2
-  py{27,34,35,36}-unit,py36-lint,py36-setup,py{27,34,35,36}-cover,py36-docs: -e context/opencensus-context
-  py{27,34,35,36}-unit,py36-lint,py36-docs: -e contrib/opencensus-correlation
-  py{27,34,35,36}-unit,py36-lint,py36-docs: -e .
-  py{27,34,35,36}-unit,py36-lint: -e contrib/opencensus-ext-azure
-  py{27,34,35,36}-unit,py36-lint: -e contrib/opencensus-ext-dbapi
-  py{27,34,35,36}-unit,py36-lint: -e contrib/opencensus-ext-django
-  py{27,34,35,36}-unit,py36-lint: -e contrib/opencensus-ext-flask
-  py{27,34,35,36}-unit,py36-lint: -e contrib/opencensus-ext-gevent
-  py{27,34,35,36}-unit,py36-lint: -e contrib/opencensus-ext-grpc
-  py{27,34,35,36}-unit,py36-lint: -e contrib/opencensus-ext-httplib
-  py{27,34,35,36}-unit,py36-lint: -e contrib/opencensus-ext-jaeger
-  py{27,34,35,36}-unit,py36-lint: -e contrib/opencensus-ext-logging
-  py{27,34,35,36}-unit,py36-lint: -e contrib/opencensus-ext-mysql
-  py{27,34,35,36}-unit,py36-lint: -e contrib/opencensus-ext-ocagent
-  py{27,34,35,36}-unit,py36-lint: -e contrib/opencensus-ext-postgresql
-  py{27,34,35,36}-unit,py36-lint: -e contrib/opencensus-ext-prometheus
-  py{27,34,35,36}-unit,py36-lint: -e contrib/opencensus-ext-pymongo
-  py{27,34,35,36}-unit,py36-lint: -e contrib/opencensus-ext-pymysql
-  py{27,34,35,36}-unit,py36-lint: -e contrib/opencensus-ext-pyramid
-  py{27,34,35,36}-unit,py36-lint: -e contrib/opencensus-ext-requests
-  py{27,34,35,36}-unit,py36-lint: -e contrib/opencensus-ext-sqlalchemy
-  py{27,34,35,36}-unit,py36-lint: -e contrib/opencensus-ext-stackdriver
-  py{27,34,35,36}-unit,py36-lint: -e contrib/opencensus-ext-threading
-  py{27,34,35,36}-unit,py36-lint: -e contrib/opencensus-ext-zipkin
-  py{27,34,35,36}-unit,py36-lint: -e contrib/opencensus-ext-google-cloud-clientlibs
-  py36-lint: flake8
-  py36-setup: docutils
-  py36-setup: pygments
-  py{27,34,35,36}-cover: coverage
-  py{27,34,35,36}-cover: pytest-cov
-  py36-docs: setuptools >= 36.4.0
-  py36-docs: sphinx >= 1.6.3
+  py{27,34,35,36,37}-unit,py37-lint: mock
+  py{27,34,35,36,37}-unit,py37-lint: pytest
+  py{27,34,35,36,37}-unit,py37-lint: pytest-cov
+  py{27,34,35,36,37}-unit,py37-lint: retrying
+  py{27,34,35,36,37}-unit,py37-lint: unittest2
+  py{27,34,35,36,37}-unit,py37-lint,py37-setup,py{27,34,35,36,37}-cover,py37-docs: -e context/opencensus-context
+  py{27,34,35,36,37}-unit,py37-lint,py37-docs: -e contrib/opencensus-correlation
+  py{27,34,35,36,37}-unit,py37-lint,py37-docs: -e .
+  py{27,34,35,36,37}-unit,py37-lint: -e contrib/opencensus-ext-azure
+  py{27,34,35,36,37}-unit,py37-lint: -e contrib/opencensus-ext-dbapi
+  py{27,34,35,36,37}-unit,py37-lint: -e contrib/opencensus-ext-django
+  py{27,34,35,36,37}-unit,py37-lint: -e contrib/opencensus-ext-flask
+  py{27,34,35,36,37}-unit,py37-lint: -e contrib/opencensus-ext-gevent
+  py{27,34,35,36,37}-unit,py37-lint: -e contrib/opencensus-ext-grpc
+  py{27,34,35,36,37}-unit,py37-lint: -e contrib/opencensus-ext-httplib
+  py{27,34,35,36,37}-unit,py37-lint: -e contrib/opencensus-ext-jaeger
+  py{27,34,35,36,37}-unit,py37-lint: -e contrib/opencensus-ext-logging
+  py{27,34,35,36,37}-unit,py37-lint: -e contrib/opencensus-ext-mysql
+  py{27,34,35,36,37}-unit,py37-lint: -e contrib/opencensus-ext-ocagent
+  py{27,34,35,36,37}-unit,py37-lint: -e contrib/opencensus-ext-postgresql
+  py{27,34,35,36,37}-unit,py37-lint: -e contrib/opencensus-ext-prometheus
+  py{27,34,35,36,37}-unit,py37-lint: -e contrib/opencensus-ext-pymongo
+  py{27,34,35,36,37}-unit,py37-lint: -e contrib/opencensus-ext-pymysql
+  py{27,34,35,36,37}-unit,py37-lint: -e contrib/opencensus-ext-pyramid
+  py{27,34,35,36,37}-unit,py37-lint: -e contrib/opencensus-ext-requests
+  py{27,34,35,36,37}-unit,py37-lint: -e contrib/opencensus-ext-sqlalchemy
+  py{27,34,35,36,37}-unit,py37-lint: -e contrib/opencensus-ext-stackdriver
+  py{27,34,35,36,37}-unit,py37-lint: -e contrib/opencensus-ext-threading
+  py{27,34,35,36,37}-unit,py37-lint: -e contrib/opencensus-ext-zipkin
+  py{27,34,35,36,37}-unit,py37-lint: -e contrib/opencensus-ext-google-cloud-clientlibs
+  py37-lint: flake8
+  py37-setup: docutils
+  py37-setup: pygments
+  py{27,34,35,36,37}-cover: coverage
+  py{27,34,35,36,37}-cover: pytest-cov
+  py37-docs: setuptools >= 36.4.0
+  py37-docs: sphinx >= 1.6.3
 
 commands = 
-  py{27,34,35,36}-unit: py.test --quiet --cov={envdir}/opencensus --cov=context --cov=contrib --cov-report= --cov-config=.coveragerc --cov-fail-under=97 tests/unit/ context/ contrib/
+  py{27,34,35,36,37}-unit: py.test --quiet --cov={envdir}/opencensus --cov=context --cov=contrib --cov-report= --cov-config=.coveragerc --cov-fail-under=97 tests/unit/ context/ contrib/
   ; TODO: System tests
-  py36-lint: flake8 context/ contrib/ opencensus/ tests/ examples/
-  py36-setup: python setup.py check --restructuredtext --strict
-  py{27,34,35,36}-cover: coverage report --show-missing --fail-under=97
-  py{27,34,35,36}-cover: coverage erase
-  py36-docs: bash ./scripts/update_docs.sh
+  py37-lint: flake8 context/ contrib/ opencensus/ tests/ examples/
+  py37-setup: python setup.py check --restructuredtext --strict
+  py{27,34,35,36,37}-cover: coverage report --show-missing --fail-under=97
+  py{27,34,35,36,37}-cover: coverage erase
+  py37-docs: bash ./scripts/update_docs.sh
   ; TODO deployment
 


### PR DESCRIPTION
Include an environment in which tests run for Python 3.7 under Travis.

@reyang @c24t 