### PR TITLE
Fix FlaskMiddleware and OpenCensusTweenFactory path in docs and examples

### DIFF
--- a/contrib/opencensus-ext-pyramid/examples/app/__init__.py
+++ b/contrib/opencensus-ext-pyramid/examples/app/__init__.py
@@ -37,7 +37,7 @@ def main(global_config, **settings):
     config.add_route('hello', '/')
     config.add_route('trace_requests', '/requests')
 
-    config.add_tween('opencensus.trace.ext.pyramid'
+    config.add_tween('opencensus.ext.pyramid'
                      '.pyramid_middleware.OpenCensusTweenFactory',
                      over=MAIN)
 

--- a/docs/trace/usage.rst
+++ b/docs/trace/usage.rst
@@ -159,7 +159,7 @@ for a Flask application:
 
 .. code:: python
 
-    from opencensus.trace.ext.flask.flask_middleware import FlaskMiddleware
+    from opencensus.ext.flask.flask_middleware import FlaskMiddleware
 
     app = flask.Flask(__name__)
 
@@ -195,7 +195,7 @@ requests will be automatically traced.
 
 .. code:: python
 
-    from opencensus.trace.ext.flask.flask_middleware import FlaskMiddleware
+    from opencensus.ext.flask.flask_middleware import FlaskMiddleware
 
     app = flask.Flask(__name__)
 
@@ -265,7 +265,7 @@ traced.
     def main(global_config, **settings):
         config = Configurator(settings=settings)
 
-        config.add_tween('opencensus.trace.ext.pyramid'
+        config.add_tween('opencensus.ext.pyramid'
                          '.pyramid_middleware.OpenCensusTweenFactory')
 
 To configure the sampler, exporter, and propagator, pass the instances


### PR DESCRIPTION
Missed in ff80d11801b78a4242080f55d22bb77e6434164c and
772ac6e88ba4f919a95ae64b650e83e49af0c97c.