### PR TITLE
Add support for exporting Custom Events to Azure App Insights.

### DIFF
--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/events_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/events_exporter/__init__.py
@@ -1,0 +1,24 @@
+from opencensus.ext.azure.common import utils
+from opencensus.ext.azure.common.protocol import Data, Envelope, Event
+from opencensus.ext.azure.log_exporter import AzureLogHandler
+
+
+class AzureEventHandler(AzureLogHandler):
+    def __init__(self, **options):
+        super(AzureEventHandler, self).__init__(**options)
+
+    def log_record_to_envelope(self, record):
+        envelope = Envelope(
+            iKey=self.options.instrumentation_key,
+            tags=dict(utils.azure_monitor_context),
+            time=utils.timestamp_to_iso_str(record.created),
+        )
+
+        envelope.name = "Microsoft.ApplicationInsights.Event"
+        data = Event(
+            name=record.msg,
+            properties=record.args,
+            measurements=None,
+        )
+        envelope.data = Data(baseData=data, baseType='EventData')
+        return envelope

--- a/contrib/opencensus-ext-azure/tests/test_azure_event_exporter.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_event_exporter.py
@@ -1,0 +1,69 @@
+import logging
+import os
+import shutil
+import unittest
+
+import mock
+
+from opencensus.ext.azure import events_exporter
+
+TEST_FOLDER = os.path.abspath('.test.logs')
+
+
+def setUpModule():
+    os.makedirs(TEST_FOLDER)
+
+
+def tearDownModule():
+    shutil.rmtree(TEST_FOLDER)
+
+
+class TestAzureEventHandler(unittest.TestCase):
+    def test_log_record_to_envelope(self):
+        handler = events_exporter.AzureEventHandler(
+            instrumentation_key='12345678-1234-5678-abcd-12345678abcd',
+            storage_path=os.path.join(TEST_FOLDER, self.id()),
+        )
+        envelope = handler.log_record_to_envelope(mock.MagicMock(
+            msg="test"
+        ))
+        self.assertEqual(
+            envelope.iKey,
+            '12345678-1234-5678-abcd-12345678abcd')
+
+        self.assertEqual(
+            envelope.name,
+            'Microsoft.ApplicationInsights.Event')
+
+        self.assertEqual(
+            envelope.get("data").baseData.get("name"),
+            "test")
+        handler.close()
+
+    def test_log_record_to_envelope_with_properties(self):
+        handler = events_exporter.AzureEventHandler(
+            instrumentation_key='12345678-1234-5678-abcd-12345678abcd',
+            storage_path=os.path.join(TEST_FOLDER, self.id()),
+        )
+        envelope = handler.log_record_to_envelope(mock.MagicMock(
+            msg="test",
+            args={"sku": "SKU-12312"}
+        ))
+        self.assertEqual(
+            len(envelope.get("data").baseData.get("properties")),
+            1)
+        handler.close()
+
+    @mock.patch('requests.post', return_value=mock.Mock())
+    def test_export(self, requests_mock):
+        logger = logging.getLogger(self.id())
+        handler = events_exporter.AzureEventHandler(
+            instrumentation_key='12345678-1234-5678-abcd-12345678abcd',
+            storage_path=os.path.join(TEST_FOLDER, self.id()),
+        )
+        logger.addHandler(handler)
+        logger.warning('test_metric')
+        handler.close()
+        self.assertEqual(len(requests_mock.call_args_list), 1)
+        post_body = requests_mock.call_args_list[0][1]['data']
+        self.assertTrue('test_metric' in post_body)


### PR DESCRIPTION
This PR enables sending Custom Events to Application Insights (Azure) from an application by creating a new logging exporter with the expected data structure used by App Insights for this feature. 

Custom Events in App Insights are a special type of structured, searchable data points reflecting an event or action. An event must contain an event name and optionally a set of properties (in the form of dictionaries) that are attached to that entry. 

