### PR TITLE
Hotfix/django flask pyramid status code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Updated `django`, `flask`, `httplib` and `pyramid` modules.
 
 ## 0.7.1
 Released 2019-08-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Updated `django`, `flask`, `httplib` and `pyramid` modules.
+  ([#755](https://github.com/census-instrumentation/opencensus-python/pull/755))
 
 ## 0.7.1
 Released 2019-08-05

--- a/contrib/opencensus-ext-django/CHANGELOG.md
+++ b/contrib/opencensus-ext-django/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Updated `http.status_code` attribute to be an int.
+  ([#755](https://github.com/census-instrumentation/opencensus-python/pull/755))
 
 ## 0.7.0
 Released 2019-07-31

--- a/contrib/opencensus-ext-django/CHANGELOG.md
+++ b/contrib/opencensus-ext-django/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Updated `http.status_code` attribute to be an int.
 
 ## 0.7.0
 Released 2019-07-31

--- a/contrib/opencensus-ext-django/examples/app/views.py
+++ b/contrib/opencensus-ext-django/examples/app/views.py
@@ -59,7 +59,7 @@ def greetings(request):
 
 def trace_requests(request):
     response = requests.get('http://www.google.com')
-    return HttpResponse(str(response.status_code))
+    return HttpResponse(response.status_code)
 
 
 def mysql_trace(request):

--- a/contrib/opencensus-ext-django/opencensus/ext/django/middleware.py
+++ b/contrib/opencensus-ext-django/opencensus/ext/django/middleware.py
@@ -215,7 +215,7 @@ class OpencensusMiddleware(MiddlewareMixin):
             span = _get_django_span()
             span.add_attribute(
                 attribute_key=HTTP_STATUS_CODE,
-                attribute_value=str(response.status_code))
+                attribute_value=response.status_code)
 
             _set_django_attributes(span, request)
 

--- a/contrib/opencensus-ext-django/tests/test_django_middleware.py
+++ b/contrib/opencensus-ext-django/tests/test_django_middleware.py
@@ -222,7 +222,7 @@ class TestOpencensusMiddleware(unittest.TestCase):
             'http.path': u'/wiki/Rabbit',
             'http.route': u'/wiki/Rabbit',
             'http.url': u'http://testserver/wiki/Rabbit',
-            'http.status_code': '200',
+            'http.status_code': 200,
             'django.user.id': '123',
             'django.user.name': 'test_name'
         }
@@ -277,7 +277,7 @@ class TestOpencensusMiddleware(unittest.TestCase):
             'http.path': u'/wiki/Rabbit',
             'http.route': u'/wiki/Rabbit',
             'http.url': u'http://testserver/wiki/Rabbit',
-            'http.status_code': '500',
+            'http.status_code': 500,
             'django.user.id': '123',
             'django.user.name': 'test_name'
         }

--- a/contrib/opencensus-ext-flask/CHANGELOG.md
+++ b/contrib/opencensus-ext-flask/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Updated `http.status_code` attribute to be an int.
 
 ## 0.7.1
 Released 2019-08-05

--- a/contrib/opencensus-ext-flask/CHANGELOG.md
+++ b/contrib/opencensus-ext-flask/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Updated `http.status_code` attribute to be an int.
+  ([#755](https://github.com/census-instrumentation/opencensus-python/pull/755))
 
 ## 0.7.1
 Released 2019-08-05

--- a/contrib/opencensus-ext-flask/opencensus/ext/flask/flask_middleware.py
+++ b/contrib/opencensus-ext-flask/opencensus/ext/flask/flask_middleware.py
@@ -181,7 +181,7 @@ class FlaskMiddleware(object):
             tracer = execution_context.get_opencensus_tracer()
             tracer.add_attribute_to_current_span(
                 HTTP_STATUS_CODE,
-                str(response.status_code)
+                response.status_code
             )
         except Exception:  # pragma: NO COVER
             log.error('Failed to trace request', exc_info=True)

--- a/contrib/opencensus-ext-flask/tests/test_flask_middleware.py
+++ b/contrib/opencensus-ext-flask/tests/test_flask_middleware.py
@@ -305,7 +305,7 @@ class TestFlaskMiddleware(unittest.TestCase):
                 'http.path': u'/wiki/Rabbit',
                 'http.url': u'http://localhost/wiki/Rabbit',
                 'http.route': u'/wiki/<entry>',
-                'http.status_code': u'200'
+                'http.status_code': 200
             }
 
             self.assertEqual(span.attributes, expected_attributes)

--- a/contrib/opencensus-ext-httplib/CHANGELOG.md
+++ b/contrib/opencensus-ext-httplib/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Updated `http.status_code` attribute to be an int.
 
 ## 0.7.1
 Released 2019-08-06

--- a/contrib/opencensus-ext-httplib/CHANGELOG.md
+++ b/contrib/opencensus-ext-httplib/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Updated `http.status_code` attribute to be an int.
+  ([#755](https://github.com/census-instrumentation/opencensus-python/pull/755))
 
 ## 0.7.1
 Released 2019-08-06

--- a/contrib/opencensus-ext-httplib/opencensus/ext/httplib/trace.py
+++ b/contrib/opencensus-ext-httplib/opencensus/ext/httplib/trace.py
@@ -121,7 +121,7 @@ def wrap_httplib_response(response_func):
 
         # Add the status code to attributes
         _tracer.add_attribute_to_current_span(
-            HTTP_STATUS_CODE, str(result.status))
+            HTTP_STATUS_CODE, result.status)
 
         _tracer.end_span()
         return result

--- a/contrib/opencensus-ext-pyramid/CHANGELOG.md
+++ b/contrib/opencensus-ext-pyramid/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Updated `http.status_code` attribute to be an int.
+  ([#755](https://github.com/census-instrumentation/opencensus-python/pull/755))
 
 ## 0.7.0
 Released 2019-07-31

--- a/contrib/opencensus-ext-pyramid/CHANGELOG.md
+++ b/contrib/opencensus-ext-pyramid/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Updated `http.status_code` attribute to be an int.
 
 ## 0.7.0
 Released 2019-07-31

--- a/contrib/opencensus-ext-pyramid/examples/app/__init__.py
+++ b/contrib/opencensus-ext-pyramid/examples/app/__init__.py
@@ -28,7 +28,7 @@ def hello(request):
 @view_config(route_name='trace_requests')
 def trace_requests(request):
     response = requests.get('http://www.google.com')
-    return Response(str(response.status_code))
+    return Response(response.status_code)
 
 
 def main(global_config, **settings):

--- a/contrib/opencensus-ext-pyramid/opencensus/ext/pyramid/pyramid_middleware.py
+++ b/contrib/opencensus-ext-pyramid/opencensus/ext/pyramid/pyramid_middleware.py
@@ -121,7 +121,7 @@ class OpenCensusTweenFactory(object):
             tracer = execution_context.get_opencensus_tracer()
             tracer.add_attribute_to_current_span(
                 HTTP_STATUS_CODE,
-                str(response.status_code))
+                response.status_code)
 
             tracer.end_span()
             tracer.finish()

--- a/contrib/opencensus-ext-pyramid/tests/test_pyramid_middleware.py
+++ b/contrib/opencensus-ext-pyramid/tests/test_pyramid_middleware.py
@@ -241,7 +241,7 @@ class TestPyramidMiddleware(unittest.TestCase):
             'http.path': u'/',
             'http.route': u'/',
             'http.url': u'http://example.com',
-            'http.status_code': '200',
+            'http.status_code': 200,
         }
 
         self.assertEqual(span.parent_span.span_id, span_id)

--- a/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/trace_exporter/__init__.py
@@ -69,7 +69,10 @@ def set_attributes(trace):
         if span.get('attributes') is None:
             span['attributes'] = {}
 
-        if 'attributeMap' in span['attributes']:
+        if 'http.status_code' in span['attributes']:
+            value = span['attributes']['http.status_code']
+            span['attributes']['http.status_code'] = str(value)
+        elif 'attributeMap' in span['attributes']:
             if 'http.status_code' in span['attributes']['attributeMap']:
                 value = (span['attributes']['attributeMap']
                          ['http.status_code']['int_value']['value'])

--- a/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/trace_exporter/__init__.py
@@ -69,9 +69,17 @@ def set_attributes(trace):
         if span.get('attributes') is None:
             span['attributes'] = {}
 
-        if 'http.status_code' in span['attributes']:
-            span['attributes']['http.status_code'] =\
-                str(span['attributes']['http.status_code'])
+        if 'attributeMap' in span['attributes']:
+            if 'http.status_code' in span['attributes']['attributeMap']:
+                value = (span['attributes']['attributeMap']
+                         ['http.status_code']['int_value']['value'])
+                span['attributes']['attributeMap']['http.status_code'] = \
+                    {
+                        'string_value': {
+                            'truncated_byte_count': 0,
+                            'value': str(value)
+                        }
+                    }
 
         if is_gae_environment():
             set_gae_attributes(span)

--- a/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/trace_exporter/__init__.py
@@ -30,8 +30,10 @@ from opencensus.trace import base_exporter
 from opencensus.trace import span_data
 from opencensus.trace.attributes import Attributes
 
-logging.basicConfig()
-log = logging.Logger(__name__)
+logger = logging.Logger(__name__)
+sh = logging.StreamHandler()
+logger.setLevel(logging.DEBUG)
+logger.addHandler(sh)
 
 
 # Agent
@@ -75,7 +77,7 @@ def set_attributes(trace):
         if span.get('attributes') is None:
             span['attributes'] = {}
 
-        log.warning(span['attributes'])
+        logger.warning(span['attributes'])
 
         if 'http.status_code' in span['attributes']:
             value = span['attributes']['http.status_code']
@@ -98,8 +100,10 @@ def set_attributes(trace):
                         value = (span['attributes']['attributeMap']
                                      ['http.status_code']['int_value'])
                         (span['attributes']['attributeMap']
-                             ['http.status_code']['string_value']) = \
-                            str(value)
+                             ['http.status_code']) = \
+                            {
+                                'string_value': str(value)
+                            }
 
                     elif 'value' not in (span['attributes']['attributeMap']
                                          ['http.status_code']['int_value']):

--- a/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/trace_exporter/__init__.py
@@ -73,6 +73,9 @@ def set_attributes(trace):
 
         log = logging.Logger(__name__)
         log.info(span['attributes'])
+        handler = logging.StreamHandler()
+        handler.setLevel(logging.DEBUG)
+        log.addHandler(handler)
 
         if 'http.status_code' in span['attributes']:
             value = span['attributes']['http.status_code']

--- a/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/trace_exporter/__init__.py
@@ -274,6 +274,9 @@ class StackdriverExporter(base_exporter.Exporter):
                 if (attribute_key in ATTRIBUTE_MAPPING):
                     new_key = ATTRIBUTE_MAPPING.get(attribute_key)
                     value[new_key] = value.pop(attribute_key)
+                    if attribute_key == 'http.status_code':
+                        value[new_key]['int_value']['value'] = \
+                            str(value[new_key]['int_value']['value'])
 
         return attribute_map
 

--- a/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/trace_exporter/__init__.py
@@ -90,8 +90,19 @@ def set_attributes(trace):
                         str(value)
                 elif 'int_value' in (span['attributes']['attributeMap']
                                      ['http.status_code']):
-                    if 'value' in (span['attributes']['attributeMap']
-                                   ['http.status_code']['int_value']):
+                    if isinstance(
+                        span['attributes']['attributeMap']
+                            ['http.status_code']['int_value'],
+                            int
+                    ):
+                        value = (span['attributes']['attributeMap']
+                                     ['http.status_code']['int_value'])
+                        (span['attributes']['attributeMap']
+                             ['http.status_code']['string_value']) = \
+                            str(value)
+
+                    elif 'value' not in (span['attributes']['attributeMap']
+                                         ['http.status_code']['int_value']):
                         value = (span['attributes']['attributeMap']
                                      ['http.status_code']['int_value']
                                      ['value'])

--- a/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/trace_exporter/__init__.py
@@ -69,6 +69,10 @@ def set_attributes(trace):
         if span.get('attributes') is None:
             span['attributes'] = {}
 
+        if 'http.status_code' in span['attributes']:
+            span['attributes']['http.status_code'] =\
+                str(span['attributes']['http.status_code'])
+
         if is_gae_environment():
             set_gae_attributes(span)
 
@@ -274,9 +278,6 @@ class StackdriverExporter(base_exporter.Exporter):
                 if (attribute_key in ATTRIBUTE_MAPPING):
                     new_key = ATTRIBUTE_MAPPING.get(attribute_key)
                     value[new_key] = value.pop(attribute_key)
-                    if attribute_key == 'http.status_code':
-                        value[new_key]['int_value']['value'] = \
-                            str(value[new_key]['int_value']['value'])
 
         return attribute_map
 

--- a/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/trace_exporter/__init__.py
@@ -281,7 +281,8 @@ class StackdriverExporter(base_exporter.Exporter):
                         hack = hack['int_value']
                         if not isinstance(hack, int):
                             hack = hack['value']
-                        value[new_key] = {'int_value': {
+                        value[new_key] = {'string_value': {
+                            'truncated_byte_count': 0,
                             'value': str(hack),
                         }}
 

--- a/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/trace_exporter/__init__.py
@@ -87,15 +87,27 @@ def set_attributes(trace):
                         str(value)
                 elif 'int_value' in (span['attributes']['attributeMap']
                                      ['http.status_code']):
-                    value = (span['attributes']['attributeMap']
-                             ['http.status_code']['int_value']['value'])
-                    span['attributes']['attributeMap']['http.status_code'] = \
-                        {
-                            'string_value': {
-                                'truncated_byte_count': 0,
-                                'value': str(value)
+                    if 'value' in (span['attributes']['attributeMap']
+                                   ['http.status_code']['int_value']):
+                        value = (span['attributes']['attributeMap']
+                                     ['http.status_code']['int_value']
+                                     ['value'])
+                        (span['attributes']['attributeMap']
+                             ['http.status_code']) = \
+                            {
+                                'string_value': {
+                                    'truncated_byte_count': 0,
+                                    'value': str(value)
+                                }
                             }
-                        }
+                    else:
+                        value = (span['attributes']['attributeMap']
+                                     ['http.status_code']['int_value'])
+                        (span['attributes']['attributeMap']
+                         ['http.status_code']) = \
+                            {
+                                'string_value': str(value)
+                            }
 
         if is_gae_environment():
             set_gae_attributes(span)

--- a/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/trace_exporter/__init__.py
@@ -281,8 +281,7 @@ class StackdriverExporter(base_exporter.Exporter):
                         hack = hack['int_value']
                         if not isinstance(hack, int):
                             hack = hack['value']
-                        value[new_key] = {'string_value': {
-                            'truncated_byte_count': 0,
+                        value[new_key] = {'int_value': {
                             'value': str(hack),
                         }}
 

--- a/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/trace_exporter/__init__.py
@@ -30,6 +30,10 @@ from opencensus.trace import base_exporter
 from opencensus.trace import span_data
 from opencensus.trace.attributes import Attributes
 
+logging.basicConfig()
+log = logging.Logger(__name__)
+
+
 # Agent
 AGENT = 'opencensus-python [{}]'.format(__version__)
 
@@ -71,11 +75,7 @@ def set_attributes(trace):
         if span.get('attributes') is None:
             span['attributes'] = {}
 
-        log = logging.Logger(__name__)
-        log.info(span['attributes'])
-        handler = logging.StreamHandler()
-        handler.setLevel(logging.DEBUG)
-        log.addHandler(handler)
+        log.warning(span['attributes'])
 
         if 'http.status_code' in span['attributes']:
             value = span['attributes']['http.status_code']

--- a/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/trace_exporter/__init__.py
@@ -15,6 +15,8 @@
 from collections import defaultdict
 import os
 
+import logging
+
 from google.cloud.trace.client import Client
 
 from opencensus.common.monitored_resource import aws_identity_doc_utils
@@ -69,20 +71,24 @@ def set_attributes(trace):
         if span.get('attributes') is None:
             span['attributes'] = {}
 
+        log = logging.Logger(__name__)
+        log.info(span['attributes'])
+
         if 'http.status_code' in span['attributes']:
             value = span['attributes']['http.status_code']
             span['attributes']['http.status_code'] = str(value)
         elif 'attributeMap' in span['attributes']:
             if 'http.status_code' in span['attributes']['attributeMap']:
                 if 'int_value' not in (span['attributes']['attributeMap']
-                                   ['http.status_code']):
+                                       ['http.status_code']):
                     value = (span['attributes']['attributeMap']
-                            ['http.status_code'])
+                             ['http.status_code'])
                     span['attributes']['attributeMap']['http.status_code'] = \
                         str(value)
-                else:
+                elif 'int_value' in (span['attributes']['attributeMap']
+                                     ['http.status_code']):
                     value = (span['attributes']['attributeMap']
-                            ['http.status_code']['int_value']['value'])
+                             ['http.status_code']['int_value']['value'])
                     span['attributes']['attributeMap']['http.status_code'] = \
                         {
                             'string_value': {

--- a/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/trace_exporter/__init__.py
@@ -74,15 +74,22 @@ def set_attributes(trace):
             span['attributes']['http.status_code'] = str(value)
         elif 'attributeMap' in span['attributes']:
             if 'http.status_code' in span['attributes']['attributeMap']:
-                value = (span['attributes']['attributeMap']
-                         ['http.status_code']['int_value']['value'])
-                span['attributes']['attributeMap']['http.status_code'] = \
-                    {
-                        'string_value': {
-                            'truncated_byte_count': 0,
-                            'value': str(value)
+                if 'int_value' not in (span['attributes']['attributeMap']
+                                   ['http.status_code']):
+                    value = (span['attributes']['attributeMap']
+                            ['http.status_code'])
+                    span['attributes']['attributeMap']['http.status_code'] = \
+                        str(value)
+                else:
+                    value = (span['attributes']['attributeMap']
+                            ['http.status_code']['int_value']['value'])
+                    span['attributes']['attributeMap']['http.status_code'] = \
+                        {
+                            'string_value': {
+                                'truncated_byte_count': 0,
+                                'value': str(value)
+                            }
                         }
-                    }
 
         if is_gae_environment():
             set_gae_attributes(span)

--- a/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_exporter.py
+++ b/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_exporter.py
@@ -448,7 +448,8 @@ class TestStackdriverExporter(unittest.TestCase):
                     }
                 },
                 '/http/status_code': {
-                    'int_value': {
+                    'string_value': {
+                        'truncated_byte_count': 0,
                         'value': '200'
                     }
                 },
@@ -552,7 +553,8 @@ class TestStackdriverExporter(unittest.TestCase):
             'outer key': 'some value',
             'attributeMap': {
                 '/http/status_code': {
-                    'int_value': {
+                    'string_value': {
+                        'truncated_byte_count': 0,
                         'value': '200'
                     }
                 }

--- a/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_exporter.py
+++ b/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_exporter.py
@@ -281,6 +281,7 @@ class TestStackdriverExporter(unittest.TestCase):
         self.assertIsNone(exporter.map_attributes(None))
 
     def test_translate_common_attributes_to_stackdriver(self):
+        self.maxDiff = None
         project_id = 'PROJECT'
         client = mock.Mock()
         client.project = project_id
@@ -449,7 +450,7 @@ class TestStackdriverExporter(unittest.TestCase):
                 },
                 '/http/status_code': {
                     'int_value': {
-                        'value': 200
+                        'value': '200'
                     }
                 },
                 '/http/url': {

--- a/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_exporter.py
+++ b/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_exporter.py
@@ -170,6 +170,11 @@ class TestStackdriverExporter(unittest.TestCase):
                         'truncated_byte_count': 0,
                         'value': 'host'
                     }
+                },
+                'http.status_code': {
+                    'int_value': {
+                        'value': 200
+                    }
                 }
             }
         }
@@ -239,6 +244,12 @@ class TestStackdriverExporter(unittest.TestCase):
                         'string_value': {
                             'truncated_byte_count': 0,
                             'value': 'host'
+                        }
+                    },
+                    '/http/status_code': {
+                        'string_value': {
+                            'truncated_byte_count': 0,
+                            'value': '200'
                         }
                     }
                 }

--- a/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_exporter.py
+++ b/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_exporter.py
@@ -448,8 +448,7 @@ class TestStackdriverExporter(unittest.TestCase):
                     }
                 },
                 '/http/status_code': {
-                    'string_value': {
-                        'truncated_byte_count': 0,
+                    'int_value': {
                         'value': '200'
                     }
                 },
@@ -553,8 +552,7 @@ class TestStackdriverExporter(unittest.TestCase):
             'outer key': 'some value',
             'attributeMap': {
                 '/http/status_code': {
-                    'string_value': {
-                        'truncated_byte_count': 0,
+                    'int_value': {
                         'value': '200'
                     }
                 }

--- a/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_exporter.py
+++ b/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_exporter.py
@@ -281,7 +281,6 @@ class TestStackdriverExporter(unittest.TestCase):
         self.assertIsNone(exporter.map_attributes(None))
 
     def test_translate_common_attributes_to_stackdriver(self):
-        self.maxDiff = None
         project_id = 'PROJECT'
         client = mock.Mock()
         client.project = project_id
@@ -328,8 +327,9 @@ class TestStackdriverExporter(unittest.TestCase):
                     }
                 },
                 'http.status_code': {
-                    'int_value': {
-                        'value': 200
+                    'string_value': {
+                        'truncated_byte_count': 0,
+                        'value': '200'
                     }
                 },
                 'http.url': {
@@ -449,7 +449,8 @@ class TestStackdriverExporter(unittest.TestCase):
                     }
                 },
                 '/http/status_code': {
-                    'int_value': {
+                    'string_value': {
+                        'truncated_byte_count': 0,
                         'value': '200'
                     }
                 },

--- a/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_exporter.py
+++ b/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_exporter.py
@@ -170,11 +170,6 @@ class TestStackdriverExporter(unittest.TestCase):
                         'truncated_byte_count': 0,
                         'value': 'host'
                     }
-                },
-                'http.status_code': {
-                    'int_value': {
-                        'value': 200
-                    }
                 }
             }
         }
