### PR TITLE
Bump version for httplibs and requests to 0.7.1

### DIFF
--- a/contrib/opencensus-ext-httplib/CHANGELOG.md
+++ b/contrib/opencensus-ext-httplib/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.7.1
+Released 2019-08-06
+
+  - Support exporter changes in `opencensus>=0.7.0`
+
 ## 0.1.3
 Released 2019-05-31
 

--- a/contrib/opencensus-ext-httplib/version.py
+++ b/contrib/opencensus-ext-httplib/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.3'
+__version__ = '0.7.1'

--- a/contrib/opencensus-ext-requests/CHANGELOG.md
+++ b/contrib/opencensus-ext-requests/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.7.1
+Released 2019-08-06
+
+  - Support exporter changes in `opencensus>=0.7.0`
+
 ## 0.1.2
 Released 2019-04-24
 

--- a/contrib/opencensus-ext-requests/version.py
+++ b/contrib/opencensus-ext-requests/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.2'
+__version__ = '0.7.1'


### PR DESCRIPTION
The `0.7.0` release did not include an update for `opencensus-ext-httplibs` and `opencensus-ext-requests` which had non-breaking changes from [#729].