### PR TITLE
[RFC] Update Flask plugin to allow existing Tracer instance re-use

### DIFF
--- a/contrib/opencensus-ext-flask/opencensus/ext/flask/flask_middleware.py
+++ b/contrib/opencensus-ext-flask/opencensus/ext/flask/flask_middleware.py
@@ -71,13 +71,14 @@ class FlaskMiddleware(object):
                        :class:`.TextFormatPropagator`.
     """
 
-    def __init__(self, app=None, blacklist_paths=None, sampler=None,
+    def __init__(self, app=None, blacklist_paths=None, tracer=None, sampler=None,
                  exporter=None, propagator=None):
         self.app = app
         self.blacklist_paths = blacklist_paths
         self.sampler = sampler
         self.exporter = exporter
         self.propagator = propagator
+        self.tracer = tracer
 
         if self.app is not None:
             self.init_app(app)
@@ -131,11 +132,14 @@ class FlaskMiddleware(object):
         try:
             span_context = self.propagator.from_headers(flask.request.headers)
 
-            tracer = tracer_module.Tracer(
-                span_context=span_context,
-                sampler=self.sampler,
-                exporter=self.exporter,
-                propagator=self.propagator)
+            if not self.tracer:
+                tracer = tracer_module.Tracer(
+                    span_context=span_context,
+                    sampler=self.sampler,
+                    exporter=self.exporter,
+                    propagator=self.propagator)
+            else:
+                tracer = self.tracer
 
             span = tracer.start_span()
             span.span_kind = span_module.SpanKind.SERVER


### PR DESCRIPTION
### Background, Details

Right now Flask middleware / plugin creates new Tracer instance for each request.

This it not great when you are using the same tracer singleton instance across the whole application / service and when using other plugins (such as https://github.com/census-instrumentation/opencensus-python/blob/master/contrib/opencensus-ext-google-cloud-clientlibs/) which allow you to specify which tracer instance to use (e.g. using ``config_integration.trace_integrations([...], tracer=my_singleton_tracer_instance)``).

Because existing singleton tracer instance can't re re-used, this means libraries and code which use singleton tracer instance can't be part of the root span created by the Flask middleware.

Before my change:

![Screenshot from 2019-07-23 23-00-56](https://user-images.githubusercontent.com/125088/61747547-61dfb680-ad9e-11e9-9f86-19c9f620602b.png)

![Screenshot from 2019-07-23 23-08-03](https://user-images.githubusercontent.com/125088/61747709-c00c9980-ad9e-11e9-86eb-b7473b0d8d22.png)

As you can see, span created by ``opencensus-ext-google-cloud-clientlibs`` which uses application / service global Tracer instance is not part of the request span (but I want it to be).

----

After my change:

![Screenshot from 2019-07-23 23-00-43](https://user-images.githubusercontent.com/125088/61747577-7328c300-ad9e-11e9-9844-4ab80ab0acf4.png)

I pass existing singleton tracer instance to Flask middleware and as such, span is correctly part of the root request span,

### Proposed Solution

To solve for that, I propose adding new optional ``tracer`` argument to the constructor.

When this argument is provided, sampler, exporter and propagator arguments are redundant and mutually exclusive (if agreed on this approach, I can update docs and code to throw if mutually exclusive arguments are provided).