### PR TITLE
Django middleware: allow autogenerated span name override

### DIFF
--- a/contrib/opencensus-ext-django/opencensus/ext/django/middleware.py
+++ b/contrib/opencensus-ext-django/opencensus/ext/django/middleware.py
@@ -188,7 +188,10 @@ class OpencensusMiddleware(MiddlewareMixin):
         except Exception:  # pragma: NO COVER
             log.error('Failed to trace request', exc_info=True)
 
-    def process_view(self, request, view_func, *args, **kwargs):
+    def get_span_name(self, request):
+        return utils.get_func_name(request.resolver_match.func)
+
+    def process_view(self, request, *args, **kwargs):
         """Process view is executed before the view function, here we get the
         function name add set it as the span name.
         """
@@ -202,7 +205,7 @@ class OpencensusMiddleware(MiddlewareMixin):
             # function name of the request.
             tracer = _get_current_tracer()
             span = tracer.current_span()
-            span.name = utils.get_func_name(view_func)
+            span.name = self.get_span_name(request)
         except Exception:  # pragma: NO COVER
             log.error('Failed to trace request', exc_info=True)
 

--- a/contrib/opencensus-ext-django/tests/test_django_middleware.py
+++ b/contrib/opencensus-ext-django/tests/test_django_middleware.py
@@ -82,7 +82,10 @@ class TestOpencensusMiddleware(unittest.TestCase):
             middleware_obj = self.middleware_kls()
 
         assert isinstance(middleware_obj.sampler, samplers.AlwaysOnSampler)
-        assert isinstance(middleware_obj.exporter, print_exporter.PrintExporter)
+        assert isinstance(
+            middleware_obj.exporter,
+            print_exporter.PrintExporter,
+        )
         assert isinstance(
             middleware_obj.propagator,
             trace_context_http_header_format.TraceContextPropagator,
@@ -390,7 +393,8 @@ class TestCustomisedOpencensusMiddleware(TestOpencensusMiddleware):
         # test process_view
         middleware_obj.process_view(django_request)
 
-        self.assertEqual(span.name, 'MyService.test_django_middleware.MockViewOk')
+        self.assertEqual(
+            span.name, 'MyService.test_django_middleware.MockViewOk')
 
 
 class Test__set_django_attributes(unittest.TestCase):


### PR DESCRIPTION
In the Django Middleware, a span is created with an autogenerated name. The name setting is currently part of the `process_view()` function which also contains other logic for the middleware functionality, so it's not easy / safe to override this method for the purpose of customizing the span naming. With the Django new-style middleware in the future, there won't be a `process_view()` method alltogether (see https://github.com/census-instrumentation/opencensus-python/blob/63e2c97682ba9aea2dd0668ff3ac338581e683da/contrib/opencensus-ext-django/opencensus/ext/django/middleware.py#L123), so people having customized the process_view method for the purpose of span naming will have an issue.

This PR adds a separate span naming method to the middleware as a hook to allow end-user customization. It's sole purpose is to generate a span name, which gives people an easy way to customize the naming convention by subclassing the middleware and overriding this single method without impacting the other functioning of the middleware (compatible with both this style and new-style middleware).