### PR TITLE
Azure log exporter

### DIFF
--- a/contrib/opencensus-ext-azure/CHANGELOG.md
+++ b/contrib/opencensus-ext-azure/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 - Added log exporter
-  ([#657](https://github.com/census-instrumentation/opencensus-python/pull/657))
-  ([#668](https://github.com/census-instrumentation/opencensus-python/pull/668))
+  ([#657](https://github.com/census-instrumentation/opencensus-python/pull/657),
+  [#668](https://github.com/census-instrumentation/opencensus-python/pull/668))
 - Added persistent storage support
   ([#640](https://github.com/census-instrumentation/opencensus-python/pull/640))
 - Changed AzureExporter constructor signature to use kwargs

--- a/contrib/opencensus-ext-azure/CHANGELOG.md
+++ b/contrib/opencensus-ext-azure/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Added log exporter
   ([#657](https://github.com/census-instrumentation/opencensus-python/pull/657))
+  ([#668](https://github.com/census-instrumentation/opencensus-python/pull/668))
 - Added persistent storage support
   ([#640](https://github.com/census-instrumentation/opencensus-python/pull/640))
 - Changed AzureExporter constructor signature to use kwargs

--- a/contrib/opencensus-ext-azure/examples/logs/error.py
+++ b/contrib/opencensus-ext-azure/examples/logs/error.py
@@ -23,7 +23,7 @@ logger.addHandler(AzureLogHandler())
 
 def main():
     try:
-        n = 1 / 0  # generate a ZeroDivisionError
+        return 1 / 0  # generate a ZeroDivisionError
     except:
         logger.exception('Captured an exception.')
 

--- a/contrib/opencensus-ext-azure/examples/logs/error.py
+++ b/contrib/opencensus-ext-azure/examples/logs/error.py
@@ -21,11 +21,13 @@ logger = logging.getLogger(__name__)
 # APPINSIGHTS_INSTRUMENTATIONKEY environment variable.
 logger.addHandler(AzureLogHandler())
 
+
 def main():
     try:
         return 1 / 0  # generate a ZeroDivisionError
-    except:
+    except Exception:
         logger.exception('Captured an exception.')
+
 
 if __name__ == '__main__':
     main()

--- a/contrib/opencensus-ext-azure/examples/logs/global_exception_handler.py
+++ b/contrib/opencensus-ext-azure/examples/logs/global_exception_handler.py
@@ -20,7 +20,12 @@ logger = logging.getLogger(__name__)
 # TODO: you need to specify the instrumentation key in the
 # APPINSIGHTS_INSTRUMENTATIONKEY environment variable.
 logger.addHandler(AzureLogHandler())
-try:
-    raise Exception('Hello from exception.')
-except:
-    logger.exception('Got an exception.')
+
+def main():
+    try:
+        n = 1 / 0  # generate a ZeroDivisionError
+    except:
+        logger.exception('Captured an exception.')
+
+if __name__ == '__main__':
+    main()

--- a/contrib/opencensus-ext-azure/examples/logs/global_exception_handler.py
+++ b/contrib/opencensus-ext-azure/examples/logs/global_exception_handler.py
@@ -15,23 +15,12 @@
 import logging
 
 from opencensus.ext.azure.log_exporter import AzureLogHandler
-from opencensus.ext.azure.trace_exporter import AzureExporter
-from opencensus.trace import config_integration
-from opencensus.trace.samplers import ProbabilitySampler
-from opencensus.trace.tracer import Tracer
-
-config_integration.trace_integrations(['logging'])
 
 logger = logging.getLogger(__name__)
-
 # TODO: you need to specify the instrumentation key in the
 # APPINSIGHTS_INSTRUMENTATIONKEY environment variable.
-handler = AzureLogHandler()
-logger.addHandler(handler)
-
-tracer = Tracer(exporter=AzureExporter(), sampler=ProbabilitySampler(1.0))
-
-logger.warning('Before the span')
-with tracer.span(name='test'):
-    logger.warning('In the span')
-logger.warning('After the span')
+logger.addHandler(AzureLogHandler())
+try:
+    raise Exception('Hello from exception.')
+except:
+    logger.exception('Got an exception.')

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
@@ -15,11 +15,11 @@
 import os
 import sys
 
-from opencensus.ext.azure.common.protocol import Object
+from opencensus.ext.azure.common.protocol import BaseObject
 
 
-class Options(Object):
-    prototype = Object(
+class Options(BaseObject):
+    _default = BaseObject(
         endpoint='https://dc.services.visualstudio.com/v2/track',
         export_interval=15.0,
         grace_period=5.0,

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/protocol.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/protocol.py
@@ -36,10 +36,10 @@ class BaseObject(dict):
     def __getattr__(self, name):
         try:
             return self[name]
-        except KeyError as ex:
+        except KeyError:
             raise AttributeError("'{}' object has no attribute {}".format(
                 type(self).__name__,
-                ex,
+                name,
             ))
 
     def __getitem__(self, key):

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/protocol.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/protocol.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 
-class Object(dict):
+class BaseObject(dict):
     def __init__(self, *args, **kwargs):
-        super(Object, self).__init__(*args, **kwargs)
+        super(BaseObject, self).__init__(*args, **kwargs)
         for key in kwargs:
             self[key] = kwargs[key]
 
@@ -25,9 +25,9 @@ class Object(dict):
             for item in self.items():
                 if item[0] not in tmp:
                     tmp[item[0]] = item[1]
-            if self.prototype == self:
+            if self._default == self:
                 break
-            self = self.prototype
+            self = self._default
         return repr(tmp)
 
     def __setattr__(self, name, value):
@@ -43,18 +43,18 @@ class Object(dict):
             ))
 
     def __getitem__(self, key):
-        if self.prototype is self:
-            return super(Object, self).__getitem__(key)
+        if self._default is self:
+            return super(BaseObject, self).__getitem__(key)
         if key in self:
-            return super(Object, self).__getitem__(key)
-        return self.prototype[key]
+            return super(BaseObject, self).__getitem__(key)
+        return self._default[key]
 
 
-Object.prototype = Object()
+BaseObject._default = BaseObject()
 
 
-class Data(Object):
-    prototype = Object(
+class Data(BaseObject):
+    _default = BaseObject(
         baseData=None,
         baseType=None,
     )
@@ -65,8 +65,8 @@ class Data(Object):
         self.baseType = self.baseType
 
 
-class Envelope(Object):
-    prototype = Object(
+class Envelope(BaseObject):
+    _default = BaseObject(
         ver=1,
         name='',
         time='',
@@ -84,8 +84,8 @@ class Envelope(Object):
         self.time = self.time
 
 
-class Event(Object):
-    prototype = Object(
+class Event(BaseObject):
+    _default = BaseObject(
         ver=2,
         name='',
         properties=None,
@@ -98,8 +98,8 @@ class Event(Object):
         self.name = self.name
 
 
-class Message(Object):
-    prototype = Object(
+class Message(BaseObject):
+    _default = BaseObject(
         ver=2,
         message='',
         severityLevel=None,
@@ -113,8 +113,8 @@ class Message(Object):
         self.message = self.message
 
 
-class RemoteDependency(Object):
-    prototype = Object(
+class RemoteDependency(BaseObject):
+    _default = BaseObject(
         ver=2,
         name='',
         id='',
@@ -136,8 +136,8 @@ class RemoteDependency(Object):
         self.duration = self.duration
 
 
-class Request(Object):
-    prototype = Object(
+class Request(BaseObject):
+    _default = BaseObject(
         ver=2,
         id='',
         duration='',

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/protocol.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/protocol.py
@@ -98,6 +98,22 @@ class Event(BaseObject):
         self.name = self.name
 
 
+class ExceptionData(BaseObject):
+    _default = BaseObject(
+        ver=2,
+        exceptions=[],
+        severityLevel=None,
+        problemId=None,
+        properties=None,
+        measurements=None,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super(ExceptionData, self).__init__(*args, **kwargs)
+        self.ver = self.ver
+        self.exceptions = self.exceptions
+
+
 class Message(BaseObject):
     _default = BaseObject(
         ver=2,

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/transport.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/transport.py
@@ -24,6 +24,8 @@ logger = logging.getLogger(__name__)
 class TransportMixin(object):
     def _transmit_from_storage(self):
         for blob in self.storage.gets():
+            # give a few more seconds for blob lease operation
+            # to reduce the chance of race (for perf consideration)
             if blob.lease(self.options.timeout + 5):
                 envelopes = blob.get()  # TODO: handle error
                 result = self._transmit(envelopes)

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/transport.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/transport.py
@@ -1,0 +1,133 @@
+# Copyright 2019, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+import requests
+
+from opencensus.trace import execution_context
+
+logger = logging.getLogger(__name__)
+
+
+class TransportMixin(object):
+    def _transmit_from_storage(self):
+        for blob in self.storage.gets():
+            if blob.lease(self.options.timeout + 5):
+                envelopes = blob.get()  # TODO: handle error
+                result = self._transmit(envelopes)
+                if result > 0:
+                    blob.lease(result)
+                else:
+                    blob.delete(silent=True)
+
+    def _transmit(self, envelopes):
+        """
+        Transmit the data envelopes to the ingestion service.
+        Return a negative value for partial success or non-retryable failure.
+        Return 0 if all envelopes have been successfully ingested.
+        Return the next retry time in seconds for retryable failure.
+        This function should never throw exception.
+        """
+        # TODO: prevent requests being tracked
+        blacklist_hostnames = execution_context.get_opencensus_attr(
+            'blacklist_hostnames',
+        )
+        execution_context.set_opencensus_attr(
+            'blacklist_hostnames',
+            ['dc.services.visualstudio.com'],
+        )
+        try:
+            response = requests.post(
+                url=self.options.endpoint,
+                data=json.dumps(envelopes),
+                headers={
+                    'Accept': 'application/json',
+                    'Content-Type': 'application/json; charset=utf-8',
+                },
+                timeout=self.options.timeout,
+            )
+        except Exception as ex:  # TODO: consider RequestException
+            logger.warning('Transient client side error %s.', ex)
+            # client side error (retryable)
+            return self.options.minimum_retry_interval
+        finally:
+            execution_context.set_opencensus_attr(
+                'blacklist_hostnames',
+                blacklist_hostnames,
+            )
+        text = 'N/A'
+        data = None
+        try:
+            text = response.text
+        except Exception as ex:
+            logger.warning('Error while reading response body %s.', ex)
+        else:
+            try:
+                data = json.loads(text)
+            except Exception:
+                pass
+        if response.status_code == 200:
+            logger.info('Transmission succeeded: %s.', text)
+            return 0
+        if response.status_code == 206:  # Partial Content
+            # TODO: store the unsent data
+            if data:
+                try:
+                    resend_envelopes = []
+                    for error in data['errors']:
+                        if error['statusCode'] in (
+                                429,  # Too Many Requests
+                                500,  # Internal Server Error
+                                503,  # Service Unavailable
+                        ):
+                            resend_envelopes.append(envelopes[error['index']])
+                        else:
+                            logger.error(
+                                'Data drop %s: %s %s.',
+                                error['statusCode'],
+                                error['message'],
+                                envelopes[error['index']],
+                            )
+                    if resend_envelopes:
+                        self.storage.put(resend_envelopes)
+                except Exception as ex:
+                    logger.error(
+                        'Error while processing %s: %s %s.',
+                        response.status_code,
+                        text,
+                        ex,
+                    )
+                return -response.status_code
+            # cannot parse response body, fallback to retry
+        if response.status_code in (
+                206,  # Partial Content
+                429,  # Too Many Requests
+                500,  # Internal Server Error
+                503,  # Service Unavailable
+        ):
+            logger.warning(
+                'Transient server side error %s: %s.',
+                response.status_code,
+                text,
+            )
+            # server side error (retryable)
+            return self.options.minimum_retry_interval
+        logger.error(
+            'Non-retryable server side error %s: %s.',
+            response.status_code,
+            text,
+        )
+        # server side error (non-retryable)
+        return -response.status_code

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/utils.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 import locale
 import os
 import platform
@@ -24,6 +25,7 @@ except ImportError:
 
 from opencensus.common.version import __version__ as opencensus_version
 from opencensus.common.utils import timestamp_to_microseconds
+from opencensus.common.utils import to_iso_str
 from opencensus.ext.azure.common.version import __version__ as ext_version
 
 azure_monitor_context = {
@@ -55,6 +57,10 @@ def timestamp_to_duration(start_time, end_time):
     end_time_us = timestamp_to_microseconds(end_time)
     duration_us = int(end_time_us - start_time_us)
     return microseconds_to_duration(duration_us)
+
+
+def timestamp_to_iso_str(timestamp):
+    return to_iso_str(datetime.datetime.utcfromtimestamp(timestamp))
 
 
 def url_to_dependency_name(url):

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/log_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/log_exporter/__init__.py
@@ -93,7 +93,7 @@ class Worker(threading.Thread):
             except Exception:
                 logger.exception('Unhandled exception from exporter.')
 
-    def stop(self, timeout=None):
+    def stop(self, timeout=None):  # pragma: NO COVER
         start_time = time.time()
         wait_time = timeout
         if self.is_alive() and not self._stopping:
@@ -129,7 +129,7 @@ class AzureLogHandler(TransportMixin, BaseLogHandler):
         self.storage.close()
         super(AzureLogHandler, self).close()
 
-    def _export(self, batch, event=None):
+    def _export(self, batch, event=None):  # pragma: NO COVER
         try:
             if batch:
                 envelopes = [self.log_record_to_envelope(x) for x in batch]

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/log_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/log_exporter/__init__.py
@@ -58,7 +58,7 @@ class BaseLogHandler(logging.Handler):
                 event.set()
 
     def export(self, batch):
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: NO COVER
 
     def flush(self, timeout=None):
         self._queue.flush(timeout=timeout)
@@ -87,8 +87,7 @@ class Worker(threading.Thread):
                     logger.exception('Unhandled exception from exporter.')
                 if batch[-1] is src.EXIT_EVENT:
                     break
-                else:
-                    continue
+                continue  # pragma: NO COVER
             try:
                 dst._export(batch)
             except Exception:

--- a/contrib/opencensus-ext-azure/tests/test_azure_log_exporter.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_log_exporter.py
@@ -1,0 +1,130 @@
+# Copyright 2019, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import mock
+import os
+import shutil
+import unittest
+
+from opencensus.ext.azure import log_exporter
+
+TEST_FOLDER = os.path.abspath('.test.logs')
+
+
+def setUpModule():
+    os.makedirs(TEST_FOLDER)
+
+
+def tearDownModule():
+    shutil.rmtree(TEST_FOLDER)
+
+
+def throw(exc_type, *args, **kwargs):
+    def func(*_args, **_kwargs):
+        raise exc_type(*args, **kwargs)
+    return func
+
+
+class CustomLogHandler(log_exporter.BaseLogHandler):
+    def __init__(self, max_batch_size, callback):
+        self.export_interval = 1
+        self.max_batch_size = max_batch_size
+        self.callback = callback
+        super(CustomLogHandler, self).__init__()
+
+    def export(self, batch):
+        return self.callback(batch)
+
+
+class TestBaseLogHandler(unittest.TestCase):
+    def test_basic(self):
+        logger = logging.getLogger(self.id())
+        handler = CustomLogHandler(10, lambda batch: None)
+        logger.addHandler(handler)
+        logger.warning('TEST')
+        handler.flush()
+        logger.warning('TEST')
+        logger.removeHandler(handler)
+        handler.close()
+
+    def test_export_exception(self):
+        logger = logging.getLogger(self.id())
+        handler = CustomLogHandler(1, throw(Exception))
+        logger.addHandler(handler)
+        logger.warning('TEST')
+        logger.removeHandler(handler)
+        handler.flush()
+        handler.close()
+
+
+class TestAzureLogHandler(unittest.TestCase):
+    def test_ctor(self):
+        from opencensus.ext.azure.common import Options
+        instrumentation_key = Options._default.instrumentation_key
+        Options._default.instrumentation_key = None
+        self.assertRaises(ValueError, lambda: log_exporter.AzureLogHandler())
+        Options._default.instrumentation_key = instrumentation_key
+
+    @mock.patch('requests.post', return_value=mock.Mock())
+    def test_exception(self, requests_mock):
+        logger = logging.getLogger(self.id())
+        handler = log_exporter.AzureLogHandler(
+            instrumentation_key='12345678-1234-5678-abcd-12345678abcd',
+            storage_path=os.path.join(TEST_FOLDER, self.id()),
+        )
+        logger.addHandler(handler)
+        try:
+            return 1 / 0  # generate a ZeroDivisionError
+        except Exception:
+            logger.exception('Captured an exception.')
+        handler.close()
+
+    @mock.patch('requests.post', return_value=mock.Mock())
+    def test_export_empty(self, request_mock):
+        handler = log_exporter.AzureLogHandler(
+            instrumentation_key='12345678-1234-5678-abcd-12345678abcd',
+            storage_path=os.path.join(TEST_FOLDER, self.id()),
+        )
+        handler._export([])
+        self.assertEqual(len(os.listdir(handler.storage.path)), 0)
+        handler.close()
+
+    @mock.patch('opencensus.ext.azure.log_exporter.AzureLogHandler.log_record_to_envelope')  # noqa: E501
+    def test_export_failure(self, log_record_to_envelope_mock):
+        log_record_to_envelope_mock.return_value = ['bar']
+        handler = log_exporter.AzureLogHandler(
+            instrumentation_key='12345678-1234-5678-abcd-12345678abcd',
+            storage_path=os.path.join(TEST_FOLDER, self.id()),
+        )
+        with mock.patch('opencensus.ext.azure.log_exporter.AzureLogHandler._transmit') as transmit:  # noqa: E501
+            transmit.return_value = 10
+            handler._export(['foo'])
+        self.assertEqual(len(os.listdir(handler.storage.path)), 1)
+        self.assertIsNone(handler.storage.get())
+        handler.close()
+
+    def test_log_record_to_envelope(self):
+        handler = log_exporter.AzureLogHandler(
+            instrumentation_key='12345678-1234-5678-abcd-12345678abcd',
+            storage_path=os.path.join(TEST_FOLDER, self.id()),
+        )
+        envelope = handler.log_record_to_envelope(mock.MagicMock(
+            exc_info=None,
+            levelno=10,
+        ))
+        self.assertEqual(
+            envelope.iKey,
+            '12345678-1234-5678-abcd-12345678abcd')
+        handler.close()

--- a/contrib/opencensus-ext-azure/tests/test_azure_trace_exporter.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_trace_exporter.py
@@ -415,7 +415,9 @@ class TestAzureExporter(unittest.TestCase):
         self.assertEqual(len(os.listdir(exporter.storage.path)), 1)
         exporter._stop()
 
-    def test_transmission_lease_failure(self):
+    @mock.patch('requests.post', return_value=mock.Mock())
+    def test_transmission_lease_failure(self, requests_mock):
+        requests_mock.return_value = MockResponse(200, 'unknown')
         exporter = trace_exporter.AzureExporter(
             instrumentation_key='12345678-1234-5678-abcd-12345678abcd',
             storage_path=os.path.join(TEST_FOLDER, self.id()),

--- a/contrib/opencensus-ext-azure/tests/test_azure_trace_exporter.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_trace_exporter.py
@@ -40,10 +40,10 @@ def throw(exc_type, *args, **kwargs):
 class TestAzureExporter(unittest.TestCase):
     def test_ctor(self):
         from opencensus.ext.azure.common import Options
-        instrumentation_key = Options.prototype.instrumentation_key
-        Options.prototype.instrumentation_key = None
+        instrumentation_key = Options._default.instrumentation_key
+        Options._default.instrumentation_key = None
         self.assertRaises(ValueError, lambda: trace_exporter.AzureExporter())
-        Options.prototype.instrumentation_key = instrumentation_key
+        Options._default.instrumentation_key = instrumentation_key
 
     @mock.patch('requests.post', return_value=mock.Mock())
     def test_emit_empty(self, request_mock):

--- a/contrib/opencensus-ext-azure/tests/test_azure_utils.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_utils.py
@@ -31,6 +31,11 @@ class TestUtils(unittest.TestCase):
                 '2010-10-24T07:28:38.234567Z',
             ), '0.00:00:00.111')
 
+    def test_timestamp_to_iso_str(self):
+        self.assertEqual(utils.timestamp_to_iso_str(
+                1287905318.123456,
+            ), '2010-10-24T07:28:38.123456Z')
+
     def test_url_to_dependency_name(self):
         self.assertEqual(
             utils.url_to_dependency_name(

--- a/contrib/opencensus-ext-azure/tests/test_protocol.py
+++ b/contrib/opencensus-ext-azure/tests/test_protocol.py
@@ -18,7 +18,7 @@ from opencensus.ext.azure.common import protocol
 
 class TestProtocol(unittest.TestCase):
     def test_object(self):
-        data = protocol.Object()
+        data = protocol.BaseObject()
         self.assertEqual(repr(data), '{}')
         data.foo = 1
         self.assertEqual(data.foo, 1)

--- a/contrib/opencensus-ext-azure/tests/test_protocol.py
+++ b/contrib/opencensus-ext-azure/tests/test_protocol.py
@@ -42,6 +42,10 @@ class TestProtocol(unittest.TestCase):
         data = protocol.Event()
         self.assertEqual(data.ver, 2)
 
+    def test_exception_data(self):
+        data = protocol.ExceptionData()
+        self.assertEqual(data.ver, 2)
+
     def test_message(self):
         data = protocol.Message()
         self.assertEqual(data.ver, 2)


### PR DESCRIPTION
1. Implemented the actual log conversion and exporting logic.
2. Moved the network/storage transmission logic from trace exporter to a shared mixin, applied to both traces and logs.
3. Avoid common names (`Object` and `prototype`), use `BaseObject` and `_default` instead. (Addressing the comments left in https://github.com/census-instrumentation/opencensus-python/pull/613#issuecomment-483432780).