### PR TITLE
Remove broken rst section for stackdriver exporter

### DIFF
--- a/contrib/opencensus-ext-stackdriver/README.rst
+++ b/contrib/opencensus-ext-stackdriver/README.rst
@@ -30,9 +30,6 @@ This example shows how to report the traces to Stackdriver Trace:
         project_id='your_cloud_project')
     tracer = tracer_module.Tracer(exporter=exporter)
 
-StackdriverExporter requires the google-cloud-trace package. Install
-google-cloud-trace using `pip`_ or `pipenv`_:
-
 ::
 
     pip install google-cloud-trace


### PR DESCRIPTION
The `README.rst` doc for `opencensus-ext-stackdriver` has broken links, which caused rendering problem (refer to https://pypi.org/project/opencensus-ext-stackdriver/0.3.0/).

Given the dependency is now included in `setup.py` file after the package refactor, we don't need to instruct users to manually install `google-cloud-trace`, time to remove the entire section.