### PR TITLE
[TextFormatPropagator] fix parent trace_option data type to string

### DIFF
--- a/opencensus/trace/propagation/text_format.py
+++ b/opencensus/trace/propagation/text_format.py
@@ -49,7 +49,7 @@ class TextFormatPropagator(object):
             if key == _SPAN_ID_KEY:
                 span_id = carrier[key]
             if key == _TRACE_OPTIONS_KEY:
-                trace_options = bool(carrier[key])
+                trace_options = carrier[key]
 
         if trace_options is None:
             trace_options = DEFAULT_TRACE_OPTIONS


### PR DESCRIPTION
DEFAULT_TRACE_OPTIONS is string, so mixing bool here has broken situation as following:

```
>>> from opencensus.trace.propagation.text_format import TextFormatPropagator
>>> propagator = TextFormatPropagator()
>>> data = {}
>>> span_context = propagator.from_carrier(data)
>>> span_context.trace_options.set_enabled(True)
>>> print(propagator.to_carrier(span_context, data))
{'opencensus-trace-traceid': 'ad39a21155167cc115a13e5f4cfb6cd4', 'opencensus-trace-traceoptions': '1'}
>>> span_context = propagator.from_carrier(data)
>>> span_context.trace_options.set_enabled(True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/mnt/c/Users/kawai/Documents/kwi-opencensus/opencensus/trace/trace_options.py", line 78, in set_enabled
    self.enabled = self.get_enabled()
  File "/mnt/c/Users/kawai/Documents/kwi-opencensus/opencensus/trace/trace_options.py", line 65, in get_enabled
    enabled = bool(int(self.trace_options_byte) & _ENABLED_BITMASK)
ValueError: invalid literal for int() with base 10: 'Tru1'
>>> print(propagator.to_carrier(span_context, data))
{'opencensus-trace-traceid': 'ad39a21155167cc115a13e5f4cfb6cd4', 'opencensus-trace-traceoptions': 'Tru1'}
```