### PR TITLE
Bump SD exporter package version for release

### DIFF
--- a/contrib/opencensus-ext-stackdriver/CHANGELOG.md
+++ b/contrib/opencensus-ext-stackdriver/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.5.0
+Released 2019-08-05
+
+  - Support exporter changes in `opencensus>=0.7.0`
+
 ## 0.4.0
 Released 2019-05-31
 

--- a/contrib/opencensus-ext-stackdriver/version.py
+++ b/contrib/opencensus-ext-stackdriver/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.5.dev0'
+__version__ = '0.6.dev0'


### PR DESCRIPTION
See https://github.com/census-instrumentation/opencensus-python/issues/745. The `0.7.0` release didn't include a version update for `opencensus-ext-stackdriver`, which included a breaking change from #708.