### PR TITLE
Update codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,8 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-*               @census-instrumentation/global-owners @c24t @reyang @songy23
+*       @census-instrumentation/global-owners @c24t @reyang @songy23 @victoraugustolls
+
+/contrib/opencensus-ext-azure/ @lzchen
+
+/contrib/opencensus-ext-django/ @timgraham

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,3 @@
 *       @census-instrumentation/global-owners @c24t @reyang @songy23 @victoraugustolls
 
 /contrib/opencensus-ext-azure/ @lzchen
-
-/contrib/opencensus-ext-django/ @timgraham


### PR DESCRIPTION
1. Propose to add @victoraugustolls as the owner. Victor has expressed strong interest and commitment in OpenCensus and OpenTelemetry Python SDKs. He has contributed #735, #738, #746 and #755, the code quality is excellent!
2. Add @lzchen as the owner for `opencensus-ext-azure` package. @lzchen is the full time employee of Microsoft working on OpenCensus/OpenTelemetry Python SDKs and the integration with Azure.

Please let me know if you have any objections.