### PR TITLE
Update GCP metadata URL

### DIFF
--- a/opencensus/common/monitored_resource/gcp_metadata_config.py
+++ b/opencensus/common/monitored_resource/gcp_metadata_config.py
@@ -14,7 +14,7 @@
 
 from opencensus.common.http_handler import get_request
 
-_GCP_METADATA_URI = 'http://metadata/computeMetadata/v1/'
+_GCP_METADATA_URI = 'http://metadata.google.internal/computeMetadata/v1/'
 _GCP_METADATA_URI_HEADER = {'Metadata-Flavor': 'Google'}
 
 # ID of the GCP project associated with this resource, such as "my-project"


### PR DESCRIPTION
Fix for @red2k18

This PR changes the GCP metadata URI, which currently causes some environments that expect a FQDN to fail to load resources. See https://github.com/census-instrumentation/opencensus-java/pull/1855 for the same change in the java client.