@@ -244,12 +239,6 @@ class TestStackdriverExporter(unittest.TestCase):
                         'string_value': {
                             'truncated_byte_count': 0,
                             'value': 'host'
-                        }
-                    },
-                    '/http/status_code': {
-                        'string_value': {
-                            'truncated_byte_count': 0,
-                            'value': '200'
                         }
                     }
                 }
@@ -338,9 +327,8 @@ class TestStackdriverExporter(unittest.TestCase):
                     }
                 },
                 'http.status_code': {
-                    'string_value': {
-                        'truncated_byte_count': 0,
-                        'value': '200'
+                    'int_value': {
+                        'value': 200
                     }
                 },
                 'http.url': {
@@ -537,6 +525,37 @@ class TestStackdriverExporter(unittest.TestCase):
                     'string_value': {
                         'truncated_byte_count': 0,
                         'value': 'post'
+                    }
+                }
+            }
+        }
+
+        exporter.map_attributes(attributes)
+        self.assertEqual(attributes, expected_attributes)
+
+    def test_translate_common_attributes_status_code(self):
+        project_id = 'PROJECT'
+        client = mock.Mock()
+        client.project = project_id
+        exporter = trace_exporter.StackdriverExporter(
+            client=client, project_id=project_id)
+
+        attributes = {
+            'outer key': 'some value',
+            'attributeMap': {
+                'http.status_code': {
+                    'int_value': 200
+                }
+            }
+        }
+
+        expected_attributes = {
+            'outer key': 'some value',
+            'attributeMap': {
+                '/http/status_code': {
+                    'string_value': {
+                        'truncated_byte_count': 0,
+                        'value': '200'
                     }
                 }
             }

--- a/tests/system/trace/django/django_system_test.py
+++ b/tests/system/trace/django/django_system_test.py
@@ -102,8 +102,8 @@ class TestDjangoTrace(unittest.TestCase):
             self.assertEqual(len(spans), 1)
 
             for span in spans:
-                labels = span.get('labels')
-                self.assertEqual(labels.get('/http/status_code'), 200)
+                attributes = span.get('attributes')
+                self.assertEqual(attributes.get('/http/status_code'), 200)
 
         test_with_retry(self)
 
@@ -126,15 +126,15 @@ class TestDjangoTrace(unittest.TestCase):
             request_succeeded = False
 
             for span in spans:
-                labels = span.get('labels')
-                if '/http/status_code' in labels.keys():
-                    self.assertEqual(labels.get('/http/status_code'), 200)
+                attributes = span.get('attributes')
+                if '/http/status_code' in attributes.keys():
+                    self.assertEqual(attributes.get('/http/status_code'), 200)
                     request_succeeded = True
 
                 if span.get('name') == '[mysql.query]SELECT 2*3':
                     self.assertEqual(
-                        labels.get('mysql.cursor.method.name'), 'execute')
-                    self.assertEqual(labels.get('mysql.query'), 'SELECT 2*3')
+                        attributes.get('mysql.cursor.method.name'), 'execute')
+                    self.assertEqual(attributes.get('mysql.query'), 'SELECT 2*3')
 
             self.assertTrue(request_succeeded)
 
