### PR TITLE
Add optional custom properties to logging messages.

### DIFF
--- a/contrib/opencensus-ext-azure/README.rst
+++ b/contrib/opencensus-ext-azure/README.rst
@@ -73,6 +73,20 @@ You can enrich the logs with trace IDs and span IDs by using the `logging integr
         logger.warning('In the span')
     logger.warning('After the span')
 
+You can also add custom properties to your log messages in the form of key-values.
+
+WARNING: For this feature to work, you need to pass a dictionary as the argument. If you pass arguments of any other type, the logger will ignore them. The solution is to convert these arguments into a dictionary.
+
+.. code:: python
+
+    import logging
+
+    from opencensus.ext.azure.log_exporter import AzureLogHandler
+
+    logger = logging.getLogger(__name__)
+    logger.addHandler(AzureLogHandler(connection_string='InstrumentationKey=<your-instrumentation_key-here>'))
+    logger.warning('action', {'key-1': 'value-1', 'key-2': 'value2'})
+
 Metrics
 ~~~~~~~
 

--- a/contrib/opencensus-ext-azure/examples/logs/properties.py
+++ b/contrib/opencensus-ext-azure/examples/logs/properties.py
@@ -1,0 +1,24 @@
+# Copyright 2019, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from opencensus.ext.azure.log_exporter import AzureLogHandler
+
+logger = logging.getLogger(__name__)
+# TODO: you need to specify the instrumentation key in a connection string
+# and place it in the APPLICATIONINSIGHTS_CONNECTION_STRING
+# environment variable.
+logger.addHandler(AzureLogHandler())
+logger.warning('action', {'key-1': 'value-1', 'key-2': 'value2'})

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/log_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/log_exporter/__init__.py
@@ -198,6 +198,8 @@ class AzureLogHandler(TransportMixin, BaseLogHandler):
             )
             envelope.data = Data(baseData=data, baseType='ExceptionData')
         else:
+            if isinstance(record.args, dict):
+                properties.update(record.args)
             envelope.name = 'Microsoft.ApplicationInsights.Message'
             data = Message(
                 message=self.format(record),


### PR DESCRIPTION
The idea behind this PR is to allow users to track additional information to logging actions by simply adding to the default properties, any additional metadata passed by the user in the form of a dictionary. 

The usage of this would look like this:

```
import logging

from opencensus.ext.azure.log_exporter import AzureLogHandler

logger = logging.getLogger(__name__)
# TODO: set APPLICATIONINSIGHTS_CONNECTION_STRING as environment variable.
logger.addHandler(AzureLogHandler())
logger.warning('action', {'key-1': 'value-1', 'key-2': 'value2'})
```

Once this data is uploaded to App Insights, you can search in the `traces` table by keys included in the `customDimensions` column like this:

```
traces
| where customDimensions.key-1 == "value-1"
| limit 50
| order by timestamp desc 
```

This is a good option instead of using Custom Events which is not currently supported in Open Census.