### PR TITLE
Bump SD exporter to 0.7.1 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Added `set_status` to `span`
+  ([#738](https://github.com/census-instrumentation/opencensus-python/pull/738))
 
 ## 0.7.0
 Released 2019-07-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
 ## Unreleased
+
+## 0.7.1
+Released 2019-08-05
+
 - Added `set_status` to `span`
   ([#738](https://github.com/census-instrumentation/opencensus-python/pull/738))
+- Update released stackdriver exporter version
 
 ## 0.7.0
 Released 2019-07-31

--- a/contrib/opencensus-ext-django/CHANGELOG.md
+++ b/contrib/opencensus-ext-django/CHANGELOG.md
@@ -5,8 +5,9 @@
 ## 0.7.0
 Released 2019-07-31
 
-- Updated span attributes to include some missing attributes listed [here](https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/HTTP.md#attributes)
-([#735](https://github.com/census-instrumentation/opencensus-python/pull/735))
+- Updated span attributes to include some missing attributes listed
+  [here](https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/HTTP.md#attributes)
+  ([#735](https://github.com/census-instrumentation/opencensus-python/pull/735))
 
 ## 0.3.2
 Released 2019-07-26

--- a/contrib/opencensus-ext-flask/CHANGELOG.md
+++ b/contrib/opencensus-ext-flask/CHANGELOG.md
@@ -6,8 +6,9 @@
 Released 2019-07-31
 
 - Make ProbabilitySampler default
-- Updated span attributes to include some missing attributes listed [here](https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/HTTP.md#attributes)
-([#735](https://github.com/census-instrumentation/opencensus-python/pull/735))
+- Updated span attributes to include some missing attributes listed
+  [here](https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/HTTP.md#attributes)
+  ([#735](https://github.com/census-instrumentation/opencensus-python/pull/735))
 
 ## 0.3.0
 Released 2019-04-24

--- a/contrib/opencensus-ext-flask/CHANGELOG.md
+++ b/contrib/opencensus-ext-flask/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.7.1
+Released 2019-08-05
+
+- Update for core library changes
+
 ## 0.7.0
 Released 2019-07-31
 

--- a/contrib/opencensus-ext-flask/setup.py
+++ b/contrib/opencensus-ext-flask/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'flask >= 0.12.3, < 2.0.0',
-        'opencensus >= 0.7.0, < 1.0.0',
+        'opencensus >= 0.7.1, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-flask/tests/test_flask_middleware.py
+++ b/contrib/opencensus-ext-flask/tests/test_flask_middleware.py
@@ -316,8 +316,10 @@ class TestFlaskMiddleware(unittest.TestCase):
         exported_spandata = mock_exporter.export.call_args[0][0][0]
         self.assertIsInstance(exported_spandata, span_data.SpanData)
         self.assertIsInstance(exported_spandata.status, status.Status)
-        self.assertEqual(exported_spandata.status.code, code_pb2.UNKNOWN)
-        self.assertEqual(exported_spandata.status.message, 'error')
+        self.assertEqual(
+            exported_spandata.status.canonical_code, code_pb2.UNKNOWN
+        )
+        self.assertEqual(exported_spandata.status.description, 'error')
 
     def test_teardown_include_exception_and_traceback(self):
         mock_exporter = mock.MagicMock()
@@ -331,8 +333,10 @@ class TestFlaskMiddleware(unittest.TestCase):
         exported_spandata = mock_exporter.export.call_args[0][0][0]
         self.assertIsInstance(exported_spandata, span_data.SpanData)
         self.assertIsInstance(exported_spandata.status, status.Status)
-        self.assertEqual(exported_spandata.status.code, code_pb2.UNKNOWN)
-        self.assertEqual(exported_spandata.status.message, 'error')
+        self.assertEqual(
+            exported_spandata.status.canonical_code, code_pb2.UNKNOWN
+        )
+        self.assertEqual(exported_spandata.status.description, 'error')
         self.assertIsInstance(
             exported_spandata.stack_trace, stack_trace.StackTrace
         )

--- a/contrib/opencensus-ext-flask/version.py
+++ b/contrib/opencensus-ext-flask/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.7.0'
+__version__ = '0.7.1'

--- a/contrib/opencensus-ext-grpc/CHANGELOG.md
+++ b/contrib/opencensus-ext-grpc/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.7.1
+Released 2019-08-05
+
+- Update for core library changes
+
 ## 0.3.0
 Released 2019-05-31
 

--- a/contrib/opencensus-ext-grpc/setup.py
+++ b/contrib/opencensus-ext-grpc/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'grpcio >= 1.0.0, < 2.0.0',
-        'opencensus >= 0.7.0, < 1.0.0',
+        'opencensus >= 0.7.1, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-grpc/tests/test_server_interceptor.py
+++ b/contrib/opencensus-ext-grpc/tests/test_server_interceptor.py
@@ -147,8 +147,10 @@ class TestOpenCensusServerInterceptor(unittest.TestCase):
 
             # check that the status obj is attached to the current span
             self.assertIsNotNone(current_span.status)
-            self.assertEqual(current_span.status.code, code_pb2.UNKNOWN)
-            self.assertEqual(current_span.status.message, 'Test')
+            self.assertEqual(
+                current_span.status.canonical_code, code_pb2.UNKNOWN
+            )
+            self.assertEqual(current_span.status.description, 'Test')
 
     @mock.patch(
         'opencensus.trace.execution_context.get_opencensus_tracer')

--- a/contrib/opencensus-ext-grpc/version.py
+++ b/contrib/opencensus-ext-grpc/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.3.0'
+__version__ = '0.7.1'

--- a/contrib/opencensus-ext-jaeger/CHANGELOG.md
+++ b/contrib/opencensus-ext-jaeger/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.7.1
+Released 2019-08-05
+
+- Update for core library changes
+
 ## 0.2.2
 Released 2019-05-31
 

--- a/contrib/opencensus-ext-jaeger/opencensus/ext/jaeger/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-jaeger/opencensus/ext/jaeger/trace_exporter/__init__.py
@@ -184,12 +184,12 @@ class JaegerExporter(base_exporter.Exporter):
                 tags.append(jaeger.Tag(
                     key='status.code',
                     vType=jaeger.TagType.LONG,
-                    vLong=status.code))
+                    vLong=status.canonical_code))
 
                 tags.append(jaeger.Tag(
                     key='status.message',
                     vType=jaeger.TagType.STRING,
-                    vStr=status.message))
+                    vStr=status.description))
 
             refs = _extract_refs_from_span(span)
             logs = _extract_logs_from_span(span)

--- a/contrib/opencensus-ext-jaeger/setup.py
+++ b/contrib/opencensus-ext-jaeger/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.7.0, < 1.0.0',
+        'opencensus >= 0.7.1, < 1.0.0',
         'thrift >= 0.10.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-jaeger/version.py
+++ b/contrib/opencensus-ext-jaeger/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.2'
+__version__ = '0.7.1'

--- a/contrib/opencensus-ext-ocagent/CHANGELOG.md
+++ b/contrib/opencensus-ext-ocagent/CHANGELOG.md
@@ -2,12 +2,17 @@
 
 ## Unreleased
 
+## 0.7.1
+Released 2019-08-05
+
+- Update for core library changes
+
 ## 0.4.0
 Released 2019-05-31
 
-- Remove well_known_types.Error and well_known_types.ParseError.
-Note this could be a breaking change if you depend on an older 
-version of protobuf and use ParseError.
+- Remove well_known_types.Error and well_known_types.ParseError. Note this
+  could be a breaking change if you depend on an older version of protobuf and
+  use ParseError.
 
 ## 0.3.0
 Released 2019-04-24

--- a/contrib/opencensus-ext-ocagent/opencensus/ext/ocagent/trace_exporter/utils.py
+++ b/contrib/opencensus-ext-ocagent/opencensus/ext/ocagent/trace_exporter/utils.py
@@ -43,8 +43,9 @@ def translate_to_trace_proto(span_data):
             span_data.start_time),
         end_time=ocagent_utils.proto_ts_from_datetime_str(span_data.end_time),
         status=trace_pb2.Status(
-            code=span_data.status.code,
-            message=span_data.status.message)
+            code=span_data.status.canonical_code,
+            message=span_data.status.description,
+        )
         if span_data.status is not None else None,
         same_process_as_parent_span=BoolValue(
             value=span_data.same_process_as_parent_span)

--- a/contrib/opencensus-ext-ocagent/setup.py
+++ b/contrib/opencensus-ext-ocagent/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'grpcio >= 1.0.0, < 2.0.0',
-        'opencensus >= 0.7.0, < 1.0.0',
+        'opencensus >= 0.7.1, < 1.0.0',
         'opencensus-proto >= 0.1.0, < 1.0.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-ocagent/version.py
+++ b/contrib/opencensus-ext-ocagent/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.4.0'
+__version__ = '0.7.1'

--- a/contrib/opencensus-ext-pymongo/CHANGELOG.md
+++ b/contrib/opencensus-ext-pymongo/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
 ## Unreleased
-- Changed attributes names to make it compatible with [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-semantic-conventions.md), maintaining OpenCensus specs fidelity
-([#738](https://github.com/census-instrumentation/opencensus-python/pull/738))
+
+## 0.7.1
+Released 2019-08-05
+
+- Changed attributes names to make it compatible with
+  [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-semantic-conventions.md),
+  maintaining OpenCensus specs fidelity
+  ([#738](https://github.com/census-instrumentation/opencensus-python/pull/738))
 
 ## 0.1.3
 Released 2019-05-31

--- a/contrib/opencensus-ext-pymongo/CHANGELOG.md
+++ b/contrib/opencensus-ext-pymongo/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Changed attributes names to make it compatible with [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-semantic-conventions.md), maintaining OpenCensus specs fidelity
+([#738](https://github.com/census-instrumentation/opencensus-python/pull/738))
 
 ## 0.1.3
 Released 2019-05-31

--- a/contrib/opencensus-ext-pymongo/opencensus/ext/pymongo/trace.py
+++ b/contrib/opencensus-ext-pymongo/opencensus/ext/pymongo/trace.py
@@ -16,8 +16,11 @@ import logging
 
 from pymongo import monitoring
 
+from google.rpc import code_pb2
+
 from opencensus.trace import execution_context
 from opencensus.trace import span as span_module
+from opencensus.trace import status as status_module
 
 
 log = logging.getLogger(__name__)
@@ -34,7 +37,6 @@ def trace_integration(tracer=None):
 
 
 class MongoCommandListener(monitoring.CommandListener):
-
     def __init__(self, tracer=None):
         self._tracer = tracer
 
@@ -44,11 +46,23 @@ class MongoCommandListener(monitoring.CommandListener):
 
     def started(self, event):
         span = self.tracer.start_span(
-            name='{}.{}.{}.{}'.format(MODULE_NAME,
-                                      event.database_name,
-                                      event.command.get(event.command_name),
-                                      event.command_name))
+            name='{}.{}.{}.{}'.format(
+                MODULE_NAME,
+                event.database_name,
+                event.command.get(event.command_name),
+                event.command_name,
+            )
+        )
         span.span_kind = span_module.SpanKind.CLIENT
+
+        self.tracer.add_attribute_to_current_span('component', 'mongodb')
+        self.tracer.add_attribute_to_current_span('db.type', 'mongodb')
+        self.tracer.add_attribute_to_current_span(
+            'db.instance', event.database_name
+        )
+        self.tracer.add_attribute_to_current_span(
+            'db.statement', event.command.get(event.command_name)
+        )
 
         for attr in COMMAND_ATTRIBUTES:
             _attr = event.command.get(attr)
@@ -56,18 +70,23 @@ class MongoCommandListener(monitoring.CommandListener):
                 self.tracer.add_attribute_to_current_span(attr, str(_attr))
 
         self.tracer.add_attribute_to_current_span(
-            'request_id', event.request_id)
+            'request_id', event.request_id
+        )
 
         self.tracer.add_attribute_to_current_span(
-            'connection_id', str(event.connection_id))
+            'connection_id', str(event.connection_id)
+        )
 
     def succeeded(self, event):
-        self._stop('succeeded')
+        self._stop(code_pb2.OK)
 
     def failed(self, event):
-        self._stop('failed')
+        self._stop(code_pb2.UNKNOWN, 'MongoDB error', event.failure)
 
-    def _stop(self, status):
-        self.tracer.add_attribute_to_current_span('status', status)
-
+    def _stop(self, code, message='', details=None):
+        span = self.tracer.current_span()
+        status = status_module.Status(
+            code=code, message=message, details=details
+        )
+        span.set_status(status)
         self.tracer.end_span()

--- a/contrib/opencensus-ext-pymongo/setup.py
+++ b/contrib/opencensus-ext-pymongo/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.7.0, < 1.0.0',
+        'opencensus >= 0.7.1, < 1.0.0',
         'pymongo >= 3.1.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-pymongo/version.py
+++ b/contrib/opencensus-ext-pymongo/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.3'
+__version__ = '0.7.1'

--- a/contrib/opencensus-ext-stackdriver/CHANGELOG.md
+++ b/contrib/opencensus-ext-stackdriver/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 0.5.0
+## 0.7.1
 Released 2019-08-05
 
   - Support exporter changes in `opencensus>=0.7.0`

--- a/contrib/opencensus-ext-stackdriver/setup.py
+++ b/contrib/opencensus-ext-stackdriver/setup.py
@@ -41,7 +41,7 @@ setup(
     install_requires=[
         'google-cloud-monitoring >= 0.30.0, < 1.0.0',
         'google-cloud-trace >= 0.20.0, < 1.0.0',
-        'opencensus >= 0.7.0, < 1.0.0',
+        'opencensus >= 0.7.1, < 1.0.0',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/opencensus/common/version/__init__.py
+++ b/opencensus/common/version/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.7.0'
+__version__ = '0.7.1'

--- a/opencensus/trace/base_span.py
+++ b/opencensus/trace/base_span.py
@@ -80,6 +80,14 @@ class BaseSpan(object):
         """
         raise NotImplementedError
 
+    def set_status(self, status):
+        """Sets span status.
+
+        :type code: :class: `~opencensus.trace.status.Status`
+        :param code: A Status object.
+        """
+        raise NotImplementedError
+
     def start(self):
         """Set the start time for a span."""
         raise NotImplementedError

--- a/opencensus/trace/blank_span.py
+++ b/opencensus/trace/blank_span.py
@@ -136,6 +136,14 @@ class BlankSpan(base_span.BaseSpan):
         """
         pass
 
+    def set_status(self, status):
+        """No-op implementation of this method.
+
+        :type code: :class: `~opencensus.trace.status.Status`
+        :param code: A Status object.
+        """
+        pass
+
     def start(self):
         """No-op implementation of this method."""
         pass

--- a/opencensus/trace/span.py
+++ b/opencensus/trace/span.py
@@ -264,9 +264,13 @@ class Span(base_span.BaseSpan):
         else:
             self.links = BoundedList.from_seq(MAX_NUM_LINKS, links)
 
+        if status is None:
+            self.status = status_module.Status.as_ok()
+        else:
+            self.status = status
+
         self.span_id = span_id
         self.stack_trace = stack_trace
-        self.status = status
         self.same_process_as_parent_span = same_process_as_parent_span
         self._child_spans = []
         self.context_tracer = context_tracer
@@ -345,6 +349,18 @@ class Span(base_span.BaseSpan):
         else:
             raise TypeError("Type Error: received {}, but requires Link.".
                             format(type(link).__name__))
+
+    def set_status(self, status):
+        """Sets span status.
+
+        :type code: :class: `~opencensus.trace.status.Status`
+        :param code: A Status object.
+        """
+        if isinstance(status, status_module.Status):
+            self.status = status
+        else:
+            raise TypeError("Type Error: received {}, but requires Status.".
+                            format(type(status).__name__))
 
     def start(self):
         """Set the start time for a span."""

--- a/opencensus/trace/status.py
+++ b/opencensus/trace/status.py
@@ -39,17 +39,31 @@ class Status(object):
                     See: https://cloud.google.com/trace/docs/reference/v2/
                          rest/v2/Status#FIELDS.details
     """
-    def __init__(self, code, message, details=None):
+    def __init__(self, code, message=None, details=None):
         self.code = code
         self.message = message
         self.details = details
+
+    @property
+    def canonical_code(self):
+        return self.code
+
+    @property
+    def description(self):
+        return self.message
+
+    @property
+    def is_ok(self):
+        return self.canonical_code == code_pb2.OK
 
     def format_status_json(self):
         """Convert a Status object to json format."""
         status_json = {}
 
-        status_json['code'] = self.code
-        status_json['message'] = self.message
+        status_json['code'] = self.canonical_code
+
+        if self.description is not None:
+            status_json['message'] = self.description
 
         if self.details is not None:
             status_json['details'] = self.details
@@ -61,4 +75,10 @@ class Status(object):
         return cls(
             code=code_pb2.UNKNOWN,
             message=str(exc)
+        )
+
+    @classmethod
+    def as_ok(cls):
+        return cls(
+            code=code_pb2.OK,
         )

--- a/tests/unit/trace/test_base_span.py
+++ b/tests/unit/trace/test_base_span.py
@@ -73,6 +73,12 @@ class TestBaseSpan(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             span.add_link(None)
 
+    def test_set_status_abstract(self):
+        span = BaseSpan()
+
+        with self.assertRaises(NotImplementedError):
+            span.set_status(None)
+
     def test_iter_abstract(self):
         span = BaseSpan()
 

--- a/tests/unit/trace/test_blank_span.py
+++ b/tests/unit/trace/test_blank_span.py
@@ -18,6 +18,7 @@ import unittest
 
 from opencensus.common import utils
 from opencensus.trace.link import Link
+from opencensus.trace.status import Status
 from opencensus.trace.span import format_span_json
 from opencensus.trace.time_event import MessageEvent
 
@@ -58,6 +59,9 @@ class TestBlankSpan(unittest.TestCase):
 
         link = Link(span_id='1234', trace_id='4567')
         span.add_link(link)
+
+        status = Status(0, 'Ok', {'details': 'ok'})
+        span.set_status(status)
 
         message_event = mock.Mock()
         message_event = MessageEvent(datetime.datetime.utcnow(), mock.Mock())

--- a/tests/unit/trace/test_span.py
+++ b/tests/unit/trace/test_span.py
@@ -45,6 +45,7 @@ class TestSpan(unittest.TestCase):
     def test_constructor_defaults(self):
         span_id = 'test_span_id'
         span_name = 'test_span_name'
+        status = Status.as_ok()
 
         patch = mock.patch(
             'opencensus.trace.span.generate_span_id', return_value=span_id)
@@ -56,6 +57,7 @@ class TestSpan(unittest.TestCase):
         self.assertEqual(span.span_id, span_id)
         self.assertIsNone(span.parent_span)
         self.assertEqual(span.attributes, {})
+        self.assertDictEqual(span.status.__dict__, status.__dict__)
         self.assertIsNone(span.start_time)
         self.assertIsNone(span.end_time)
         self.assertEqual(span.children, [])
@@ -181,6 +183,24 @@ class TestSpan(unittest.TestCase):
 
         self.assertEqual(len(span.links), 1)
 
+    def test_set_status(self):
+        span_name = 'test_span_name'
+        span = self._make_one(span_name)
+        status = mock.Mock()
+
+        with self.assertRaises(TypeError):
+            span.set_status(status)
+
+        code = 1
+        message = 'ok'
+        details = {'object': 'ok'}
+        status = Status(code=code, message=message, details=details)
+        span.set_status(status)
+
+        self.assertEqual(span.status.canonical_code, code)
+        self.assertEqual(span.status.description, message)
+        self.assertEqual(span.status.details, details)
+
     def test_start(self):
         span_name = 'root_span'
         span = self._make_one(span_name)
@@ -278,8 +298,8 @@ class TestSpan(unittest.TestCase):
         self.assertIsNotNone(stack_frame['load_module']['build_id']['value'])
 
         self.assertIsNotNone(root_span.status)
-        self.assertEqual(root_span.status.message, exception_message)
-        self.assertEqual(root_span.status.code, code_pb2.UNKNOWN)
+        self.assertEqual(root_span.status.description, exception_message)
+        self.assertEqual(root_span.status.canonical_code, code_pb2.UNKNOWN)
 
 
 class Test_format_span_json(unittest.TestCase):

--- a/tests/unit/trace/test_status.py
+++ b/tests/unit/trace/test_status.py
@@ -25,9 +25,20 @@ class TestStatus(unittest.TestCase):
         message = 'test message'
         status = status_module.Status(code=code, message=message)
 
-        self.assertEqual(status.code, code)
-        self.assertEqual(status.message, message)
+        self.assertEqual(status.canonical_code, code)
+        self.assertEqual(status.description, message)
         self.assertIsNone(status.details)
+
+    def test_format_status_json_without_message(self):
+        code = 100
+        status = status_module.Status(code=code)
+        status_json = status.format_status_json()
+
+        expected_status_json = {
+            'code': code
+        }
+
+        self.assertEqual(expected_status_json, status_json)
 
     def test_format_status_json_with_details(self):
         code = 100
@@ -64,9 +75,23 @@ class TestStatus(unittest.TestCase):
 
         self.assertEqual(expected_status_json, status_json)
 
+    def test_is_ok(self):
+        status = status_module.Status.as_ok()
+        self.assertTrue(status.is_ok)
+
+        status = status_module.Status(code=code_pb2.UNKNOWN)
+        self.assertFalse(status.is_ok)
+
     def test_create_from_exception(self):
         message = 'test message'
         exc = ValueError(message)
         status = status_module.Status.from_exception(exc)
-        self.assertEqual(status.message, message)
-        self.assertEqual(status.code, code_pb2.UNKNOWN)
+        self.assertEqual(status.description, message)
+        self.assertEqual(status.canonical_code, code_pb2.UNKNOWN)
+        self.assertIsNone(status.details)
+
+    def test_create_as_ok(self):
+        status = status_module.Status.as_ok()
+        self.assertEqual(status.canonical_code, code_pb2.OK)
+        self.assertIsNone(status.description)
+        self.assertIsNone(status.details)


### PR DESCRIPTION
#747 bumped `opencensus-ext-exporter` to `0.5.0`, but to be consistent with the core library releases this should be an `0.7.x` release. This PR bumps the core library and the exporter to `0.7.1` so we can release them together.

@reyang I think this is the most consistent way to version the packages even though it means changing the version number of the core library without any changes.