@@ -161,16 +161,16 @@ class TestDjangoTrace(unittest.TestCase):
             request_succeeded = False
 
             for span in spans:
-                labels = span.get('labels')
-                if '/http/status_code' in labels.keys():
-                    self.assertEqual(labels.get('/http/status_code'), 200)
+                attributes = span.get('attributes')
+                if '/http/status_code' in attributes.keys():
+                    self.assertEqual(attributes.get('/http/status_code'), 200)
                     request_succeeded = True
 
                 if span.get('name') == '[postgresql.query]SELECT 2*3':
                     self.assertEqual(
-                        labels.get('postgresql.cursor.method.name'), 'execute')
+                        attributes.get('postgresql.cursor.method.name'), 'execute')
                     self.assertEqual(
-                        labels.get('postgresql.query'), 'SELECT 2*3')
+                        attributes.get('postgresql.query'), 'SELECT 2*3')
 
             self.assertTrue(request_succeeded)
 
@@ -194,9 +194,9 @@ class TestDjangoTrace(unittest.TestCase):
             request_succeeded = False
 
             for span in spans:
-                labels = span.get('labels')
-                if '/http/status_code' in labels.keys():
-                    self.assertEqual(labels.get('/http/status_code'), 200)
+                attributes = span.get('attributes')
+                if '/http/status_code' in attributes.keys():
+                    self.assertEqual(attributes.get('/http/status_code'), 200)
                     request_succeeded = True
 
             self.assertTrue(request_succeeded)
