### PR TITLE
Use scopped logger in transports.async_

### DIFF
--- a/opencensus/common/transports/async_.py
+++ b/opencensus/common/transports/async_.py
@@ -27,6 +27,8 @@ _DEFAULT_WAIT_PERIOD = 60.0  # Seconds
 _WORKER_THREAD_NAME = 'opencensus.common.Worker'
 _WORKER_TERMINATOR = object()
 
+logger = logging.getLogger(__name__)
+
 
 class _Worker(object):
     """A background thread that exports batches of data.
@@ -108,7 +110,7 @@ class _Worker(object):
                 try:
                     self.exporter.emit(data)
                 except Exception:
-                    logging.exception(
+                    logger.exception(
                         '%s failed to emit data.'
                         'Dropping %s objects from queue.',
                         self.exporter.__class__.__name__,

--- a/tests/unit/common/transports/test_async.py
+++ b/tests/unit/common/transports/test_async.py
@@ -199,7 +199,7 @@ class Test_Worker(unittest.TestCase):
         # trace2 should be left in the queue because worker is terminated.
         self.assertEqual(worker._queue.qsize(), 1)
 
-    @mock.patch('logging.exception')
+    @mock.patch('opencensus.common.transports.async_.logger.exception')
     def test__thread_main_alive_on_emit_failed(self, mock):
 
         class Exporter(object):


### PR DESCRIPTION
Use a logger scoped to the class instead of a root logger, much like: https://github.com/census-instrumentation/opencensus-python/blob/master/opencensus/metrics/transport.py#L21

This gives users more control over what this library can log.