### PR TITLE
Update Flask middleware to not use full URL with query params as a span name

### DIFF
--- a/contrib/opencensus-ext-flask/CHANGELOG.md
+++ b/contrib/opencensus-ext-flask/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## in development
+
+- Don't use full URL with query parameters for the span name and span HTTP_URL
+  span attribute.
+
+  Query params can contain sensitive values which shouldn't be logged. Now just
+  the url without the query parameters is used.
+
+  Before: ``http://example.com/path/bar?foo=bar&bar=baz``, now:
+  ``http://example.com/path/bar``.
+
 ## Unreleased
 - Make ProbabilitySampler default
 

--- a/contrib/opencensus-ext-flask/opencensus/ext/flask/flask_middleware.py
+++ b/contrib/opencensus-ext-flask/opencensus/ext/flask/flask_middleware.py
@@ -146,7 +146,7 @@ class FlaskMiddleware(object):
             tracer.add_attribute_to_current_span(
                 HTTP_METHOD, flask.request.method)
             tracer.add_attribute_to_current_span(
-                HTTP_URL, str(flask.request.base_url))
+                HTTP_URL, str(flask.request.url))
             execution_context.set_opencensus_attr(
                 'blacklist_hostnames',
                 self.blacklist_hostnames)

--- a/contrib/opencensus-ext-flask/opencensus/ext/flask/flask_middleware.py
+++ b/contrib/opencensus-ext-flask/opencensus/ext/flask/flask_middleware.py
@@ -142,11 +142,11 @@ class FlaskMiddleware(object):
             # Set the span name as the name of the current module name
             span.name = '[{}]{}'.format(
                 flask.request.method,
-                flask.request.url)
+                flask.request.base_url)
             tracer.add_attribute_to_current_span(
                 HTTP_METHOD, flask.request.method)
             tracer.add_attribute_to_current_span(
-                HTTP_URL, str(flask.request.url))
+                HTTP_URL, str(flask.request.base_url))
             execution_context.set_opencensus_attr(
                 'blacklist_hostnames',
                 self.blacklist_hostnames)

--- a/contrib/opencensus-ext-flask/tests/test_flask_middleware.py
+++ b/contrib/opencensus-ext-flask/tests/test_flask_middleware.py
@@ -266,7 +266,6 @@ class TestFlaskMiddleware(unittest.TestCase):
                 'http.url': u'http://localhost/path/value',
                 'http.method': 'GET',
             }
-            print(span.name)
 
             self.assertEqual(span.name,
                              '[GET]http://localhost/path/value')

--- a/contrib/opencensus-ext-flask/tests/test_flask_middleware.py
+++ b/contrib/opencensus-ext-flask/tests/test_flask_middleware.py
@@ -263,7 +263,11 @@ class TestFlaskMiddleware(unittest.TestCase):
             span = tracer.current_span()
 
             expected_attributes = {
-                'http.url': u'http://localhost/path/value',
+                # NOTE: Query params need to be include as per spec
+                # https://github.com/census-instrumentation/opencensus-specs
+                # TODO: Open feedback PR to spec and suggestion making query
+                # params optional since they can contain sensitive data
+                'http.url': u'http://localhost/path/value?foo=bar&bar=baz',
                 'http.method': 'GET',
             }
 


### PR DESCRIPTION
This pull request updates Flask middleware so it doesn't use full URL with query params as a spam name.

A lot of times query parameters can contain sensitive data (things such as API keys etc, since not all the services support sending such information via headers so query params are often used as a fallback in such scenarios).

We could perhaps add config option to include query parameters as an attribute with an option for blacklisted attributes (this does increase the complexity of the code and adds additional processing time and overhead to the middleware though).

## TODO

- [x] Tests