### PR TITLE
Implement Connection Strings for Azure Exporters

### DIFF
--- a/contrib/opencensus-ext-azure/CHANGELOG.md
+++ b/contrib/opencensus-ext-azure/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Implement connection strings
+  ([#767](https://github.com/census-instrumentation/opencensus-python/pull/767))
 - Standard metrics incoming requests per second
   ([#758](https://github.com/census-instrumentation/opencensus-python/pull/758))
 

--- a/contrib/opencensus-ext-azure/README.rst
+++ b/contrib/opencensus-ext-azure/README.rst
@@ -24,9 +24,8 @@ The **Azure Monitor Log Handler** allows you to export Python logs to `Azure Mon
 This example shows how to send a warning level log to Azure Monitor.
 
 * Create an Azure Monitor resource and get the instrumentation key, more information can be found `here <https://docs.microsoft.com/azure/azure-monitor/app/create-new-resource>`_.
-* Place your instrumentation key in a connection string and into ``APPLICATIONINSIGHTS_CONNECTION_STRING`` environment variable.
-* You can also put the instrumentation key in ``APPINSIGHTS_INSTRUMENTATIONKEY`` environment variable.
-* Alternatively, you can specify either the connection string or instrumentation key directly in your code, which will take priority over a set environment variable.
+* Place your instrumentation key in a `connection string` and directly into your code.
+* Alternatively, you can specify your `connection string` in an environment variable ``APPLICATIONINSIGHTS_CONNECTION_STRING``.
 
 .. code:: python
 
@@ -35,15 +34,16 @@ This example shows how to send a warning level log to Azure Monitor.
     from opencensus.ext.azure.log_exporter import AzureLogHandler
 
     logger = logging.getLogger(__name__)
-    logger.addHandler(AzureLogHandler())
+    logger.addHandler(AzureLogHandler(connection_string='InstrumentationKey=<your-instrumentation_key-here>'))
     logger.warning('Hello, World!')
+
+* Alternatively, you can specify your `connection string` in an environment variable ``APPLICATIONINSIGHTS_CONNECTION_STRING``.
 
 You can enrich the logs with trace IDs and span IDs by using the `logging integration <../opencensus-ext-logging>`_.
 
 * Create an Azure Monitor resource and get the instrumentation key, more information can be found `here <https://docs.microsoft.com/azure/azure-monitor/app/create-new-resource>`_.
-* Place your instrumentation key in a connection string and into ``APPLICATIONINSIGHTS_CONNECTION_STRING`` environment variable.
-* You can also put the instrumentation key in ``APPINSIGHTS_INSTRUMENTATIONKEY`` environment variable.
-* Alternatively, you can specify either the connection string or instrumentation key directly in your code, which will take priority over a set environment variable.
+* Place your instrumentation key in a `connection string` and directly into your code.
+* Alternatively, you can specify your `connection string` in an environment variable ``APPLICATIONINSIGHTS_CONNECTION_STRING``.
 
 .. code:: python
 
@@ -59,16 +59,19 @@ You can enrich the logs with trace IDs and span IDs by using the `logging integr
 
     logger = logging.getLogger(__name__)
 
-    handler = AzureLogHandler()
+    handler = AzureLogHandler(connection_string='InstrumentationKey=<your-instrumentation_key-here>')
     handler.setFormatter(logging.Formatter('%(traceId)s %(spanId)s %(message)s'))
     logger.addHandler(handler)
 
-    tracer = Tracer(exporter=AzureExporter(), sampler=ProbabilitySampler(1.0))
+    tracer = Tracer(
+        exporter=AzureExporter(connection_string='InstrumentationKey=<your-instrumentation_key-here>'),
+        sampler=ProbabilitySampler(1.0)
+    )
 
     logger.warning('Before the span')
     with tracer.span(name='test'):
         logger.warning('In the span')
-    logger.warning('After the span')
+    logger.warning('After the span')s
 
 Metrics
 ~~~~~~~
@@ -76,9 +79,8 @@ Metrics
 The **Azure Monitor Metrics Exporter** allows you to export metrics to `Azure Monitor`_.
 
 * Create an Azure Monitor resource and get the instrumentation key, more information can be found `here <https://docs.microsoft.com/azure/azure-monitor/app/create-new-resource>`_.
-* Place your instrumentation key in a connection string and into ``APPLICATIONINSIGHTS_CONNECTION_STRING`` environment variable.
-* You can also put the instrumentation key in ``APPINSIGHTS_INSTRUMENTATIONKEY`` environment variable.
-* Alternatively, you can specify either the connection string or instrumentation key directly in your code, which will take priority over a set environment variable.
+* Place your instrumentation key in a `connection string` and directly into your code.
+* Alternatively, you can specify your `connection string` in an environment variable ``APPLICATIONINSIGHTS_CONNECTION_STRING``.
 
 .. code:: python
 
@@ -107,7 +109,7 @@ The **Azure Monitor Metrics Exporter** allows you to export metrics to `Azure Mo
     def main():
         # Enable metrics
         # Set the interval in seconds in which you want to send metrics
-        exporter = metrics_exporter.new_metrics_exporter()
+        exporter = metrics_exporter.new_metrics_exporter(connection_string='InstrumentationKey=<your-instrumentation-key-here>')
         view_manager.register_exporter(exporter)
 
         view_manager.register_view(CARROTS_VIEW)
@@ -140,7 +142,7 @@ The exporter also includes a set of standard metrics that are exported to Azure 
         # All you need is the next line. You can disable standard metrics by
         # passing in enable_standard_metrics=False into the constructor of
         # new_metrics_exporter() 
-        _exporter = metrics_exporter.new_metrics_exporter()
+        _exporter = metrics_exporter.new_metrics_exporter(connection_string='InstrumentationKey=<your-instrumentation-key-here>')
         
         for i in range(100):
             print(psutil.virtual_memory())
@@ -169,27 +171,31 @@ The **Azure Monitor Trace Exporter** allows you to export `OpenCensus`_ traces t
 This example shows how to send a span "hello" to Azure Monitor.
 
 * Create an Azure Monitor resource and get the instrumentation key, more information can be found `here <https://docs.microsoft.com/azure/azure-monitor/app/create-new-resource>`_.
-* Place your instrumentation key in a connection string and into ``APPLICATIONINSIGHTS_CONNECTION_STRING`` environment variable.
-* You can also put the instrumentation key in ``APPINSIGHTS_INSTRUMENTATIONKEY`` environment variable.
-* Alternatively, you can specify either the connection string or instrumentation key directly in your code, which will take priority over a set environment variable.
+* Place your instrumentation key in a `connection string` and directly into your code.
+* Alternatively, you can specify your `connection string` in an environment variable ``APPLICATIONINSIGHTS_CONNECTION_STRING``.
 
-.. code:: python
+ .. code:: python
 
     from opencensus.ext.azure.trace_exporter import AzureExporter
     from opencensus.trace.samplers import ProbabilitySampler
     from opencensus.trace.tracer import Tracer
 
-    tracer = Tracer(exporter=AzureExporter(), sampler=ProbabilitySampler(1.0))
+    tracer = Tracer(
+        exporter=AzureExporter(connection_string='InstrumentationKey=<your-instrumentation-key-here>'),
+        sampler=ProbabilitySampler(1.0)
+    )
 
     with tracer.span(name='hello'):
         print('Hello, World!')
 
-You can also specify the instrumentation key explicitly in the code.
+OpenCensus also supports several [integrations](https://github.com/census-instrumentation/opencensus-python#integration) which allows OpenCensus to integrate with third party libraries.
+
+This example shows how to integrate with the [requests](https://2.python-requests.org/en/master/) library.
 
 * Create an Azure Monitor resource and get the instrumentation key, more information can be found `here <https://docs.microsoft.com/azure/azure-monitor/app/create-new-resource>`_.
-* Place your instrumentation key in a connection string and into ``APPLICATIONINSIGHTS_CONNECTION_STRING`` environment variable.
-* You can also put the instrumentation key in ``APPINSIGHTS_INSTRUMENTATIONKEY`` environment variable.
-* Alternatively, you can specify either the connection string or instrumentation key directly in your code, which will take priority over a set environment variable.
+* Install the `requests integration package <../opencensus-ext-requests>`_ using ``pip install opencensus-ext-requests``.
+* Place your instrumentation key in a `connection string` and directly into your code.
+* Alternatively, you can specify your `connection string` in an environment variable ``APPLICATIONINSIGHTS_CONNECTION_STRING``.
 
 .. code:: python
 

--- a/contrib/opencensus-ext-azure/README.rst
+++ b/contrib/opencensus-ext-azure/README.rst
@@ -24,10 +24,9 @@ The **Azure Monitor Log Handler** allows you to export Python logs to `Azure Mon
 This example shows how to send a warning level log to Azure Monitor.
 
 * Create an Azure Monitor resource and get the instrumentation key, more information can be found `here <https://docs.microsoft.com/azure/azure-monitor/app/create-new-resource>`_.
-* Put the instrumentation key in ``APPINSIGHTS_INSTRUMENTATIONKEY`` environment variable.
-* You can also utilize a connection string with an instrumentation key. Place the connetion string in ``APPLICATIONINSIGHTS_CONNECTION_STRING`` environment variable, which will take priority over the instrumentation key environment variable.
-* You can also specify the instrumentation key explicitly in the code, which will take priority over the previous methods.
-* Finally, you can specify a connection string explicitly in the code, which will take priority over all methods.
+* Place your instrumentation key in a connection string and into ``APPLICATIONINSIGHTS_CONNECTION_STRING`` environment variable.
+* You can also put the instrumentation key in ``APPINSIGHTS_INSTRUMENTATIONKEY`` environment variable.
+* Alternatively, you can specify either the connection string or instrumentation key directly in your code, which will take priority over a set environment variable.
 
 .. code:: python
 
@@ -42,11 +41,9 @@ This example shows how to send a warning level log to Azure Monitor.
 You can enrich the logs with trace IDs and span IDs by using the `logging integration <../opencensus-ext-logging>`_.
 
 * Create an Azure Monitor resource and get the instrumentation key, more information can be found `here <https://docs.microsoft.com/azure/azure-monitor/app/create-new-resource>`_.
-* Install the `logging integration package <../opencensus-ext-logging>`_ using ``pip install opencensus-ext-logging``.
-* Put the instrumentation key in ``APPINSIGHTS_INSTRUMENTATIONKEY`` environment variable.
-* You can also utilize a connection string with an instrumentation key. Place the connetion string in ``APPLICATIONINSIGHTS_CONNECTION_STRING`` environment variable, which will take priority over the instrumentation key environment variable.
-* You can also specify the instrumentation key explicitly in the code, which will take priority over the previous methods.
-* Finally, you can specify a connection string explicitly in the code, which will take priority over all methods.
+* Place your instrumentation key in a connection string and into ``APPLICATIONINSIGHTS_CONNECTION_STRING`` environment variable.
+* You can also put the instrumentation key in ``APPINSIGHTS_INSTRUMENTATIONKEY`` environment variable.
+* Alternatively, you can specify either the connection string or instrumentation key directly in your code, which will take priority over a set environment variable.
 
 .. code:: python
 
@@ -79,10 +76,9 @@ Metrics
 The **Azure Monitor Metrics Exporter** allows you to export metrics to `Azure Monitor`_.
 
 * Create an Azure Monitor resource and get the instrumentation key, more information can be found `here <https://docs.microsoft.com/azure/azure-monitor/app/create-new-resource>`_.
-* Put the instrumentation key in ``APPINSIGHTS_INSTRUMENTATIONKEY`` environment variable.
-* You can also utilize a connection string with an instrumentation key. Place the connetion string in ``APPLICATIONINSIGHTS_CONNECTION_STRING`` environment variable, which will take priority over the instrumentation key environment variable.
-* You can also specify the instrumentation key explicitly in the code, which will take priority over the previous methods.
-* Finally, you can specify a connection string explicitly in the code, which will take priority over all methods.
+* Place your instrumentation key in a connection string and into ``APPLICATIONINSIGHTS_CONNECTION_STRING`` environment variable.
+* You can also put the instrumentation key in ``APPINSIGHTS_INSTRUMENTATIONKEY`` environment variable.
+* Alternatively, you can specify either the connection string or instrumentation key directly in your code, which will take priority over a set environment variable.
 
 .. code:: python
 
@@ -172,10 +168,9 @@ The **Azure Monitor Trace Exporter** allows you to export `OpenCensus`_ traces t
 This example shows how to send a span "hello" to Azure Monitor.
 
 * Create an Azure Monitor resource and get the instrumentation key, more information can be found `here <https://docs.microsoft.com/azure/azure-monitor/app/create-new-resource>`_.
-* Put the instrumentation key in ``APPINSIGHTS_INSTRUMENTATIONKEY`` environment variable.
-* You can also utilize a connection string with an instrumentation key. Place the connetion string in ``APPLICATIONINSIGHTS_CONNECTION_STRING`` environment variable, which will take priority over the instrumentation key environment variable.
-* You can also specify the instrumentation key explicitly in the code, which will take priority over the previous methods.
-* Finally, you can specify a connection string explicitly in the code, which will take priority over all methods.
+* Place your instrumentation key in a connection string and into ``APPLICATIONINSIGHTS_CONNECTION_STRING`` environment variable.
+* You can also put the instrumentation key in ``APPINSIGHTS_INSTRUMENTATIONKEY`` environment variable.
+* Alternatively, you can specify either the connection string or instrumentation key directly in your code, which will take priority over a set environment variable.
 
 .. code:: python
 
@@ -191,11 +186,9 @@ This example shows how to send a span "hello" to Azure Monitor.
 You can also specify the instrumentation key explicitly in the code.
 
 * Create an Azure Monitor resource and get the instrumentation key, more information can be found `here <https://docs.microsoft.com/azure/azure-monitor/app/create-new-resource>`_.
-* Install the `requests integration package <../opencensus-ext-requests>`_ using ``pip install opencensus-ext-requests``.
-* Put the instrumentation key in ``APPINSIGHTS_INSTRUMENTATIONKEY`` environment variable.
-* You can also utilize a connection string with an instrumentation key. Place the connetion string in ``APPLICATIONINSIGHTS_CONNECTION_STRING`` environment variable, which will take priority over the instrumentation key environment variable.
-* You can also specify the instrumentation key explicitly in the code, which will take priority over the previous methods.
-* Finally, you can specify a connection string explicitly in the code, which will take priority over all methods.
+* Place your instrumentation key in a connection string and into ``APPLICATIONINSIGHTS_CONNECTION_STRING`` environment variable.
+* You can also put the instrumentation key in ``APPINSIGHTS_INSTRUMENTATIONKEY`` environment variable.
+* Alternatively, you can specify either the connection string or instrumentation key directly in your code, which will take priority over a set environment variable.
 
 .. code:: python
 

--- a/contrib/opencensus-ext-azure/README.rst
+++ b/contrib/opencensus-ext-azure/README.rst
@@ -25,7 +25,9 @@ This example shows how to send a warning level log to Azure Monitor.
 
 * Create an Azure Monitor resource and get the instrumentation key, more information can be found `here <https://docs.microsoft.com/azure/azure-monitor/app/create-new-resource>`_.
 * Put the instrumentation key in ``APPINSIGHTS_INSTRUMENTATIONKEY`` environment variable.
-* You can also specify the instrumentation key explicitly in the code, which will take priority over a set environment variable.
+* You can also utilize a connection string with an instrumentation key. Place the connetion string in ``APPLICATIONINSIGHTS_CONNECTION_STRING`` environment variable, which will take priority over the instrumentation key environment variable.
+* You can also specify the instrumentation key explicitly in the code, which will take priority over the previous methods.
+* Finally, you can specify a connection string explicitly in the code, which will take priority over all methods.
 
 .. code:: python
 
@@ -42,7 +44,9 @@ You can enrich the logs with trace IDs and span IDs by using the `logging integr
 * Create an Azure Monitor resource and get the instrumentation key, more information can be found `here <https://docs.microsoft.com/azure/azure-monitor/app/create-new-resource>`_.
 * Install the `logging integration package <../opencensus-ext-logging>`_ using ``pip install opencensus-ext-logging``.
 * Put the instrumentation key in ``APPINSIGHTS_INSTRUMENTATIONKEY`` environment variable.
-* You can also specify the instrumentation key explicitly in the code, which will take priority over a set environment variable.
+* You can also utilize a connection string with an instrumentation key. Place the connetion string in ``APPLICATIONINSIGHTS_CONNECTION_STRING`` environment variable, which will take priority over the instrumentation key environment variable.
+* You can also specify the instrumentation key explicitly in the code, which will take priority over the previous methods.
+* Finally, you can specify a connection string explicitly in the code, which will take priority over all methods.
 
 .. code:: python
 
@@ -76,7 +80,9 @@ The **Azure Monitor Metrics Exporter** allows you to export metrics to `Azure Mo
 
 * Create an Azure Monitor resource and get the instrumentation key, more information can be found `here <https://docs.microsoft.com/azure/azure-monitor/app/create-new-resource>`_.
 * Put the instrumentation key in ``APPINSIGHTS_INSTRUMENTATIONKEY`` environment variable.
-* You can also specify the instrumentation key explicitly in the code, which will take priority over a set environment variable.
+* You can also utilize a connection string with an instrumentation key. Place the connetion string in ``APPLICATIONINSIGHTS_CONNECTION_STRING`` environment variable, which will take priority over the instrumentation key environment variable.
+* You can also specify the instrumentation key explicitly in the code, which will take priority over the previous methods.
+* Finally, you can specify a connection string explicitly in the code, which will take priority over all methods.
 
 .. code:: python
 
@@ -167,7 +173,9 @@ This example shows how to send a span "hello" to Azure Monitor.
 
 * Create an Azure Monitor resource and get the instrumentation key, more information can be found `here <https://docs.microsoft.com/azure/azure-monitor/app/create-new-resource>`_.
 * Put the instrumentation key in ``APPINSIGHTS_INSTRUMENTATIONKEY`` environment variable.
-* You can also specify the instrumentation key explicitly in the code, which will take priority over a set environment variable.
+* You can also utilize a connection string with an instrumentation key. Place the connetion string in ``APPLICATIONINSIGHTS_CONNECTION_STRING`` environment variable, which will take priority over the instrumentation key environment variable.
+* You can also specify the instrumentation key explicitly in the code, which will take priority over the previous methods.
+* Finally, you can specify a connection string explicitly in the code, which will take priority over all methods.
 
 .. code:: python
 
@@ -185,7 +193,9 @@ You can also specify the instrumentation key explicitly in the code.
 * Create an Azure Monitor resource and get the instrumentation key, more information can be found `here <https://docs.microsoft.com/azure/azure-monitor/app/create-new-resource>`_.
 * Install the `requests integration package <../opencensus-ext-requests>`_ using ``pip install opencensus-ext-requests``.
 * Put the instrumentation key in ``APPINSIGHTS_INSTRUMENTATIONKEY`` environment variable.
-* You can also specify the instrumentation key explicitly in the code, which will take priority over a set environment variable.
+* You can also utilize a connection string with an instrumentation key. Place the connetion string in ``APPLICATIONINSIGHTS_CONNECTION_STRING`` environment variable, which will take priority over the instrumentation key environment variable.
+* You can also specify the instrumentation key explicitly in the code, which will take priority over the previous methods.
+* Finally, you can specify a connection string explicitly in the code, which will take priority over all methods.
 
 .. code:: python
 

--- a/contrib/opencensus-ext-azure/examples/logs/correlated.py
+++ b/contrib/opencensus-ext-azure/examples/logs/correlated.py
@@ -24,8 +24,9 @@ config_integration.trace_integrations(['logging'])
 
 logger = logging.getLogger(__name__)
 
-# TODO: you need to specify the instrumentation key in the
-# APPINSIGHTS_INSTRUMENTATIONKEY environment variable.
+# TODO: you need to specify the instrumentation key in a connection string
+# and place it in the APPLICATIONINSIGHTS_CONNECTION_STRING
+# environment variable.
 handler = AzureLogHandler()
 logger.addHandler(handler)
 

--- a/contrib/opencensus-ext-azure/examples/logs/error.py
+++ b/contrib/opencensus-ext-azure/examples/logs/error.py
@@ -17,8 +17,9 @@ import logging
 from opencensus.ext.azure.log_exporter import AzureLogHandler
 
 logger = logging.getLogger(__name__)
-# TODO: you need to specify the instrumentation key in the
-# APPINSIGHTS_INSTRUMENTATIONKEY environment variable.
+# TODO: you need to specify the instrumentation key in a connection string
+# and place it in the APPLICATIONINSIGHTS_CONNECTION_STRING
+# environment variable.
 logger.addHandler(AzureLogHandler())
 
 

--- a/contrib/opencensus-ext-azure/examples/logs/simple.py
+++ b/contrib/opencensus-ext-azure/examples/logs/simple.py
@@ -17,7 +17,8 @@ import logging
 from opencensus.ext.azure.log_exporter import AzureLogHandler
 
 logger = logging.getLogger(__name__)
-# TODO: you need to specify the instrumentation key in the
-# APPINSIGHTS_INSTRUMENTATIONKEY environment variable.
+# TODO: you need to specify the instrumentation key in a connection string
+# and place it in the APPLICATIONINSIGHTS_CONNECTION_STRING
+# environment variable.
 logger.addHandler(AzureLogHandler())
 logger.warning('Hello, World!')

--- a/contrib/opencensus-ext-azure/examples/logs/simple.py
+++ b/contrib/opencensus-ext-azure/examples/logs/simple.py
@@ -20,9 +20,5 @@ logger = logging.getLogger(__name__)
 # TODO: you need to specify the instrumentation key in a connection string
 # and place it in the APPLICATIONINSIGHTS_CONNECTION_STRING
 # environment variable.
-#70c241c9-206e-4811-82b4-2bc8a52170b9
-handler = AzureLogHandler(connection_string='Authorization=IKEY')
-logger.addHandler(handler)
-print(handler.options.instrumentation_key)
-print(handler.options.endpoint)
+logger.addHandler(AzureLogHandler())
 logger.warning('Hello, World!')

--- a/contrib/opencensus-ext-azure/examples/logs/simple.py
+++ b/contrib/opencensus-ext-azure/examples/logs/simple.py
@@ -20,5 +20,9 @@ logger = logging.getLogger(__name__)
 # TODO: you need to specify the instrumentation key in a connection string
 # and place it in the APPLICATIONINSIGHTS_CONNECTION_STRING
 # environment variable.
-logger.addHandler(AzureLogHandler())
+#70c241c9-206e-4811-82b4-2bc8a52170b9
+handler = AzureLogHandler(connection_string='Authorization=IKEY')
+logger.addHandler(handler)
+print(handler.options.instrumentation_key)
+print(handler.options.endpoint)
 logger.warning('Hello, World!')

--- a/contrib/opencensus-ext-azure/examples/metrics/simple.py
+++ b/contrib/opencensus-ext-azure/examples/metrics/simple.py
@@ -38,6 +38,9 @@ CARROTS_VIEW = view_module.View("carrots_view",
 def main():
     # Enable metrics
     # Set the interval in seconds in which you want to send metrics
+    # TODO: you need to specify the instrumentation key in a connection string
+    # and place it in the APPLICATIONINSIGHTS_CONNECTION_STRING
+    # environment variable.
     exporter = metrics_exporter.new_metrics_exporter()
     view_manager.register_exporter(exporter)
 

--- a/contrib/opencensus-ext-azure/examples/metrics/standard.py
+++ b/contrib/opencensus-ext-azure/examples/metrics/standard.py
@@ -19,6 +19,9 @@ from opencensus.ext.azure import metrics_exporter
 
 
 def main():
+    # TODO: you need to specify the instrumentation key in a connection string
+    # and place it in the APPLICATIONINSIGHTS_CONNECTION_STRING
+    # environment variable.
     # All you need is the next line. You can disable standard metrics by
     # passing in enable_standard_metrics=False into the constructor of
     # new_metrics_exporter()

--- a/contrib/opencensus-ext-azure/examples/metrics/sum.py
+++ b/contrib/opencensus-ext-azure/examples/metrics/sum.py
@@ -38,6 +38,9 @@ NUM_REQUESTS_VIEW = view_module.View("Number of Requests",
 def main():
     # Enable metrics
     # Set the interval in seconds in which you want to send metrics
+    # TODO: you need to specify the instrumentation key in a connection string
+    # and place it in the APPLICATIONINSIGHTS_CONNECTION_STRING
+    # environment variable.
     exporter = metrics_exporter.new_metrics_exporter()
     view_manager.register_exporter(exporter)
 

--- a/contrib/opencensus-ext-azure/examples/traces/client.py
+++ b/contrib/opencensus-ext-azure/examples/traces/client.py
@@ -20,8 +20,9 @@ from opencensus.trace.samplers import ProbabilitySampler
 from opencensus.trace.tracer import Tracer
 
 config_integration.trace_integrations(['requests'])
-# TODO: you need to specify the instrumentation key in the
-# APPINSIGHTS_INSTRUMENTATIONKEY environment variable.
+# TODO: you need to specify the instrumentation key in a connection string
+# and place it in the APPLICATIONINSIGHTS_CONNECTION_STRING
+# environment variable.
 tracer = Tracer(exporter=AzureExporter(), sampler=ProbabilitySampler(1.0))
 with tracer.span(name='parent'):
     with tracer.span(name='child'):

--- a/contrib/opencensus-ext-azure/examples/traces/config.py
+++ b/contrib/opencensus-ext-azure/examples/traces/config.py
@@ -19,7 +19,8 @@ from opencensus.trace.tracer import Tracer
 tracer = Tracer(
     exporter=AzureExporter(
         # TODO: replace the all-zero GUID with your instrumentation key.
-        instrumentation_key='00000000-0000-0000-0000-000000000000',
+        connection_string='InstrumentationKey= \
+        00000000-0000-0000-0000-000000000000',
     ),
     sampler=ProbabilitySampler(rate=1.0),
 )

--- a/contrib/opencensus-ext-azure/examples/traces/custom.py
+++ b/contrib/opencensus-ext-azure/examples/traces/custom.py
@@ -21,7 +21,8 @@ app.config['OPENCENSUS'] = {
     'TRACE': {
         'SAMPLER': 'opencensus.trace.samplers.ProbabilitySampler(rate=1.0)',
         'EXPORTER': '''opencensus.ext.azure.trace_exporter.AzureExporter(
-            instrumentation_key='00000000-0000-0000-0000-000000000000',
+            connection_string=
+            'InstrumentationKey=00000000-0000-0000-0000-000000000000',
         )''',
     },
 }

--- a/contrib/opencensus-ext-azure/examples/traces/server.py
+++ b/contrib/opencensus-ext-azure/examples/traces/server.py
@@ -20,8 +20,9 @@ from opencensus.ext.flask.flask_middleware import FlaskMiddleware
 from opencensus.trace import config_integration
 from opencensus.trace.samplers import ProbabilitySampler
 
-# TODO: you need to specify the instrumentation key in the
-# APPINSIGHTS_INSTRUMENTATIONKEY environment variable.
+# TODO: you need to specify the instrumentation key in a connection string
+# and place it in the APPLICATIONINSIGHTS_CONNECTION_STRING
+# environment variable.
 app = Flask(__name__)
 middleware = FlaskMiddleware(
     app,

--- a/contrib/opencensus-ext-azure/examples/traces/simple.py
+++ b/contrib/opencensus-ext-azure/examples/traces/simple.py
@@ -16,8 +16,9 @@ from opencensus.ext.azure.trace_exporter import AzureExporter
 from opencensus.trace.samplers import ProbabilitySampler
 from opencensus.trace.tracer import Tracer
 
-# TODO: you need to specify the instrumentation key in the
-# APPINSIGHTS_INSTRUMENTATIONKEY environment variable.
+# TODO: you need to specify the instrumentation key in a connection string
+# and place it in the APPLICATIONINSIGHTS_CONNECTION_STRING
+# environment variable.
 tracer = Tracer(exporter=AzureExporter(), sampler=ProbabilitySampler(1.0))
 
 with tracer.span(name='foo'):

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
@@ -73,8 +73,8 @@ def parse_connection_string(connection_string):
             endpoint = 'https://' + location_prefix + 'dc.' + endpoint_suffix
             result[INGESTION_ENDPOINT] = endpoint
         else:
-            # Use default endpoint if cannot construct
-            result[INGESTION_ENDPOINT] = 'https://dc.services.visualstudio.com'
+            # Default to None if cannot construct
+            result[INGESTION_ENDPOINT] = None
     return result
 
 

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
@@ -34,12 +34,12 @@ def process_options(options):
     env_ikey = os.getenv(ENV_INSTRUMENTATION_KEY)
 
     options.instrumentation_key = code_cs.get(INSTRUMENTATION_KEY) \
-                                    or code_ikey \
-                                    or env_cs.get(INSTRUMENTATION_KEY) \
-                                    or env_ikey
+        or code_ikey \
+        or env_cs.get(INSTRUMENTATION_KEY) \
+        or env_ikey
     endpoint = code_cs.get(INGESTION_ENDPOINT) \
-                or env_cs.get(INGESTION_ENDPOINT) \
-                or DEFAULT_BREEZE_ENDPOINT
+        or env_cs.get(INGESTION_ENDPOINT) \
+        or DEFAULT_BREEZE_ENDPOINT
     options.endpoint = endpoint + '/v2/track'
 
 
@@ -54,8 +54,8 @@ def parse_connection_string(connection_string):
     # Validate authorization
     auth = result.get(AUTHORIZATION)
     if auth is None:
-        raise ValueError('Missing \'Authorization\' in connection string:' \
-            + connection_string)
+        raise ValueError('Missing \'Authorization\' in connection string:'
+                         + connection_string)
     if auth.lower() != 'ikey':
         raise ValueError('Invalid authorization mechanism: ' + auth)
     # Construct the ingestion endpoint if not passed in explicitly

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
@@ -50,14 +50,11 @@ def parse_connection_string(connection_string):
         pairs = connection_string.split(';')
         result = dict(s.split('=') for s in pairs)
     except Exception:
-        raise ValueError('Invalid connection string: ' + connection_string)
+        raise ValueError('Invalid connection string')
     # Validate authorization
     auth = result.get(AUTHORIZATION)
-    if auth is None:
-        raise ValueError('Missing \'Authorization\' in connection string:'
-                         + connection_string)
-    if auth.lower() != 'ikey':
-        raise ValueError('Invalid authorization mechanism: ' + auth)
+    if auth is not None and auth.lower() != 'ikey':
+        raise ValueError('Invalid authorization mechanism')
     # Construct the ingestion endpoint if not passed in explicitly
     if result.get(INGESTION_ENDPOINT) is None:
         endpoint_suffix = ''

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
@@ -33,9 +33,15 @@ def process_options(options):
     env_cs = parse_connection_string(os.getenv(ENV_CONNECTION_STRING))
     env_ikey = os.getenv(ENV_INSTRUMENTATION_KEY)
 
-    options.instrumentation_key = code_cs.get(INSTRUMENTATION_KEY) or code_ikey or env_cs.get(INSTRUMENTATION_KEY) or env_ikey
-    endpoint = code_cs.get(INGESTION_ENDPOINT) or env_cs.get(INGESTION_ENDPOINT) or DEFAULT_BREEZE_ENDPOINT
+    options.instrumentation_key = code_cs.get(INSTRUMENTATION_KEY) \
+                                    or code_ikey \
+                                    or env_cs.get(INSTRUMENTATION_KEY) \
+                                    or env_ikey
+    endpoint = code_cs.get(INGESTION_ENDPOINT) \
+                or env_cs.get(INGESTION_ENDPOINT) \
+                or DEFAULT_BREEZE_ENDPOINT
     options.endpoint = endpoint + '/v2/track'
+
 
 def parse_connection_string(connection_string):
     if connection_string is None:
@@ -48,7 +54,8 @@ def parse_connection_string(connection_string):
     # Validate authorization
     auth = result.get(AUTHORIZATION)
     if auth is None:
-        raise ValueError('Missing \'Authorization\' in connection string: ' + connection_string)
+        raise ValueError('Missing \'Authorization\' in connection string:' \
+            + connection_string)
     if auth.lower() != 'ikey':
         raise ValueError('Invalid authorization mechanism: ' + auth)
     # Construct the ingestion endpoint if not passed in explicitly
@@ -60,11 +67,13 @@ def parse_connection_string(connection_string):
             # Get regional information if provided
             if result.get(LOCATION) is not None:
                 location_prefix = result.get(LOCATION) + '.'
-            result[INGESTION_ENDPOINT] = 'https://' + location_prefix + 'dc.' + endpoint_suffix
+            endpoint = 'https://' + location_prefix + 'dc.' + endpoint_suffix
+            result[INGESTION_ENDPOINT] = endpoint
         else:
             # Use default endpoint if cannot construct
             result[INGESTION_ENDPOINT] = DEFAULT_BREEZE_ENDPOINT
     return result
+
 
 class Options(BaseObject):
     def __init__(self, *args, **kwargs):

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
@@ -33,7 +33,7 @@ def process_options(options):
     env_cs = parse_connection_string(os.getenv(ENV_CONNECTION_STRING))
     env_ikey = os.getenv(ENV_INSTRUMENTATION_KEY)
 
-    options.instrumentation_key = code_cs.get(INSTRUMENTATION_KEY) or code_ikey or env_ikey
+    options.instrumentation_key = code_cs.get(INSTRUMENTATION_KEY) or code_ikey or env_cs.get(INSTRUMENTATION_KEY) or env_ikey
     endpoint = code_cs.get(INGESTION_ENDPOINT) or env_cs.get(INGESTION_ENDPOINT) or DEFAULT_BREEZE_ENDPOINT
     options.endpoint = endpoint + '/v2/track'
 

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
@@ -17,8 +17,8 @@ import sys
 
 from opencensus.ext.azure.common.protocol import BaseObject
 
-INGESTION_ENDPOINT = 'IngestionEndpoint'
-INSTRUMENTATION_KEY = 'InstrumentationKey'
+INGESTION_ENDPOINT = 'ingestionendpoint'
+INSTRUMENTATION_KEY = 'instrumentationkey'
 
 
 def process_options(options):
@@ -53,21 +53,23 @@ def parse_connection_string(connection_string):
     try:
         pairs = connection_string.split(';')
         result = dict(s.split('=') for s in pairs)
+        # Convert keys to lower-case due to case type-insensitive checking
+        result = {key.lower(): value for key, value in result.items()}
     except Exception:
         raise ValueError('Invalid connection string')
     # Validate authorization
-    auth = result.get('Authorization')
+    auth = result.get('authorization')
     if auth is not None and auth.lower() != 'ikey':
         raise ValueError('Invalid authorization mechanism')
     # Construct the ingestion endpoint if not passed in explicitly
     if result.get(INGESTION_ENDPOINT) is None:
         endpoint_suffix = ''
         location_prefix = ''
-        suffix = result.get('EndpointSuffix')
+        suffix = result.get('endpointsuffix')
         if suffix is not None:
             endpoint_suffix = suffix
             # Get regional information if provided
-            prefix = result.get('Location')
+            prefix = result.get('location')
             if prefix is not None:
                 location_prefix = prefix + '.'
             endpoint = 'https://' + location_prefix + 'dc.' + endpoint_suffix

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
@@ -12,19 +12,80 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
 import sys
 
 from opencensus.ext.azure.common.protocol import BaseObject
 
+logger = logging.getLogger(__name__)
+
+ENV_INSTRUMENTATION_KEY = 'APPINSIGHTS_INSTRUMENTATIONKEY'
+ENV_CONNECTION_STRING = 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+INSTRUMENTATION_KEY = 'InstrumentationKey'
+INGESTION_ENDPOINT = 'IngestionEndpoint'
+
+
+def process_options(options):
+    env_ikey = os.getenv(ENV_INSTRUMENTATION_KEY)
+    env_cs = os.getenv(ENV_CONNECTION_STRING)
+    code_ikey = options.instrumentation_key
+    code_endpoint = options.endpoint
+    options.instrumentation_key = None
+    options.endpoint = None
+    
+    if options.connection_string is not None:
+        # Hardcoded connection string
+        cs = parse_connection_string(options.connection_string)
+        ikey = cs.get(INSTRUMENTATION_KEY)
+        if ikey is not None:
+            options.instrumentation_key = ikey
+        else:
+            logger.warning('Missing \'InstrumentationKey\' in connection string')
+        endpoint = cs.get(INGESTION_ENDPOINT)
+        if endpoint is not None:
+            options.endpoint = endpoint + '/v2/track'
+    if options.instrumentation_key is None and code_ikey is not None:
+        # Hardcoded instrumentation key
+        options.instrumentation_key = code_ikey
+    if options.instrumentation_key is None and env_cs is not None:
+        # Environment variable connection string
+        ikey = parse_connection_string(env_cs).get(INSTRUMENTATION_KEY)
+        if ikey is not None:
+            options.instrumentation_key = ikey
+            return
+        else:
+            logger.warning('Missing \'InstrumentationKey\' in environment connection string')
+        endpoint = cs.get(INGESTION_ENDPOINT)
+        if endpoint is not None and options.endpoint is None:
+            options.endpoint = endpoint + '/v2/track'
+    # Environment variable instrumentation key
+    if options.instrumentation_key is None:
+        options.instrumentation_key = env_ikey
+    if options.endpoint is None:
+        options.endpoint = code_endpoint
+        
+
+def parse_connection_string(connection_string):
+    try:
+        pairs = connection_string.split(';')
+        return dict(s.split('=') for s in pairs)
+    except Exception:
+        raise ValueError("Invalid connection string: " + connection_string)
+
 
 class Options(BaseObject):
+    def __init__(self, *args, **kwargs):
+        super(Options, self).__init__(*args, **kwargs)
+        process_options(self)
+
     _default = BaseObject(
-        enable_standard_metrics=True,
+        connection_string=None,
+        enable_standard_metrics=False,
         endpoint='https://dc.services.visualstudio.com/v2/track',
         export_interval=15.0,
         grace_period=5.0,
-        instrumentation_key=os.getenv('APPINSIGHTS_INSTRUMENTATIONKEY', None),
+        instrumentation_key=None,
         max_batch_size=100,
         minimum_retry_interval=60,  # minimum retry interval in seconds
         proxy=None,

--- a/contrib/opencensus-ext-azure/tests/test_options.py
+++ b/contrib/opencensus-ext-azure/tests/test_options.py
@@ -104,7 +104,7 @@ class TestOptions(unittest.TestCase):
     def test_parse_connection_string_default_auth(self):
         cs = 'InstrumentationKey=123'
         result = common.parse_connection_string(cs)
-        self.assertEqual(result['InstrumentationKey'], '123')
+        self.assertEqual(result['instrumentationkey'], '123')
 
     def test_parse_connection_string_invalid_auth(self):
         cs = 'Authorization=asd'
@@ -116,23 +116,23 @@ class TestOptions(unittest.TestCase):
             'Location=us;EndpointSuffix=suffix'
         result = common.parse_connection_string(cs)
 
-        self.assertEqual(result['IngestionEndpoint'], '123')
+        self.assertEqual(result['ingestionendpoint'], '123')
 
     def test_parse_connection_string_default(self):
         cs = 'Authorization=ikey;Location=us'
         result = common.parse_connection_string(cs)
 
-        self.assertEqual(result['IngestionEndpoint'],
+        self.assertEqual(result['ingestionendpoint'],
                          None)
 
     def test_parse_connection_string_no_location(self):
         cs = 'Authorization=ikey;EndpointSuffix=suffix'
         result = common.parse_connection_string(cs)
 
-        self.assertEqual(result['IngestionEndpoint'], 'https://dc.suffix')
+        self.assertEqual(result['ingestionendpoint'], 'https://dc.suffix')
 
     def test_parse_connection_string_location(self):
         cs = 'Authorization=ikey;EndpointSuffix=suffix;Location=us'
         result = common.parse_connection_string(cs)
 
-        self.assertEqual(result['IngestionEndpoint'], 'https://us.dc.suffix')
+        self.assertEqual(result['ingestionendpoint'], 'https://us.dc.suffix')

--- a/contrib/opencensus-ext-azure/tests/test_options.py
+++ b/contrib/opencensus-ext-azure/tests/test_options.py
@@ -87,8 +87,8 @@ class TestOptions(unittest.TestCase):
         options.connection_string = None
         common.process_options(options)
 
-        self.assertEqual(options.endpoint, \
-            'https://dc.services.visualstudio.com/v2/track')
+        self.assertEqual(options.endpoint,
+                         'https://dc.services.visualstudio.com/v2/track')
 
     def test_parse_connection_string_none(self):
         cs = None
@@ -98,18 +98,18 @@ class TestOptions(unittest.TestCase):
 
     def test_parse_connection_string_invalid(self):
         cs = 'asd'
-        self.assertRaises(ValueError, \
-            lambda: common.parse_connection_string(cs))
+        self.assertRaises(ValueError,
+                          lambda: common.parse_connection_string(cs))
 
     def test_parse_connection_string_missing_auth(self):
         cs = 'asd=asd'
-        self.assertRaises(ValueError, \
-            lambda: common.parse_connection_string(cs))
+        self.assertRaises(ValueError,
+                          lambda: common.parse_connection_string(cs))
 
     def test_parse_connection_string_invalid_auth(self):
         cs = 'Authorization=asd'
-        self.assertRaises(ValueError, \
-            lambda: common.parse_connection_string(cs))
+        self.assertRaises(ValueError,
+                          lambda: common.parse_connection_string(cs))
 
     def test_parse_connection_string_explicit_endpoint(self):
         cs = 'Authorization=ikey;IngestionEndpoint=123;' \
@@ -122,8 +122,8 @@ class TestOptions(unittest.TestCase):
         cs = 'Authorization=ikey;Location=us'
         result = common.parse_connection_string(cs)
 
-        self.assertEqual(result['IngestionEndpoint'], \
-            'https://dc.services.visualstudio.com')
+        self.assertEqual(result['IngestionEndpoint'],
+                         'https://dc.services.visualstudio.com')
 
     def test_parse_connection_string_no_location(self):
         cs = 'Authorization=ikey;EndpointSuffix=suffix'

--- a/contrib/opencensus-ext-azure/tests/test_options.py
+++ b/contrib/opencensus-ext-azure/tests/test_options.py
@@ -1,0 +1,130 @@
+# Copyright 2019, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+
+from opencensus.ext.azure import common
+
+
+class TestOptions(unittest.TestCase):
+    def setUp(self):
+        os.environ.clear()
+
+    def test_process_options_ikey_code_cs(self):
+        options = common.Options()
+        options.connection_string = 'Authorization=ikey;InstrumentationKey=123'
+        options.instrumentation_key = '456'
+        os.environ['APPLICATIONINSIGHTS_CONNECTION_STRING'] = 'Authorization=ikey;InstrumentationKey=789'
+        os.environ['APPINSIGHTS_INSTRUMENTATIONKEY'] = '101112'
+        common.process_options(options)
+
+        self.assertEqual(options.instrumentation_key, '123')
+
+    def test_process_options_ikey_code_ikey(self):
+        options = common.Options()
+        options.connection_string = None
+        options.instrumentation_key = '456'
+        os.environ['APPLICATIONINSIGHTS_CONNECTION_STRING'] = 'Authorization=ikey;InstrumentationKey=789'
+        os.environ['APPINSIGHTS_INSTRUMENTATIONKEY'] = '101112'
+        common.process_options(options)
+
+        self.assertEqual(options.instrumentation_key, '456')
+
+    def test_process_options_ikey_env_cs(self):
+        options = common.Options()
+        options.connection_string = None
+        options.instrumentation_key = None
+        os.environ['APPLICATIONINSIGHTS_CONNECTION_STRING'] = 'Authorization=ikey;InstrumentationKey=789'
+        os.environ['APPINSIGHTS_INSTRUMENTATIONKEY'] = '101112'
+        common.process_options(options)
+
+        self.assertEqual(options.instrumentation_key, '789')
+
+    def test_process_options_ikey_env_ikey(self):
+        options = common.Options()
+        options.connection_string = None
+        options.instrumentation_key = None
+        os.environ['APPINSIGHTS_INSTRUMENTATIONKEY'] = '101112'
+        common.process_options(options)
+
+        self.assertEqual(options.instrumentation_key, '101112')
+
+    def test_process_options_endpoint_code_cs(self):
+        options = common.Options()
+        suffix = '/v2/track'
+        options.connection_string = 'Authorization=ikey;IngestionEndpoint=123'
+        os.environ['APPLICATIONINSIGHTS_CONNECTION_STRING'] = 'Authorization=ikey;IngestionEndpoint=456'
+        common.process_options(options)
+
+        self.assertEqual(options.endpoint, '123/v2/track')
+
+    def test_process_options_endpoint_env_cs(self):
+        options = common.Options()
+        suffix = '/v2/track'
+        options.connection_string = None
+        os.environ['APPLICATIONINSIGHTS_CONNECTION_STRING'] = 'Authorization=ikey;IngestionEndpoint=456'
+        common.process_options(options)
+
+        self.assertEqual(options.endpoint, '456/v2/track')
+
+    def test_process_options_endpoint_default(self):
+        options = common.Options()
+        suffix = '/v2/track'
+        options.connection_string = None
+        common.process_options(options)
+
+        self.assertEqual(options.endpoint, 'https://dc.services.visualstudio.com/v2/track')
+
+    def test_parse_connection_string_none(self):
+        cs = None
+        result = common.parse_connection_string(cs)
+
+        self.assertEqual(result, {})
+
+    def test_parse_connection_string_invalid(self):
+        cs = 'asd'
+        self.assertRaises(ValueError, lambda: common.parse_connection_string(cs))
+
+    def test_parse_connection_string_missing_auth(self):
+        cs = 'asd=asd'
+        self.assertRaises(ValueError, lambda: common.parse_connection_string(cs))
+
+    def test_parse_connection_string_invalid_auth(self):
+        cs = 'Authorization=asd'
+        self.assertRaises(ValueError, lambda: common.parse_connection_string(cs))
+
+    def test_parse_connection_string_explicit_endpoint(self):
+        cs = 'Authorization=ikey;IngestionEndpoint=123;Location=us;EndpointSuffix=suffix'
+        result = common.parse_connection_string(cs)
+
+        self.assertEqual(result['IngestionEndpoint'], '123')
+
+    def test_parse_connection_string_default(self):
+        cs = 'Authorization=ikey;Location=us'
+        result = common.parse_connection_string(cs)
+
+        self.assertEqual(result['IngestionEndpoint'], 'https://dc.services.visualstudio.com')
+
+    def test_parse_connection_string_no_location(self):
+        cs = 'Authorization=ikey;EndpointSuffix=suffix'
+        result = common.parse_connection_string(cs)
+
+        self.assertEqual(result['IngestionEndpoint'], 'https://dc.suffix')
+
+    def test_parse_connection_string_location(self):
+        cs = 'Authorization=ikey;EndpointSuffix=suffix;Location=us'
+        result = common.parse_connection_string(cs)
+
+        self.assertEqual(result['IngestionEndpoint'], 'https://us.dc.suffix')

--- a/contrib/opencensus-ext-azure/tests/test_options.py
+++ b/contrib/opencensus-ext-azure/tests/test_options.py
@@ -123,7 +123,7 @@ class TestOptions(unittest.TestCase):
         result = common.parse_connection_string(cs)
 
         self.assertEqual(result['IngestionEndpoint'],
-                         'https://dc.services.visualstudio.com')
+                         None)
 
     def test_parse_connection_string_no_location(self):
         cs = 'Authorization=ikey;EndpointSuffix=suffix'

--- a/contrib/opencensus-ext-azure/tests/test_options.py
+++ b/contrib/opencensus-ext-azure/tests/test_options.py
@@ -26,7 +26,8 @@ class TestOptions(unittest.TestCase):
         options = common.Options()
         options.connection_string = 'Authorization=ikey;InstrumentationKey=123'
         options.instrumentation_key = '456'
-        os.environ['APPLICATIONINSIGHTS_CONNECTION_STRING'] = 'Authorization=ikey;InstrumentationKey=789'
+        os.environ['APPLICATIONINSIGHTS_CONNECTION_STRING'] = \
+            'Authorization=ikey;InstrumentationKey=789'
         os.environ['APPINSIGHTS_INSTRUMENTATIONKEY'] = '101112'
         common.process_options(options)
 
@@ -36,7 +37,8 @@ class TestOptions(unittest.TestCase):
         options = common.Options()
         options.connection_string = None
         options.instrumentation_key = '456'
-        os.environ['APPLICATIONINSIGHTS_CONNECTION_STRING'] = 'Authorization=ikey;InstrumentationKey=789'
+        os.environ['APPLICATIONINSIGHTS_CONNECTION_STRING'] = \
+            'Authorization=ikey;InstrumentationKey=789'
         os.environ['APPINSIGHTS_INSTRUMENTATIONKEY'] = '101112'
         common.process_options(options)
 
@@ -46,7 +48,8 @@ class TestOptions(unittest.TestCase):
         options = common.Options()
         options.connection_string = None
         options.instrumentation_key = None
-        os.environ['APPLICATIONINSIGHTS_CONNECTION_STRING'] = 'Authorization=ikey;InstrumentationKey=789'
+        os.environ['APPLICATIONINSIGHTS_CONNECTION_STRING'] = \
+            'Authorization=ikey;InstrumentationKey=789'
         os.environ['APPINSIGHTS_INSTRUMENTATIONKEY'] = '101112'
         common.process_options(options)
 
@@ -63,29 +66,29 @@ class TestOptions(unittest.TestCase):
 
     def test_process_options_endpoint_code_cs(self):
         options = common.Options()
-        suffix = '/v2/track'
         options.connection_string = 'Authorization=ikey;IngestionEndpoint=123'
-        os.environ['APPLICATIONINSIGHTS_CONNECTION_STRING'] = 'Authorization=ikey;IngestionEndpoint=456'
+        os.environ['APPLICATIONINSIGHTS_CONNECTION_STRING'] = \
+            'Authorization=ikey;IngestionEndpoint=456'
         common.process_options(options)
 
         self.assertEqual(options.endpoint, '123/v2/track')
 
     def test_process_options_endpoint_env_cs(self):
         options = common.Options()
-        suffix = '/v2/track'
         options.connection_string = None
-        os.environ['APPLICATIONINSIGHTS_CONNECTION_STRING'] = 'Authorization=ikey;IngestionEndpoint=456'
+        os.environ['APPLICATIONINSIGHTS_CONNECTION_STRING'] = \
+            'Authorization=ikey;IngestionEndpoint=456'
         common.process_options(options)
 
         self.assertEqual(options.endpoint, '456/v2/track')
 
     def test_process_options_endpoint_default(self):
         options = common.Options()
-        suffix = '/v2/track'
         options.connection_string = None
         common.process_options(options)
 
-        self.assertEqual(options.endpoint, 'https://dc.services.visualstudio.com/v2/track')
+        self.assertEqual(options.endpoint, \
+            'https://dc.services.visualstudio.com/v2/track')
 
     def test_parse_connection_string_none(self):
         cs = None
@@ -95,18 +98,22 @@ class TestOptions(unittest.TestCase):
 
     def test_parse_connection_string_invalid(self):
         cs = 'asd'
-        self.assertRaises(ValueError, lambda: common.parse_connection_string(cs))
+        self.assertRaises(ValueError, \
+            lambda: common.parse_connection_string(cs))
 
     def test_parse_connection_string_missing_auth(self):
         cs = 'asd=asd'
-        self.assertRaises(ValueError, lambda: common.parse_connection_string(cs))
+        self.assertRaises(ValueError, \
+            lambda: common.parse_connection_string(cs))
 
     def test_parse_connection_string_invalid_auth(self):
         cs = 'Authorization=asd'
-        self.assertRaises(ValueError, lambda: common.parse_connection_string(cs))
+        self.assertRaises(ValueError, \
+            lambda: common.parse_connection_string(cs))
 
     def test_parse_connection_string_explicit_endpoint(self):
-        cs = 'Authorization=ikey;IngestionEndpoint=123;Location=us;EndpointSuffix=suffix'
+        cs = 'Authorization=ikey;IngestionEndpoint=123;' \
+            'Location=us;EndpointSuffix=suffix'
         result = common.parse_connection_string(cs)
 
         self.assertEqual(result['IngestionEndpoint'], '123')
@@ -115,7 +122,8 @@ class TestOptions(unittest.TestCase):
         cs = 'Authorization=ikey;Location=us'
         result = common.parse_connection_string(cs)
 
-        self.assertEqual(result['IngestionEndpoint'], 'https://dc.services.visualstudio.com')
+        self.assertEqual(result['IngestionEndpoint'], \
+            'https://dc.services.visualstudio.com')
 
     def test_parse_connection_string_no_location(self):
         cs = 'Authorization=ikey;EndpointSuffix=suffix'

--- a/contrib/opencensus-ext-azure/tests/test_options.py
+++ b/contrib/opencensus-ext-azure/tests/test_options.py
@@ -101,10 +101,10 @@ class TestOptions(unittest.TestCase):
         self.assertRaises(ValueError,
                           lambda: common.parse_connection_string(cs))
 
-    def test_parse_connection_string_missing_auth(self):
-        cs = 'asd=asd'
-        self.assertRaises(ValueError,
-                          lambda: common.parse_connection_string(cs))
+    def test_parse_connection_string_default_auth(self):
+        cs = 'InstrumentationKey=123'
+        result = common.parse_connection_string(cs)
+        self.assertEqual(result['InstrumentationKey'], '123')
 
     def test_parse_connection_string_invalid_auth(self):
         cs = 'Authorization=asd'


### PR DESCRIPTION
Implements connection strings as defined by the spec.

We allow the user to provide an instrumentation_key value and connection_string value explicitly, as well as have the environment variable counterparts to these.

Connection strings currently provide another way to derive the instrumentation key as well as define an ingestion endpoint. 
The priority for instrumentation key:
1. from explicit connection string in code
2. from explicit ikey in code
3. from environment variable connection string
4. from environment variable ikey

The priority for endpoint:
1. from explicit connection string in code
2. from environment variable connection string
3. Default Breeze endpoint

TODO:
Link to documentation for connection strings when created