@@ -222,9 +222,9 @@ class TestDjangoTrace(unittest.TestCase):
             request_succeeded = False
 
             for span in spans:
-                labels = span.get('labels')
-                if '/http/status_code' in labels.keys():
-                    self.assertEqual(labels.get('/http/status_code'), 200)
+                attributes = span.get('attributes')
+                if '/http/status_code' in attributes.keys():
+                    self.assertEqual(attributes.get('/http/status_code'), 200)
                     request_succeeded = True
 
             self.assertTrue(request_succeeded)

--- a/tests/system/trace/django/django_system_test.py
+++ b/tests/system/trace/django/django_system_test.py
@@ -102,8 +102,8 @@ class TestDjangoTrace(unittest.TestCase):
             self.assertEqual(len(spans), 1)
 
             for span in spans:
-                attributes = span.get('attributes')
-                self.assertEqual(attributes.get('/http/status_code'), 200)
+                labels = span.get('labels')
+                self.assertEqual(labels.get('/http/status_code'), '200')
 
         test_with_retry(self)
 
@@ -126,15 +126,17 @@ class TestDjangoTrace(unittest.TestCase):
             request_succeeded = False
 
             for span in spans:
-                attributes = span.get('attributes')
-                if '/http/status_code' in attributes.keys():
-                    self.assertEqual(attributes.get('/http/status_code'), 200)
+                labels = span.get('labels')
+                if '/http/status_code' in labels.keys():
+                    self.assertEqual(labels.get('/http/status_code'), '200')
                     request_succeeded = True
 
                 if span.get('name') == '[mysql.query]SELECT 2*3':
                     self.assertEqual(
-                        attributes.get('mysql.cursor.method.name'), 'execute')
-                    self.assertEqual(attributes.get('mysql.query'), 'SELECT 2*3')
+                        labels.get('mysql.cursor.method.name'), 'execute')
+                    self.assertEqual(
+                        labels.get('mysql.query'), 'SELECT 2*3'
+                    )
 
             self.assertTrue(request_succeeded)
 
