### PR TITLE
Bump stackdriver to 0.7.1

### DIFF
--- a/contrib/opencensus-ext-stackdriver/version.py
+++ b/contrib/opencensus-ext-stackdriver/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.5.0'
+__version__ = '0.7.1'


### PR DESCRIPTION
Missed in #749, the exporter still has the new version from #748 on the release branch.