### PR TITLE
Skip existing packages on twine upload

### DIFF
--- a/scripts/twine_upload.sh
+++ b/scripts/twine_upload.sh
@@ -41,5 +41,7 @@ done
 
 # Upload the distributions.
 for p in dist/* ; do
-  twine upload $p
+  twine upload --verbose $p
 done
+
+exit 0

--- a/scripts/twine_upload.sh
+++ b/scripts/twine_upload.sh
@@ -41,7 +41,5 @@ done
 
 # Upload the distributions.
 for p in dist/* ; do
-  twine upload --verbose $p
+  twine upload --skip-existing $p
 done
-
-exit 0


### PR DESCRIPTION
Since we don't change all package version numbers on each release some uploads to PyPI will fail. Skip these with `--skip-existing`.

See https://circleci.com/gh/census-instrumentation/opencensus-python/2556?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link for an example of a failing build.