@@ -161,16 +163,18 @@ class TestDjangoTrace(unittest.TestCase):
             request_succeeded = False
 
             for span in spans:
-                attributes = span.get('attributes')
-                if '/http/status_code' in attributes.keys():
-                    self.assertEqual(attributes.get('/http/status_code'), 200)
+                labels = span.get('labels')
+                if '/http/status_code' in labels.keys():
+                    self.assertEqual(labels.get('/http/status_code'), '200')
                     request_succeeded = True
 
                 if span.get('name') == '[postgresql.query]SELECT 2*3':
                     self.assertEqual(
-                        attributes.get('postgresql.cursor.method.name'), 'execute')
+                        labels.get(
+                            'postgresql.cursor.method.name'), 'execute'
+                        )
                     self.assertEqual(
-                        attributes.get('postgresql.query'), 'SELECT 2*3')
+                        labels.get('postgresql.query'), 'SELECT 2*3')
 
             self.assertTrue(request_succeeded)
 
@@ -194,9 +198,9 @@ class TestDjangoTrace(unittest.TestCase):
             request_succeeded = False
 
             for span in spans:
-                attributes = span.get('attributes')
-                if '/http/status_code' in attributes.keys():
-                    self.assertEqual(attributes.get('/http/status_code'), 200)
+                labels = span.get('labels')
+                if '/http/status_code' in labels.keys():
+                    self.assertEqual(labels.get('/http/status_code'), '200')
                     request_succeeded = True
 
             self.assertTrue(request_succeeded)
