### PR TITLE
Span ID generation docstring fix

### DIFF
--- a/opencensus/trace/span_context.py
+++ b/opencensus/trace/span_context.py
@@ -42,7 +42,6 @@ class SpanContext(object):
 
     :type span_id: str
     :param span_id: (Optional) Identifier for the span, unique within a trace.
-                    If not given, will generate one automatically.
 
     :type trace_options: :class: `~opencensus.trace.trace_options.TraceOptions`
     :param trace_options: (Optional) TraceOptions indicates 8 trace options.


### PR DESCRIPTION
Quick fix to revert an apparent bad edit from an old PR (#147). `SpanContext` only generates trace IDs, not span IDs.

See https://github.com/census-instrumentation/opencensus-python/pull/701#issuecomment-507374637.