### PR TITLE
Pin to pytest version 4.6.4 to unblock CI

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -49,7 +49,7 @@ def _install_dev_packages(session):
 
 def _install_test_dependencies(session):
     session.install('mock')
-    session.install('pytest')
+    session.install('pytest=4.6.4')
     session.install('pytest-cov')
     session.install('retrying')
     session.install('unittest2')

--- a/noxfile.py
+++ b/noxfile.py
@@ -49,7 +49,7 @@ def _install_dev_packages(session):
 
 def _install_test_dependencies(session):
     session.install('mock')
-    session.install('pytest=4.6.4')
+    session.install('pytest==4.6.4')
     session.install('pytest-cov')
     session.install('retrying')
     session.install('unittest2')

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ install_command = python -m pip install {opts} {packages}
 
 deps = 
   py{27,34,35,36,37}-unit,py37-lint: mock
-  py{27,34,35,36,37}-unit,py37-lint: pytest
+  py{27,34,35,36,37}-unit,py37-lint: pytest==4.6.4
   py{27,34,35,36,37}-unit,py37-lint: pytest-cov
   py{27,34,35,36,37}-unit,py37-lint: retrying
   py{27,34,35,36,37}-unit,py37-lint: unittest2


### PR DESCRIPTION
CI failure blocked #703 and #704 due to a recent release of `pytest`.
Trying to unblock them first, will fix the deprecated pytest dependency in another PR.