@@ -222,9 +226,9 @@ class TestDjangoTrace(unittest.TestCase):
             request_succeeded = False
 
             for span in spans:
-                attributes = span.get('attributes')
-                if '/http/status_code' in attributes.keys():
-                    self.assertEqual(attributes.get('/http/status_code'), 200)
+                labels = span.get('labels')
+                if '/http/status_code' in labels.keys():
+                    self.assertEqual(labels.get('/http/status_code'), '200')
                     request_succeeded = True
 
             self.assertTrue(request_succeeded)

--- a/tests/system/trace/django/django_system_test.py
+++ b/tests/system/trace/django/django_system_test.py
@@ -103,7 +103,7 @@ class TestDjangoTrace(unittest.TestCase):
 
             for span in spans:
                 labels = span.get('labels')
-                self.assertEqual(labels.get('/http/status_code'), '200')
+                self.assertEqual(labels.get('/http/status_code'), 200)
 
         test_with_retry(self)
 
@@ -128,7 +128,7 @@ class TestDjangoTrace(unittest.TestCase):
             for span in spans:
                 labels = span.get('labels')
                 if '/http/status_code' in labels.keys():
-                    self.assertEqual(labels.get('/http/status_code'), '200')
+                    self.assertEqual(labels.get('/http/status_code'), 200)
                     request_succeeded = True
 
                 if span.get('name') == '[mysql.query]SELECT 2*3':
