### PR TITLE
Update CHANGELOG and bump versions

### DIFF
--- a/contrib/opencensus-ext-grpc/version.py
+++ b/contrib/opencensus-ext-grpc/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.4.dev0'
+__version__ = '0.8.dev0'

--- a/contrib/opencensus-ext-httplib/CHANGELOG.md
+++ b/contrib/opencensus-ext-httplib/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.7.1
+Released 2019-08-06
+
+  - Support exporter changes in `opencensus>=0.7.0`
+
 ## 0.1.3
 Released 2019-05-31
 

--- a/contrib/opencensus-ext-httplib/version.py
+++ b/contrib/opencensus-ext-httplib/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.dev0'
+__version__ = '0.8.dev0'

--- a/contrib/opencensus-ext-jaeger/version.py
+++ b/contrib/opencensus-ext-jaeger/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.3.dev0'
+__version__ = '0.8.dev0'

--- a/contrib/opencensus-ext-pymongo/version.py
+++ b/contrib/opencensus-ext-pymongo/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.dev0'
+__version__ = '0.8.dev0'

--- a/contrib/opencensus-ext-requests/CHANGELOG.md
+++ b/contrib/opencensus-ext-requests/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.7.1
+Released 2019-08-06
+
+  - Support exporter changes in `opencensus>=0.7.0`
+
 ## 0.1.2
 Released 2019-04-24
 

--- a/contrib/opencensus-ext-requests/version.py
+++ b/contrib/opencensus-ext-requests/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.dev0'
+__version__ = '0.8.dev0'

--- a/contrib/opencensus-ext-stackdriver/version.py
+++ b/contrib/opencensus-ext-stackdriver/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.6.dev0'
+__version__ = '0.8.dev0'


### PR DESCRIPTION
Updates CHANGELOG.md for `opencensus-ext-httplib` and `opencensus-ext-requests` due to them being missed in the `0.7.0` release. Also bumps all packages that were change in release `0.7.1` versions to dev version `0.8.dev0`.