### PR TITLE
Validate instrumentation key in Azure Exporters

### DIFF
--- a/contrib/opencensus-ext-azure/README.rst
+++ b/contrib/opencensus-ext-azure/README.rst
@@ -24,6 +24,7 @@ The **Azure Monitor Log Handler** allows you to export Python logs to `Azure Mon
 This example shows how to send a warning level log to Azure Monitor.
 
 * Create an Azure Monitor resource and get the instrumentation key, more information can be found `here <https://docs.microsoft.com/azure/azure-monitor/app/create-new-resource>`_.
+* The instrumentation key must follow the standard UUID format as defined `here <https://tools.ietf.org/html/rfc4122>` _.
 * Put the instrumentation key in ``APPINSIGHTS_INSTRUMENTATIONKEY`` environment variable.
 * You can also specify the instrumentation key explicitly in the code, which will take priority over a set environment variable.
 
@@ -40,6 +41,7 @@ This example shows how to send a warning level log to Azure Monitor.
 You can enrich the logs with trace IDs and span IDs by using the `logging integration <../opencensus-ext-logging>`_.
 
 * Create an Azure Monitor resource and get the instrumentation key, more information can be found `here <https://docs.microsoft.com/azure/azure-monitor/app/create-new-resource>`_.
+* The instrumentation key must follow the standard UUID format as defined `here <https://tools.ietf.org/html/rfc4122>` _.
 * Install the `logging integration package <../opencensus-ext-logging>`_ using ``pip install opencensus-ext-logging``.
 * Put the instrumentation key in ``APPINSIGHTS_INSTRUMENTATIONKEY`` environment variable.
 * You can also specify the instrumentation key explicitly in the code, which will take priority over a set environment variable.
@@ -75,6 +77,7 @@ Metrics
 The **Azure Monitor Metrics Exporter** allows you to export metrics to `Azure Monitor`_.
 
 * Create an Azure Monitor resource and get the instrumentation key, more information can be found `here <https://docs.microsoft.com/azure/azure-monitor/app/create-new-resource>`_.
+* The instrumentation key must follow the standard UUID format as defined `here <https://tools.ietf.org/html/rfc4122>` _.
 * Put the instrumentation key in ``APPINSIGHTS_INSTRUMENTATIONKEY`` environment variable.
 * You can also specify the instrumentation key explicitly in the code, which will take priority over a set environment variable.
 
@@ -167,6 +170,7 @@ The **Azure Monitor Trace Exporter** allows you to export `OpenCensus`_ traces t
 This example shows how to send a span "hello" to Azure Monitor.
 
 * Create an Azure Monitor resource and get the instrumentation key, more information can be found `here <https://docs.microsoft.com/azure/azure-monitor/app/create-new-resource>`_.
+* The instrumentation key must follow the standard UUID format as defined `here <https://tools.ietf.org/html/rfc4122>` _.
 * Put the instrumentation key in ``APPINSIGHTS_INSTRUMENTATIONKEY`` environment variable.
 * You can also specify the instrumentation key explicitly in the code, which will take priority over a set environment variable.
 

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
@@ -39,3 +39,12 @@ class Options(BaseObject):
         storage_retention_period=7*24*60*60,
         timeout=10.0,  # networking timeout in seconds
     )
+
+
+def validate_instrumentation_key(instrumentation_key):
+    if not instrumentation_key:
+        raise ValueError("Instrumentation key cannot be none or empty.")
+    if len(instrumentation_key) > 26:
+        raise ValueError("Instrumentation key exceeds character limit.")
+    
+

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import re
 import sys
 
 from opencensus.ext.azure.common.protocol import BaseObject
@@ -41,10 +42,21 @@ class Options(BaseObject):
     )
 
 
-def validate_instrumentation_key(instrumentation_key):
+def validate_key(instrumentation_key):
     if not instrumentation_key:
         raise ValueError("Instrumentation key cannot be none or empty.")