@@ -163,7 +163,7 @@ class TestDjangoTrace(unittest.TestCase):
             for span in spans:
                 labels = span.get('labels')
                 if '/http/status_code' in labels.keys():
-                    self.assertEqual(labels.get('/http/status_code'), '200')
+                    self.assertEqual(labels.get('/http/status_code'), 200)
                     request_succeeded = True
 
                 if span.get('name') == '[postgresql.query]SELECT 2*3':
@@ -196,7 +196,7 @@ class TestDjangoTrace(unittest.TestCase):
             for span in spans:
                 labels = span.get('labels')
                 if '/http/status_code' in labels.keys():
-                    self.assertEqual(labels.get('/http/status_code'), '200')
+                    self.assertEqual(labels.get('/http/status_code'), 200)
                     request_succeeded = True
 
             self.assertTrue(request_succeeded)
@@ -224,7 +224,7 @@ class TestDjangoTrace(unittest.TestCase):
             for span in spans:
                 labels = span.get('labels')
                 if '/http/status_code' in labels.keys():
-                    self.assertEqual(labels.get('/http/status_code'), '200')
+                    self.assertEqual(labels.get('/http/status_code'), 200)
                     request_succeeded = True
 
             self.assertTrue(request_succeeded)

--- a/tests/system/trace/flask/flask_system_test.py
+++ b/tests/system/trace/flask/flask_system_test.py
@@ -102,7 +102,7 @@ class TestFlaskTrace(unittest.TestCase):
 
             for span in spans:
                 labels = span.get('labels')
-                self.assertEqual(labels.get('/http/status_code'), '200')
+                self.assertEqual(labels.get('/http/status_code'), 200)
 
         test_with_retry(self)
 
@@ -127,7 +127,7 @@ class TestFlaskTrace(unittest.TestCase):
             for span in spans:
                 labels = span.get('labels')
                 if '/http/status_code' in labels.keys():
-                    self.assertEqual(labels.get('/http/status_code'), '200')
+                    self.assertEqual(labels.get('/http/status_code'), 200)
                     request_succeeded = True
 
                 if span.get('name') == '[mysql.query]SELECT 2*3':
@@ -162,7 +162,7 @@ class TestFlaskTrace(unittest.TestCase):
             for span in spans:
                 labels = span.get('labels')
                 if '/http/status_code' in labels.keys():
-                    self.assertEqual(labels.get('/http/status_code'), '200')
+                    self.assertEqual(labels.get('/http/status_code'), 200)
                     request_succeeded = True
 
                 if span.get('name') == '[postgresql.query]SELECT 2*3':
@@ -195,7 +195,7 @@ class TestFlaskTrace(unittest.TestCase):
             for span in spans:
                 labels = span.get('labels')
                 if '/http/status_code' in labels.keys():
-                    self.assertEqual(labels.get('/http/status_code'), '200')
+                    self.assertEqual(labels.get('/http/status_code'), 200)
                     request_succeeded = True
 
             self.assertTrue(request_succeeded)
@@ -223,7 +223,7 @@ class TestFlaskTrace(unittest.TestCase):
             for span in spans:
                 labels = span.get('labels')
                 if '/http/status_code' in labels.keys():
-                    self.assertEqual(labels.get('/http/status_code'), '200')
+                    self.assertEqual(labels.get('/http/status_code'), 200)
                     request_succeeded = True
 
             self.assertTrue(request_succeeded)

--- a/tests/system/trace/flask/flask_system_test.py
+++ b/tests/system/trace/flask/flask_system_test.py
@@ -101,8 +101,8 @@ class TestFlaskTrace(unittest.TestCase):
             self.assertEqual(len(spans), 1)
 
             for span in spans:
-                labels = span.get('labels')
-                self.assertEqual(labels.get('/http/status_code'), 200)
+                attributes = span.get('attributes')
+                self.assertEqual(attributes.get('/http/status_code'), 200)
 
         test_with_retry(self)
 
@@ -125,15 +125,15 @@ class TestFlaskTrace(unittest.TestCase):
             request_succeeded = False
 
             for span in spans:
-                labels = span.get('labels')
-                if '/http/status_code' in labels.keys():
-                    self.assertEqual(labels.get('/http/status_code'), 200)
+                attributes = span.get('attributes')
+                if '/http/status_code' in attributes.keys():
+                    self.assertEqual(attributes.get('/http/status_code'), 200)
                     request_succeeded = True
 
                 if span.get('name') == '[mysql.query]SELECT 2*3':
                     self.assertEqual(
-                        labels.get('mysql.cursor.method.name'), 'execute')
-                    self.assertEqual(labels.get('mysql.query'), 'SELECT 2*3')
+                        attributes.get('mysql.cursor.method.name'), 'execute')
+                    self.assertEqual(attributes.get('mysql.query'), 'SELECT 2*3')
 
             self.assertTrue(request_succeeded)
 
@@ -160,16 +160,16 @@ class TestFlaskTrace(unittest.TestCase):
             request_succeeded = False
 
             for span in spans:
