### PR TITLE
gRPC integration docs usage fix

### DIFF
--- a/contrib/opencensus-ext-grpc/README.rst
+++ b/contrib/opencensus-ext-grpc/README.rst
@@ -28,14 +28,6 @@ Installation
 
     pip install opencensus-ext-grpc
 
-Usage
------
-
-.. code:: python
-
-    from opencensus.trace import config_integration
-
-    config_integration.trace_integrations(['grpc'])
 
 References
 ----------

--- a/contrib/opencensus-ext-grpc/README.rst
+++ b/contrib/opencensus-ext-grpc/README.rst
@@ -19,7 +19,7 @@ directory.
 
 More information about the gRPC interceptors please see the `proposal`_.
 
-.. _proposal: https://github.com/mehrdada/proposal/blob/python-interceptors/L13-Python-Interceptors.md
+.. _proposal: https://github.com/grpc/proposal/blob/master/L13-python-interceptors.md
 
 Installation
 ------------

--- a/contrib/opencensus-ext-grpc/README.rst
+++ b/contrib/opencensus-ext-grpc/README.rst
@@ -8,14 +8,15 @@ OpenCensus gRPC Integration
 
 OpenCensus provides the implementation of interceptors for both the client side
 and server side to instrument the gRPC requests and responses. The client
-interceptors are used to create a decorated channel that intercepts client
-gRPC calls and server interceptors act as decorators over handlers.
+interceptors are used to create a decorated channel that intercepts client gRPC
+calls and server interceptors act as decorators over handlers.
 
-gRPC interceptor is a new feature in the grpcio1.8.0 release, please upgrade
-your grpcio to the latest version to use this feature.
+gRPC interceptors are a new feature as of the 1.8.0 ``grpcio`` release, please
+upgrade ``grpcio`` to the latest version to use this feature.
 
-For sample usage, please refer to the hello world example in the examples
-directory.
+For sample usage, please refer to the hello world `example`_.
+
+.. _example: ../examples/
 
 More information about the gRPC interceptors please see the `proposal`_.
 


### PR DESCRIPTION
This updates the gRPC readme to remove an outdated usage example. See #677.

@reyang let me know if you'd rather inline some of the hello world example than remove the usage section completely.