-    if len(instrumentation_key) > 26:
-        raise ValueError("Instrumentation key exceeds character limit.")
+    # Validate UUID format
+    # Specs taken from https://tools.ietf.org/html/rfc4122
+    pattern = re.compile('[0-9a-f]{8}-' \
+                         '[0-9a-f]{4}-' \
+                         '[1-5][0-9a-f]{3}-' \
+                         '[89ab][0-9a-f]{3}-' \
+                         '[0-9a-f]{12}')
+    # re.fullmatch not available for python2
+    # We use re.match, we matches from the beginning, and then do a length
+    # check to ignore everything afterward.
+    match = pattern.match(instrumentation_key)
+    if len(instrumentation_key) != 36 or not match:
+        raise ValueError("Invalid instrumentation key.")
     
 

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/log_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/log_exporter/__init__.py
@@ -20,7 +20,7 @@ import traceback
 from opencensus.common.schedule import Queue
 from opencensus.common.schedule import QueueExitEvent
 from opencensus.common.schedule import QueueEvent
-from opencensus.ext.azure.common import Options
+from opencensus.ext.azure import common
 from opencensus.ext.azure.common import utils
 from opencensus.ext.azure.common.protocol import Data
 from opencensus.ext.azure.common.protocol import Envelope
@@ -115,9 +115,8 @@ class AzureLogHandler(TransportMixin, BaseLogHandler):
     """
 
     def __init__(self, **options):
-        self.options = Options(**options)
-        if not self.options.instrumentation_key:
-            raise ValueError('The instrumentation_key is not provided.')
+        self.options = common.Options(**options)
+        common.validate_instrumentation_key(self.options.instrumentation_key)
         self.export_interval = self.options.export_interval
         self.max_batch_size = self.options.max_batch_size
         self.storage = LocalFileStorage(

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/log_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/log_exporter/__init__.py
@@ -116,7 +116,7 @@ class AzureLogHandler(TransportMixin, BaseLogHandler):
 
     def __init__(self, **options):
         self.options = common.Options(**options)
-        common.validate_instrumentation_key(self.options.instrumentation_key)
+        common.validate_key(self.options.instrumentation_key)
         self.export_interval = self.options.export_interval
         self.max_batch_size = self.options.max_batch_size
         self.storage = LocalFileStorage(

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/__init__.py
@@ -40,7 +40,7 @@ class MetricsExporter(object):
         if options is None:
             options = common.Options()
         self.options = options
-        common.validate_instrumentation_key(self.options.instrumentation_key)
+        common.validate_key(self.options.instrumentation_key)
         if self.options.max_batch_size <= 0:
             raise ValueError('Max batch size must be at least 1.')
         self.max_batch_size = self.options.max_batch_size

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/__init__.py
@@ -17,7 +17,7 @@ import logging
 import requests
 
 from opencensus.common import utils as common_utils
-from opencensus.ext.azure.common import Options
+from opencensus.ext.azure import common
 from opencensus.ext.azure.common import utils
 from opencensus.ext.azure.common.protocol import Data
 from opencensus.ext.azure.common.protocol import DataPoint
@@ -38,10 +38,9 @@ class MetricsExporter(object):
 
     def __init__(self, options=None):
         if options is None:
-            options = Options()
+            options = common.Options()
         self.options = options
-        if not self.options.instrumentation_key:
-            raise ValueError('The instrumentation_key is not provided.')
+        common.validate_instrumentation_key(self.options.instrumentation_key)
         if self.options.max_batch_size <= 0:
             raise ValueError('Max batch size must be at least 1.')
         self.max_batch_size = self.options.max_batch_size

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/trace_exporter/__init__.py
@@ -15,7 +15,7 @@
 import logging
 
 from opencensus.common.schedule import QueueExitEvent
-from opencensus.ext.azure.common import Options
+from opencensus.ext.azure import common
 from opencensus.ext.azure.common import utils
 from opencensus.ext.azure.common.exporter import BaseExporter
 from opencensus.ext.azure.common.protocol import Data
@@ -38,9 +38,8 @@ class AzureExporter(TransportMixin, BaseExporter):
     """
 
     def __init__(self, **options):
