### PR TITLE
Allowing multiple worker applications (issue #816).

### DIFF
--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
@@ -114,7 +114,7 @@ class LocalFileStorage(object):
     def _maintenance_routine(self, silent=False):
         try:
             if not os.path.isdir(self.path):
-                Path(self.path).mkdir(exist_ok=True)
+                os.makedirs(self.path, exist_ok=True)
         except Exception:
             if not silent:
                 raise

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
@@ -109,7 +109,7 @@ class LocalFileStorage(object):
     def _maintenance_routine(self, silent=False):
         try:
             if not os.path.isdir(self.path):
-                os.makedirs(self.path)
+                os.makedirs(self.path, exist_ok=True)
         except Exception:
             if not silent:
                 raise

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
@@ -5,6 +5,11 @@ import random
 
 from opencensus.common.schedule import PeriodicTask
 
+try:
+  from pathlib import Path
+except ImportError:
+  from pathlib2 import Path  # python 2 backport
+
 
 def _fmt(timestamp):
     return timestamp.strftime('%Y-%m-%dT%H%M%S.%f')
@@ -108,8 +113,8 @@ class LocalFileStorage(object):
 
     def _maintenance_routine(self, silent=False):
         try:
-            if not os.path.exists(self.path):
-                os.makedirs(self.path)
+            if not os.path.isdir(self.path):
+                Path(self.path).mkdir(exist_ok=True)
         except Exception:
             if not silent:
                 raise

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
@@ -108,8 +108,8 @@ class LocalFileStorage(object):
 
     def _maintenance_routine(self, silent=False):
         try:
-            if not os.path.isdir(self.path):
-                os.makedirs(self.path, exist_ok=True)
+            if not os.path.exists(self.path):
+                os.makedirs(self.path)
         except Exception:
             if not silent:
                 raise

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus-context == 0.2.dev0',
+        'opencensus-context == 0.1.1',
         'google-api-core >= 1.0.0, < 2.0.0',
     ],
     extras_require={},

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus-context == 0.1.1',
+        'opencensus-context == 0.2.dev0',
         'google-api-core >= 1.0.0, < 2.0.0',
     ],
     extras_require={},


### PR DESCRIPTION
Add `exist_ok=True` to `opencensus-ext-azure.ext.azure.common.storage._maintenance_routine` to avoid raising `FileExistsError` if the target directory already exists, which is the default behavior (exist_ok=False). This behavior (`exist_ok=False`) do not allow multiple worker applications (such as uvicorn) to perform `run`. 