### PR TITLE
opencensus-ext-django - support all versions of django 1.11

### DIFF
--- a/contrib/opencensus-ext-django/setup.py
+++ b/contrib/opencensus-ext-django/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'Django >= 1.11.0, <= 1.11.20',
+        'Django >= 1.11.0, < 1.12.0',
         'opencensus >= 0.7.dev0, < 1.0.0',
     ],
     extras_require={},


### PR DESCRIPTION
`opencensus-ext-django`: Support all releases of django 1.11

1.11.21 was just released, which is not compatible with the current install_requires
https://www.djangoproject.com/weblog/2019/jun/03/security-releases/