### PR TITLE
Standard Metrics - Incoming Requests Execution Time

### DIFF
--- a/contrib/opencensus-ext-azure/CHANGELOG.md
+++ b/contrib/opencensus-ext-azure/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 - Standard metrics incoming requests per second
   ([#758](https://github.com/census-instrumentation/opencensus-python/pull/758))
+- Standard metrics incoming requests average execution rate
+  ([#758](https://github.com/census-instrumentation/opencensus-python/pull/758))
 
 ## 0.7.0
 Released 2019-07-31

--- a/contrib/opencensus-ext-azure/README.rst
+++ b/contrib/opencensus-ext-azure/README.rst
@@ -154,6 +154,7 @@ Below is a list of standard metrics that are currently available:
 - Available Memory (bytes)
 - CPU Processor Time (percentage)
 - Incoming Request Rate (per second)
+- Incoming Request Average Execution Time (milliseconds)
 - Outgoing Request Rate (per second)
 - Process CPU Usage (percentage)
 - Process Private Bytes (bytes)

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/standard_metrics/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/standard_metrics/__init__.py
@@ -25,6 +25,8 @@ from opencensus.ext.azure.metrics_exporter.standard_metrics.process \
 from opencensus.ext.azure.metrics_exporter.standard_metrics.process \
     import ProcessMemoryMetric
 from opencensus.ext.azure.metrics_exporter.standard_metrics.http_requests \
+    import RequestsAvgExecutionMetric
+from opencensus.ext.azure.metrics_exporter.standard_metrics.http_requests \
     import RequestsRateMetric
 
 # List of standard metrics to track
@@ -33,6 +35,7 @@ STANDARD_METRICS = [AvailableMemoryMetric,
                     ProcessCPUMetric,
                     ProcessMemoryMetric,
                     ProcessorTimeMetric,
+                    RequestsAvgExecutionMetric,
                     RequestsRateMetric]
 
 


### PR DESCRIPTION
Part of [#695]. Standard metric for incoming requests Average Execution Time in milliseconds. Incoming requests are under "http_requests".
Track incoming requests to an HTTPServer on the application. Currently, incoming requests are shown "performanceCounters" table in Application Insights.

This is the last standard metric as part of the effort to achieve feature parity with Application Insights SDK in other languages.

![image](https://user-images.githubusercontent.com/11580155/63626203-febc8c00-c5b6-11e9-91c9-7301e8465ee7.png)
