### PR TITLE
Fix rst doc for Azure exporter

### DIFF
--- a/contrib/opencensus-ext-azure/README.rst
+++ b/contrib/opencensus-ext-azure/README.rst
@@ -78,57 +78,52 @@ The **Azure Monitor Metrics Exporter** allows you to export metrics to `Azure Mo
 * Put the instrumentation key in ``APPINSIGHTS_INSTRUMENTATIONKEY`` environment variable.
 * You can also specify the instrumentation key explicitly in the code, which will take priority over a set environment variable.
 
-Using the Metrics exporter
-*****************************
+.. code:: python
 
-    .. code:: python
+    import time
 
-        import time
+    from opencensus.ext.azure import metrics_exporter
+    from opencensus.stats import aggregation as aggregation_module
+    from opencensus.stats import measure as measure_module
+    from opencensus.stats import stats as stats_module
+    from opencensus.stats import view as view_module
+    from opencensus.tags import tag_map as tag_map_module
 
-        from opencensus.ext.azure import metrics_exporter
-        from opencensus.stats import aggregation as aggregation_module
-        from opencensus.stats import measure as measure_module
-        from opencensus.stats import stats as stats_module
-        from opencensus.stats import view as view_module
-        from opencensus.tags import tag_map as tag_map_module
+    stats = stats_module.stats
+    view_manager = stats.view_manager
+    stats_recorder = stats.stats_recorder
 
-        stats = stats_module.stats
-        view_manager = stats.view_manager
-        stats_recorder = stats.stats_recorder
+    CARROTS_MEASURE = measure_module.MeasureInt("carrots",
+                                                "number of carrots",
+                                                "carrots")
+    CARROTS_VIEW = view_module.View("carrots_view",
+                                    "number of carrots",
+                                    [],
+                                    CARROTS_MEASURE,
+                                    aggregation_module.CountAggregation())
 
-        CARROTS_MEASURE = measure_module.MeasureInt("carrots",
-                                                    "number of carrots",
-                                                    "carrots")
-        CARROTS_VIEW = view_module.View("carrots_view",
-                                        "number of carrots",
-                                        [],
-                                        CARROTS_MEASURE,
-                                        aggregation_module.CountAggregation())
+    def main():
+        # Enable metrics
+        # Set the interval in seconds in which you want to send metrics
+        exporter = metrics_exporter.new_metrics_exporter()
+        view_manager.register_exporter(exporter)
 
+        view_manager.register_view(CARROTS_VIEW)
+        mmap = stats_recorder.new_measurement_map()
+        tmap = tag_map_module.TagMap()
 
-        def main():
-            # Enable metrics
-            # Set the interval in seconds in which you want to send metrics
-            exporter = metrics_exporter.new_metrics_exporter()
-            view_manager.register_exporter(exporter)
+        mmap.measure_int_put(CARROTS_MEASURE, 1000)
+        mmap.record(tmap)
+        # Default export interval is every 15.0s
+        # Your application should run for at least this amount
+        # of time so the exporter will meet this interval
+        # Sleep can fulfill this
+        time.sleep(60)
 
-            view_manager.register_view(CARROTS_VIEW)
-            mmap = stats_recorder.new_measurement_map()
-            tmap = tag_map_module.TagMap()
+        print("Done recording metrics")
 
-            mmap.measure_int_put(CARROTS_MEASURE, 1000)
-            mmap.record(tmap)
-            # Default export interval is every 15.0s
-            # Your application should run for at least this amount
-            # of time so the exporter will meet this interval
-            # Sleep can fulfill this
-            time.sleep(60)
-
-            print("Done recording metrics")
-
-
-        if __name__ == "__main__":
-            main()
+    if __name__ == "__main__":
+        main()
 
 Trace
 ~~~~~


### PR DESCRIPTION
The previous RST doc would render the metrics example code using italic font under the second level indentation, now fixing it by aligning with traces/logs document sections.