-        self.options = Options(**options)
-        if not self.options.instrumentation_key:
-            raise ValueError('The instrumentation_key is not provided.')
+        self.options = common.Options(**options)
+        common.validate_instrumentation_key(self.options.instrumentation_key)
         self.storage = LocalFileStorage(
             path=self.options.storage_path,
             max_size=self.options.storage_max_size,

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/trace_exporter/__init__.py
@@ -39,7 +39,7 @@ class AzureExporter(TransportMixin, BaseExporter):
 
     def __init__(self, **options):
         self.options = common.Options(**options)
-        common.validate_instrumentation_key(self.options.instrumentation_key)
+        common.validate_key(self.options.instrumentation_key)
         self.storage = LocalFileStorage(
             path=self.options.storage_path,
             max_size=self.options.storage_max_size,

--- a/contrib/opencensus-ext-azure/tests/test_common.py
+++ b/contrib/opencensus-ext-azure/tests/test_common.py
@@ -1,0 +1,87 @@
+# Copyright 2019, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from opencensus.ext.azure import common
+
+
+class TestLocalFileBlob(unittest.TestCase):
+    def test_validate_key(self):
+        key = '1234abcd-5678-4efa-8abc-1234567890ab'
+        self.assertIsNone(common.validate_key(key))
+
+    def test_invalid_key_none(self):
+        key = None
+        self.assertRaises(ValueError, lambda: common.validate_key(key))
+
+    def test_invalid_key_empty(self):
+        key = ''
+        self.assertRaises(ValueError, lambda: common.validate_key(key))
+
+    def test_invalid_key_length(self):
+        key = '1234abcd-5678-4efa-8abc-1234567890abz'
+        self.assertRaises(ValueError, lambda: common.validate_key(key))
+
+    def test_invalid_key_dashes(self):
+        key = '1234abcda5678-4efa-8abc-1234567890ab'
+        self.assertRaises(ValueError, lambda: common.validate_key(key))
+
+    def test_invalid_key_section1_length(self):
+        key = '1234abcda-678-4efa-8abc-1234567890ab'
+        self.assertRaises(ValueError, lambda: common.validate_key(key))
+
+    def test_invalid_key_section2_length(self):
+        key = '1234abcd-678-a4efa-8abc-1234567890ab'
+        self.assertRaises(ValueError, lambda: common.validate_key(key))
+
+    def test_invalid_key_section3_length(self):
+        key = '1234abcd-6789-4ef-8cabc-1234567890ab'
+        self.assertRaises(ValueError, lambda: common.validate_key(key))
+
+    def test_invalid_key_section4_length(self):
+        key = '1234abcd-678-4efa-8bc-11234567890ab'
+        self.assertRaises(ValueError, lambda: common.validate_key(key))
+
+    def test_invalid_key_section5_length(self):
+        key = '234abcd-678-4efa-8abc-11234567890ab'
+        self.assertRaises(ValueError, lambda: common.validate_key(key))
+
+    def test_invalid_key_section1_hex(self):
+        key = 'x234abcd-5678-4efa-8abc-1234567890ab'
+        self.assertRaises(ValueError, lambda: common.validate_key(key))
+
+    def test_invalid_key_section2_hex(self):
+        key = '1234abcd-x678-4efa-8abc-1234567890ab'
+        self.assertRaises(ValueError, lambda: common.validate_key(key))
+
+    def test_invalid_key_section3_hex(self):
+        key = '1234abcd-5678-4xfa-8abc-1234567890ab'
+        self.assertRaises(ValueError, lambda: common.validate_key(key))
+
+    def test_invalid_key_section4_hex(self):
+        key = '1234abcd-5678-4xfa-8abc-1234567890ab'
+        self.assertRaises(ValueError, lambda: common.validate_key(key))
+
+    def test_invalid_key_section5_hex(self):
+        key = '1234abcd-5678-4xfa-8abc-1234567890ab'
+        self.assertRaises(ValueError, lambda: common.validate_key(key))
+
+    def test_invalid_key_version(self):
+        key = '1234abcd-5678-6efa-8abc-1234567890ab'
+        self.assertRaises(ValueError, lambda: common.validate_key(key))
+
+    def test_invalid_key_variant(self):
+        key = '1234abcd-5678-4efa-2abc-1234567890ab'
+        self.assertRaises(ValueError, lambda: common.validate_key(key))


### PR DESCRIPTION
Azure exporters will now throw an exception upon passing in an invalid instrumentation key.

The definition of a VALID instrumentation key is as follows:
1. Not none
2. Not empty
3. Valid UUID according to [this](https://tools.ietf.org/html/rfc4122)
      - Every character is a hex character [0-9a-f]
      - 32 characters are separated into 5 sections via 4 dashes
      - First section has 8 characters
      - Second section has 4 characters
      - Third section has 4 characters, the first one in [1-5]
      - Fourth section has 4 characters, the first one in [89ab]
      - Fifth section has 12 characters