-                labels = span.get('labels')
-                if '/http/status_code' in labels.keys():
-                    self.assertEqual(labels.get('/http/status_code'), 200)
+                attributes = span.get('attributes')
+                if '/http/status_code' in attributes.keys():
+                    self.assertEqual(attributes.get('/http/status_code'), 200)
                     request_succeeded = True
 
                 if span.get('name') == '[postgresql.query]SELECT 2*3':
                     self.assertEqual(
-                        labels.get('postgresql.cursor.method.name'), 'execute')
+                        attributes.get('postgresql.cursor.method.name'), 'execute')
                     self.assertEqual(
-                        labels.get('postgresql.query'), 'SELECT 2*3')
+                        attributes.get('postgresql.query'), 'SELECT 2*3')
 
             self.assertTrue(request_succeeded)
 
@@ -193,9 +193,9 @@ class TestFlaskTrace(unittest.TestCase):
             request_succeeded = False
 
             for span in spans:
-                labels = span.get('labels')
-                if '/http/status_code' in labels.keys():
-                    self.assertEqual(labels.get('/http/status_code'), 200)
+                attributes = span.get('attributes')
+                if '/http/status_code' in attributes.keys():
+                    self.assertEqual(attributes.get('/http/status_code'), 200)
                     request_succeeded = True
 
             self.assertTrue(request_succeeded)
@@ -221,9 +221,9 @@ class TestFlaskTrace(unittest.TestCase):
             request_succeeded = False
 
             for span in spans:
-                labels = span.get('labels')
-                if '/http/status_code' in labels.keys():
-                    self.assertEqual(labels.get('/http/status_code'), 200)
+                attributes = span.get('attributes')
+                if '/http/status_code' in attributes.keys():
+                    self.assertEqual(attributes.get('/http/status_code'), 200)
                     request_succeeded = True
 
             self.assertTrue(request_succeeded)

--- a/tests/system/trace/flask/flask_system_test.py
+++ b/tests/system/trace/flask/flask_system_test.py
@@ -101,8 +101,8 @@ class TestFlaskTrace(unittest.TestCase):
             self.assertEqual(len(spans), 1)
 
             for span in spans:
-                attributes = span.get('attributes')
-                self.assertEqual(attributes.get('/http/status_code'), 200)
+                labels = span.get('labels')
+                self.assertEqual(labels.get('/http/status_code'), '200')
 
         test_with_retry(self)
 
@@ -125,15 +125,15 @@ class TestFlaskTrace(unittest.TestCase):
             request_succeeded = False
 
             for span in spans:
-                attributes = span.get('attributes')
-                if '/http/status_code' in attributes.keys():
-                    self.assertEqual(attributes.get('/http/status_code'), 200)
+                labels = span.get('labels')
+                if '/http/status_code' in labels.keys():
+                    self.assertEqual(labels.get('/http/status_code'), '200')
                     request_succeeded = True
 
                 if span.get('name') == '[mysql.query]SELECT 2*3':
                     self.assertEqual(
-                        attributes.get('mysql.cursor.method.name'), 'execute')
-                    self.assertEqual(attributes.get('mysql.query'), 'SELECT 2*3')
+                        labels.get('mysql.cursor.method.name'), 'execute')
+                    self.assertEqual(labels.get('mysql.query'), 'SELECT 2*3')
 
             self.assertTrue(request_succeeded)
 
@@ -160,16 +160,18 @@ class TestFlaskTrace(unittest.TestCase):
             request_succeeded = False
 
             for span in spans:
-                attributes = span.get('attributes')
-                if '/http/status_code' in attributes.keys():
-                    self.assertEqual(attributes.get('/http/status_code'), 200)
+                labels = span.get('labels')
+                if '/http/status_code' in labels.keys():
+                    self.assertEqual(
+                        labels.get('/http/status_code'), '200'
+                    )
                     request_succeeded = True
 
                 if span.get('name') == '[postgresql.query]SELECT 2*3':
                     self.assertEqual(
-                        attributes.get('postgresql.cursor.method.name'), 'execute')
+                        labels.get('postgresql.cursor.method.name'), 'execute')
                     self.assertEqual(
-                        attributes.get('postgresql.query'), 'SELECT 2*3')
+                        labels.get('postgresql.query'), 'SELECT 2*3')
 
             self.assertTrue(request_succeeded)
 
@@ -193,9 +195,9 @@ class TestFlaskTrace(unittest.TestCase):
             request_succeeded = False
 
             for span in spans:
-                attributes = span.get('attributes')
-                if '/http/status_code' in attributes.keys():
-                    self.assertEqual(attributes.get('/http/status_code'), 200)
+                labels = span.get('labels')
+                if '/http/status_code' in labels.keys():
+                    self.assertEqual(labels.get('/http/status_code'), '200')
                     request_succeeded = True
 
             self.assertTrue(request_succeeded)
@@ -221,9 +223,9 @@ class TestFlaskTrace(unittest.TestCase):
             request_succeeded = False
 
             for span in spans:
-                attributes = span.get('attributes')
-                if '/http/status_code' in attributes.keys():
-                    self.assertEqual(attributes.get('/http/status_code'), 200)
+                labels = span.get('labels')
+                if '/http/status_code' in labels.keys():
+                    self.assertEqual(labels.get('/http/status_code'), '200')
                     request_succeeded = True
 
             self.assertTrue(request_succeeded)


### PR DESCRIPTION
Updating `http.status_code` to be an int, as discussed with @reyang. This affects the following contributions:
- Django
- Flask
- Httplib
- Pyramid