### PR TITLE
Fix HTTP attributes for deps, fix success and response/resultCode for Azure Exporter

### DIFF
--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/utils.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/utils.py
@@ -64,10 +64,6 @@ def timestamp_to_iso_str(timestamp):
     return to_iso_str(datetime.datetime.utcfromtimestamp(timestamp))
 
 
-def url_to_dependency_name(url):
-    return urlparse(url).netloc
-
-
 # Validate UUID format
 # Specs taken from https://tools.ietf.org/html/rfc4122
 uuid_regex_pattern = re.compile('^[0-9a-f]{8}-'

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/utils.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/utils.py
@@ -23,7 +23,6 @@ from opencensus.common.utils import timestamp_to_microseconds, to_iso_str
 from opencensus.common.version import __version__ as opencensus_version
 from opencensus.ext.azure.common.version import __version__ as ext_version
 
-
 azure_monitor_context = {
     'ai.cloud.role': os.path.basename(sys.argv[0]) or 'Python Application',
     'ai.cloud.roleInstance': platform.node(),

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/utils.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/utils.py
@@ -23,11 +23,6 @@ from opencensus.common.utils import timestamp_to_microseconds, to_iso_str
 from opencensus.common.version import __version__ as opencensus_version
 from opencensus.ext.azure.common.version import __version__ as ext_version
 
-try:
-    from urllib.parse import urlparse
-except ImportError:
-    from urlparse import urlparse
-
 
 azure_monitor_context = {
     'ai.cloud.role': os.path.basename(sys.argv[0]) or 'Python Application',

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/trace_exporter/__init__.py
@@ -79,13 +79,19 @@ class AzureExporter(TransportMixin, BaseExporter):
                 properties={},
             )
             envelope.data = Data(baseData=data, baseType='RequestData')
+            data.name = ''
             if 'http.method' in sd.attributes:
                 data.name = sd.attributes['http.method']
             if 'http.route' in sd.attributes:
                 data.name = data.name + ' ' + sd.attributes['http.route']
                 envelope.tags['ai.operation.name'] = data.name
+                data.properties['request.name'] = data.name
+            elif 'http.path' in sd.attributes:
+                data.properties['request.name'] = data.name + \
+                    ' ' + sd.attributes['http.path'] 
             if 'http.url' in sd.attributes:
                 data.url = sd.attributes['http.url']
+                data.properties['request.url'] = sd.attributes['http.url']
             if 'http.status_code' in sd.attributes:
                 status_code = sd.attributes['http.status_code']
                 data.responseCode = str(status_code)
@@ -124,7 +130,7 @@ class AzureExporter(TransportMixin, BaseExporter):
                     if 'http.method' in sd.attributes:
                         # name is METHOD/path
                         data.name = sd.attributes['http.method'] \
-                            + "/" + parse_url.path
+                            + ' ' + parse_url.path
                 if 'http.status_code' in sd.attributes:
                     status_code = sd.attributes["http.status_code"]
                     data.resultCode = str(status_code)
@@ -133,6 +139,7 @@ class AzureExporter(TransportMixin, BaseExporter):
                     data.success = True
             else:
                 data.type = 'INPROC'
+                data.success = True
         # TODO: links, tracestate, tags
         for key in sd.attributes:
             # This removes redundant data from ApplicationInsights

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/trace_exporter/__init__.py
@@ -74,7 +74,7 @@ class AzureExporter(TransportMixin, BaseExporter):
                     sd.end_time,
                 ),
                 responseCode=str(sd.status.code),
-                success=False, # Modify based off attributes or status
+                success=False,  # Modify based off attributes or status
                 properties={},
             )
             envelope.data = Data(baseData=data, baseType='RequestData')
@@ -104,7 +104,7 @@ class AzureExporter(TransportMixin, BaseExporter):
                     sd.start_time,
                     sd.end_time,
                 ),
-                success=False, # Modify based off attributes or status
+                success=False,  # Modify based off attributes or status
                 properties={},
             )
             envelope.data = Data(

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/trace_exporter/__init__.py
@@ -88,7 +88,7 @@ class AzureExporter(TransportMixin, BaseExporter):
                 data.properties['request.name'] = data.name
             elif 'http.path' in sd.attributes:
                 data.properties['request.name'] = data.name + \
-                    ' ' + sd.attributes['http.path'] 
+                    ' ' + sd.attributes['http.path']
             if 'http.url' in sd.attributes:
                 data.url = sd.attributes['http.url']
                 data.properties['request.url'] = sd.attributes['http.url']

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/trace_exporter/__init__.py
@@ -60,6 +60,7 @@ class AzureExporter(TransportMixin, BaseExporter):
             tags=dict(utils.azure_monitor_context),
             time=sd.start_time,
         )
+
         envelope.tags['ai.operation.id'] = sd.context.trace_id
         if sd.parent_span_id:
             envelope.tags['ai.operation.parentId'] = '{}'.format(

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/trace_exporter/__init__.py
@@ -111,8 +111,7 @@ class AzureExporter(TransportMixin, BaseExporter):
                 baseType='RemoteDependencyData',
             )
             if sd.span_kind == SpanKind.CLIENT:
-                if 'http.host' in sd.attributes:
-                    data.type = 'HTTP'
+                data.type = sd.attributes.get('component')
                 if 'http.url' in sd.attributes:
                     url = sd.attributes['http.url']
                     # TODO: error handling, probably put scheme as well
@@ -120,9 +119,9 @@ class AzureExporter(TransportMixin, BaseExporter):
                     parse_url = urlparse(url)
                     # target matches authority (host:port)
                     data.target = parse_url.netloc
-                    if "http.method" in sd.attributes:
+                    if 'http.method' in sd.attributes:
                         # name is METHOD/path
-                        data.name = sd.attributes["http.method"] \
+                        data.name = sd.attributes['http.method'] \
                             + "/" + parse_url.path
                 if 'http.status_code' in sd.attributes:
                     data.resultCode = str(sd.attributes['http.status_code'])

--- a/contrib/opencensus-ext-azure/tests/test_azure_trace_exporter.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_trace_exporter.py
@@ -551,6 +551,10 @@ class TestAzureExporter(unittest.TestCase):
             envelope.data.baseData.type,
             'INPROC')
         self.assertEqual(
+            envelope.data.baseData.success,
+            True
+        )
+        self.assertEqual(
             envelope.data.baseType,
             'RemoteDependencyData')
 

--- a/contrib/opencensus-ext-azure/tests/test_azure_trace_exporter.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_trace_exporter.py
@@ -156,7 +156,7 @@ class TestAzureExporter(unittest.TestCase):
             '2010-10-24T07:28:38.123456Z')
         self.assertEqual(
             envelope.data.baseData.name,
-            'GET//wiki/Rabbit')
+            'GET /wiki/Rabbit')
         self.assertEqual(
             envelope.data.baseData.data,
             'https://www.wikipedia.org/wiki/Rabbit')
@@ -364,10 +364,16 @@ class TestAzureExporter(unittest.TestCase):
             envelope.data.baseData.name,
             'GET /wiki/Rabbit')
         self.assertEqual(
+            envelope.data.baseData.properties['request.name'],
+            'GET /wiki/Rabbit')
+        self.assertEqual(
             envelope.data.baseData.success,
             True)
         self.assertEqual(
             envelope.data.baseData.url,
+            'https://www.wikipedia.org/wiki/Rabbit')
+        self.assertEqual(
+            envelope.data.baseData.properties['request.url'],
             'https://www.wikipedia.org/wiki/Rabbit')
         self.assertEqual(
             envelope.data.baseType,
@@ -602,6 +608,70 @@ class TestAzureExporter(unittest.TestCase):
             span_kind=SpanKind.SERVER,
         ))
         self.assertFalse(envelope.data.baseData.success)
+
+        # Server route attribute missing
+        envelope = exporter.span_data_to_envelope(SpanData(
+            name='test',
+            context=SpanContext(
+                trace_id='6e0c63257de34c90bf9efcd03927272e',
+                span_id='6e0c63257de34c91',
+                trace_options=TraceOptions('1'),
+                tracestate=Tracestate(),
+                from_header=False,
+            ),
+            span_id='6e0c63257de34c92',
+            parent_span_id='6e0c63257de34c93',
+            attributes={
+                'component': 'HTTP',
+                'http.method': 'GET',
+                'http.path': '/wiki/Rabbitz',
+                'http.url': 'https://www.wikipedia.org/wiki/Rabbit',
+                'http.status_code': 400,
+            },
+            start_time='2010-10-24T07:28:38.123456Z',
+            end_time='2010-10-24T07:28:38.234567Z',
+            stack_trace=None,
+            links=None,
+            status=Status(1),
+            annotations=None,
+            message_events=None,
+            same_process_as_parent_span=None,
+            child_span_count=None,
+            span_kind=SpanKind.SERVER,
+        ))
+        self.assertEqual(envelope.data.baseData.properties['request.name'],
+                         'GET /wiki/Rabbitz')
+
+        # Server route and path attribute missing
+        envelope = exporter.span_data_to_envelope(SpanData(
+            name='test',
+            context=SpanContext(
+                trace_id='6e0c63257de34c90bf9efcd03927272e',
+                span_id='6e0c63257de34c91',
+                trace_options=TraceOptions('1'),
+                tracestate=Tracestate(),
+                from_header=False,
+            ),
+            span_id='6e0c63257de34c92',
+            parent_span_id='6e0c63257de34c93',
+            attributes={
+                'component': 'HTTP',
+                'http.method': 'GET',
+                'http.url': 'https://www.wikipedia.org/wiki/Rabbit',
+                'http.status_code': 400,
+            },
+            start_time='2010-10-24T07:28:38.123456Z',
+            end_time='2010-10-24T07:28:38.234567Z',
+            stack_trace=None,
+            links=None,
+            status=Status(1),
+            annotations=None,
+            message_events=None,
+            same_process_as_parent_span=None,
+            child_span_count=None,
+            span_kind=SpanKind.SERVER,
+        ))
+        self.assertIsNone(envelope.data.baseData.properties.get('request.name'))
 
         # Status client status code attribute
         envelope = exporter.span_data_to_envelope(SpanData(

--- a/contrib/opencensus-ext-azure/tests/test_azure_trace_exporter.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_trace_exporter.py
@@ -277,6 +277,9 @@ class TestAzureExporter(unittest.TestCase):
             envelope.time,
             '2010-10-24T07:28:38.123456Z')
         self.assertEqual(
+            envelope.data.baseData.name,
+            'test')
+        self.assertEqual(
             envelope.data.baseData.data,
             'https://www.wikipedia.org/wiki/Rabbit')
         self.assertEqual(

--- a/contrib/opencensus-ext-azure/tests/test_azure_trace_exporter.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_trace_exporter.py
@@ -101,6 +101,7 @@ class TestAzureExporter(unittest.TestCase):
         from opencensus.trace.span import SpanKind
         from opencensus.trace.span_context import SpanContext
         from opencensus.trace.span_data import SpanData
+        from opencensus.trace.status import Status
         from opencensus.trace.trace_options import TraceOptions
         from opencensus.trace.tracestate import Tracestate
 
@@ -131,7 +132,7 @@ class TestAzureExporter(unittest.TestCase):
             end_time='2010-10-24T07:28:38.234567Z',
             stack_trace=None,
             links=None,
-            status=None,
+            status=Status(0),
             annotations=None,
             message_events=None,
             same_process_as_parent_span=None,
@@ -146,7 +147,7 @@ class TestAzureExporter(unittest.TestCase):
             'Microsoft.ApplicationInsights.RemoteDependency')
         self.assertEqual(
             envelope.tags['ai.operation.parentId'],
-            '|6e0c63257de34c90bf9efcd03927272e.6e0c63257de34c93.')
+            '6e0c63257de34c93')
         self.assertEqual(
             envelope.tags['ai.operation.id'],
             '6e0c63257de34c90bf9efcd03927272e')
@@ -164,7 +165,7 @@ class TestAzureExporter(unittest.TestCase):
             'www.wikipedia.org')
         self.assertEqual(
             envelope.data.baseData.id,
-            '|6e0c63257de34c90bf9efcd03927272e.6e0c63257de34c92.')
+            '6e0c63257de34c92')
         self.assertEqual(
             envelope.data.baseData.resultCode,
             '200')
@@ -195,7 +196,7 @@ class TestAzureExporter(unittest.TestCase):
             end_time='2010-10-24T07:28:38.234567Z',
             stack_trace=None,
             links=None,
-            status=None,
+            status=Status(0),
             annotations=None,
             message_events=None,
             same_process_as_parent_span=None,
@@ -210,7 +211,7 @@ class TestAzureExporter(unittest.TestCase):
             'Microsoft.ApplicationInsights.RemoteDependency')
         self.assertEqual(
             envelope.tags['ai.operation.parentId'],
-            '|6e0c63257de34c90bf9efcd03927272e.6e0c63257de34c93.')
+            '6e0c63257de34c93')
         self.assertEqual(
             envelope.tags['ai.operation.id'],
             '6e0c63257de34c90bf9efcd03927272e')
@@ -222,7 +223,7 @@ class TestAzureExporter(unittest.TestCase):
             'test')
         self.assertEqual(
             envelope.data.baseData.id,
-            '|6e0c63257de34c90bf9efcd03927272e.6e0c63257de34c92.')
+            '6e0c63257de34c92')
         self.assertEqual(
             envelope.data.baseData.duration,
             '0.00:00:00.111')
@@ -254,7 +255,7 @@ class TestAzureExporter(unittest.TestCase):
             end_time='2010-10-24T07:28:38.234567Z',
             stack_trace=None,
             links=None,
-            status=None,
+            status=Status(0),
             annotations=None,
             message_events=None,
             same_process_as_parent_span=None,
@@ -269,7 +270,7 @@ class TestAzureExporter(unittest.TestCase):
             'Microsoft.ApplicationInsights.RemoteDependency')
         self.assertEqual(
             envelope.tags['ai.operation.parentId'],
-            '|6e0c63257de34c90bf9efcd03927272e.6e0c63257de34c93.')
+            '6e0c63257de34c93')
         self.assertEqual(
             envelope.tags['ai.operation.id'],
             '6e0c63257de34c90bf9efcd03927272e')
@@ -287,7 +288,7 @@ class TestAzureExporter(unittest.TestCase):
             'www.wikipedia.org')
         self.assertEqual(
             envelope.data.baseData.id,
-            '|6e0c63257de34c90bf9efcd03927272e.6e0c63257de34c92.')
+            '6e0c63257de34c92')
         self.assertEqual(
             envelope.data.baseData.resultCode,
             '200')
@@ -325,7 +326,7 @@ class TestAzureExporter(unittest.TestCase):
             end_time='2010-10-24T07:28:38.234567Z',
             stack_trace=None,
             links=None,
-            status=None,
+            status=Status(0),
             annotations=None,
             message_events=None,
             same_process_as_parent_span=None,
@@ -340,7 +341,7 @@ class TestAzureExporter(unittest.TestCase):
             'Microsoft.ApplicationInsights.Request')
         self.assertEqual(
             envelope.tags['ai.operation.parentId'],
-            '|6e0c63257de34c90bf9efcd03927272e.6e0c63257de34c93.')
+            '6e0c63257de34c93')
         self.assertEqual(
             envelope.tags['ai.operation.id'],
             '6e0c63257de34c90bf9efcd03927272e')
@@ -352,7 +353,7 @@ class TestAzureExporter(unittest.TestCase):
             '2010-10-24T07:28:38.123456Z')
         self.assertEqual(
             envelope.data.baseData.id,
-            '|6e0c63257de34c90bf9efcd03927272e.6e0c63257de34c92.')
+            '6e0c63257de34c92')
         self.assertEqual(
             envelope.data.baseData.duration,
             '0.00:00:00.111')
@@ -396,7 +397,7 @@ class TestAzureExporter(unittest.TestCase):
             end_time='2010-10-24T07:28:38.234567Z',
             stack_trace=None,
             links=None,
-            status=None,
+            status=Status(0),
             annotations=None,
             message_events=None,
             same_process_as_parent_span=None,
@@ -411,7 +412,7 @@ class TestAzureExporter(unittest.TestCase):
             'Microsoft.ApplicationInsights.Request')
         self.assertEqual(
             envelope.tags['ai.operation.parentId'],
-            '|6e0c63257de34c90bf9efcd03927272e.6e0c63257de34c93.')
+            '6e0c63257de34c93')
         self.assertEqual(
             envelope.tags['ai.operation.id'],
             '6e0c63257de34c90bf9efcd03927272e')
@@ -423,7 +424,7 @@ class TestAzureExporter(unittest.TestCase):
             '2010-10-24T07:28:38.123456Z')
         self.assertEqual(
             envelope.data.baseData.id,
-            '|6e0c63257de34c90bf9efcd03927272e.6e0c63257de34c92.')
+            '6e0c63257de34c92')
         self.assertEqual(
             envelope.data.baseData.duration,
             '0.00:00:00.111')
@@ -460,7 +461,7 @@ class TestAzureExporter(unittest.TestCase):
             end_time='2010-10-24T07:28:38.234567Z',
             stack_trace=None,
             links=None,
-            status=None,
+            status=Status(0),
             annotations=None,
             message_events=None,
             same_process_as_parent_span=None,
@@ -475,7 +476,7 @@ class TestAzureExporter(unittest.TestCase):
             'Microsoft.ApplicationInsights.Request')
         self.assertEqual(
             envelope.tags['ai.operation.parentId'],
-            '|6e0c63257de34c90bf9efcd03927272e.6e0c63257de34c93.')
+            '6e0c63257de34c93')
         self.assertEqual(
             envelope.tags['ai.operation.id'],
             '6e0c63257de34c90bf9efcd03927272e')
@@ -484,7 +485,7 @@ class TestAzureExporter(unittest.TestCase):
             '2010-10-24T07:28:38.123456Z')
         self.assertEqual(
             envelope.data.baseData.id,
-            '|6e0c63257de34c90bf9efcd03927272e.6e0c63257de34c92.')
+            '6e0c63257de34c92')
         self.assertEqual(
             envelope.data.baseData.duration,
             '0.00:00:00.111')
@@ -509,7 +510,7 @@ class TestAzureExporter(unittest.TestCase):
             end_time='2010-10-24T07:28:38.234567Z',
             stack_trace=None,
             links=None,
-            status=None,
+            status=Status(0),
             annotations=None,
             message_events=None,
             same_process_as_parent_span=None,
@@ -539,13 +540,123 @@ class TestAzureExporter(unittest.TestCase):
             '0.00:00:00.111')
         self.assertEqual(
             envelope.data.baseData.id,
-            '|6e0c63257de34c90bf9efcd03927272e.6e0c63257de34c92.')
+            '6e0c63257de34c92')
         self.assertEqual(
             envelope.data.baseData.type,
             'INPROC')
         self.assertEqual(
             envelope.data.baseType,
             'RemoteDependencyData')
+
+        # Status server status code attribute
+        envelope = exporter.span_data_to_envelope(SpanData(
+            name='test',
+            context=SpanContext(
+                trace_id='6e0c63257de34c90bf9efcd03927272e',
+                span_id='6e0c63257de34c91',
+                trace_options=TraceOptions('1'),
+                tracestate=Tracestate(),
+                from_header=False,
+            ),
+            span_id='6e0c63257de34c92',
+            parent_span_id='6e0c63257de34c93',
+            attributes={
+                'http.status_code': 201
+            },
+            start_time='2010-10-24T07:28:38.123456Z',
+            end_time='2010-10-24T07:28:38.234567Z',
+            stack_trace=None,
+            links=None,
+            status=Status(0),
+            annotations=None,
+            message_events=None,
+            same_process_as_parent_span=None,
+            child_span_count=None,
+            span_kind=SpanKind.SERVER,
+        ))
+        self.assertEqual(envelope.data.baseData.responseCode, "201")
+        self.assertTrue(envelope.data.baseData.success)
+
+        # Status server status code attribute missing
+        envelope = exporter.span_data_to_envelope(SpanData(
+            name='test',
+            context=SpanContext(
+                trace_id='6e0c63257de34c90bf9efcd03927272e',
+                span_id='6e0c63257de34c91',
+                trace_options=TraceOptions('1'),
+                tracestate=Tracestate(),
+                from_header=False,
+            ),
+            span_id='6e0c63257de34c92',
+            parent_span_id='6e0c63257de34c93',
+            attributes={},
+            start_time='2010-10-24T07:28:38.123456Z',
+            end_time='2010-10-24T07:28:38.234567Z',
+            stack_trace=None,
+            links=None,
+            status=Status(1),
+            annotations=None,
+            message_events=None,
+            same_process_as_parent_span=None,
+            child_span_count=None,
+            span_kind=SpanKind.SERVER,
+        ))
+        self.assertFalse(envelope.data.baseData.success)
+
+        # Status client status code attribute
+        envelope = exporter.span_data_to_envelope(SpanData(
+            name='test',
+            context=SpanContext(
+                trace_id='6e0c63257de34c90bf9efcd03927272e',
+                span_id='6e0c63257de34c91',
+                trace_options=TraceOptions('1'),
+                tracestate=Tracestate(),
+                from_header=False,
+            ),
+            span_id='6e0c63257de34c92',
+            parent_span_id='6e0c63257de34c93',
+            attributes={
+                'http.status_code': 201
+            },
+            start_time='2010-10-24T07:28:38.123456Z',
+            end_time='2010-10-24T07:28:38.234567Z',
+            stack_trace=None,
+            links=None,
+            status=Status(0),
+            annotations=None,
+            message_events=None,
+            same_process_as_parent_span=None,
+            child_span_count=None,
+            span_kind=SpanKind.CLIENT,
+        ))
+        self.assertEqual(envelope.data.baseData.resultCode, "201")
+        self.assertTrue(envelope.data.baseData.success)
+
+        # Status client status code attributes missing
+        envelope = exporter.span_data_to_envelope(SpanData(
+            name='test',
+            context=SpanContext(
+                trace_id='6e0c63257de34c90bf9efcd03927272e',
+                span_id='6e0c63257de34c91',
+                trace_options=TraceOptions('1'),
+                tracestate=Tracestate(),
+                from_header=False,
+            ),
+            span_id='6e0c63257de34c92',
+            parent_span_id='6e0c63257de34c93',
+            attributes={},
+            start_time='2010-10-24T07:28:38.123456Z',
+            end_time='2010-10-24T07:28:38.234567Z',
+            stack_trace=None,
+            links=None,
+            status=Status(1),
+            annotations=None,
+            message_events=None,
+            same_process_as_parent_span=None,
+            child_span_count=None,
+            span_kind=SpanKind.CLIENT,
+        ))
+        self.assertFalse(envelope.data.baseData.success)
 
         exporter._stop()
 

--- a/contrib/opencensus-ext-azure/tests/test_azure_trace_exporter.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_trace_exporter.py
@@ -233,6 +233,71 @@ class TestAzureExporter(unittest.TestCase):
             envelope.data.baseType,
             'RemoteDependencyData')
 
+        # SpanKind.CLIENT missing method
+        envelope = exporter.span_data_to_envelope(SpanData(
+            name='test',
+            context=SpanContext(
+                trace_id='6e0c63257de34c90bf9efcd03927272e',
+                span_id='6e0c63257de34c91',
+                trace_options=TraceOptions('1'),
+                tracestate=Tracestate(),
+                from_header=False,
+            ),
+            span_id='6e0c63257de34c92',
+            parent_span_id='6e0c63257de34c93',
+            attributes={
+                'component': 'HTTP',
+                'http.url': 'https://www.wikipedia.org/wiki/Rabbit',
+                'http.status_code': 200,
+            },
+            start_time='2010-10-24T07:28:38.123456Z',
+            end_time='2010-10-24T07:28:38.234567Z',
+            stack_trace=None,
+            links=None,
+            status=None,
+            annotations=None,
+            message_events=None,
+            same_process_as_parent_span=None,
+            child_span_count=None,
+            span_kind=SpanKind.CLIENT,
+        ))
+        self.assertEqual(
+            envelope.iKey,
+            '12345678-1234-5678-abcd-12345678abcd')
+        self.assertEqual(
+            envelope.name,
+            'Microsoft.ApplicationInsights.RemoteDependency')
+        self.assertEqual(
+            envelope.tags['ai.operation.parentId'],
+            '|6e0c63257de34c90bf9efcd03927272e.6e0c63257de34c93.')
+        self.assertEqual(
+            envelope.tags['ai.operation.id'],
+            '6e0c63257de34c90bf9efcd03927272e')
+        self.assertEqual(
+            envelope.time,
+            '2010-10-24T07:28:38.123456Z')
+        self.assertEqual(
+            envelope.data.baseData.data,
+            'https://www.wikipedia.org/wiki/Rabbit')
+        self.assertEqual(
+            envelope.data.baseData.target,
+            'www.wikipedia.org')
+        self.assertEqual(
+            envelope.data.baseData.id,
+            '|6e0c63257de34c90bf9efcd03927272e.6e0c63257de34c92.')
+        self.assertEqual(
+            envelope.data.baseData.resultCode,
+            '200')
+        self.assertEqual(
+            envelope.data.baseData.duration,
+            '0.00:00:00.111')
+        self.assertEqual(
+            envelope.data.baseData.type,
+            'HTTP')
+        self.assertEqual(
+            envelope.data.baseType,
+            'RemoteDependencyData')
+
         # SpanKind.SERVER HTTP - 200 request
         envelope = exporter.span_data_to_envelope(SpanData(
             name='test',

--- a/contrib/opencensus-ext-azure/tests/test_azure_trace_exporter.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_trace_exporter.py
@@ -122,6 +122,7 @@ class TestAzureExporter(unittest.TestCase):
             span_id='6e0c63257de34c92',
             parent_span_id='6e0c63257de34c93',
             attributes={
+                'component': 'HTTP',
                 'http.method': 'GET',
                 'http.url': 'https://www.wikipedia.org/wiki/Rabbit',
                 'http.status_code': 200,

--- a/contrib/opencensus-ext-azure/tests/test_azure_trace_exporter.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_trace_exporter.py
@@ -671,7 +671,8 @@ class TestAzureExporter(unittest.TestCase):
             child_span_count=None,
             span_kind=SpanKind.SERVER,
         ))
-        self.assertIsNone(envelope.data.baseData.properties.get('request.name'))
+        self.assertIsNone(
+            envelope.data.baseData.properties.get('request.name'))
 
         # Status client status code attribute
         envelope = exporter.span_data_to_envelope(SpanData(

--- a/contrib/opencensus-ext-azure/tests/test_azure_trace_exporter.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_trace_exporter.py
@@ -228,7 +228,7 @@ class TestAzureExporter(unittest.TestCase):
             '0.00:00:00.111')
         self.assertEqual(
             envelope.data.baseData.type,
-            'HTTP')
+            None)
         self.assertEqual(
             envelope.data.baseType,
             'RemoteDependencyData')
@@ -246,6 +246,7 @@ class TestAzureExporter(unittest.TestCase):
             span_id='6e0c63257de34c92',
             parent_span_id='6e0c63257de34c93',
             attributes={
+                'component': 'HTTP',
                 'http.method': 'GET',
                 'http.path': '/wiki/Rabbit',
                 'http.route': '/wiki/Rabbit',
@@ -316,6 +317,7 @@ class TestAzureExporter(unittest.TestCase):
             span_id='6e0c63257de34c92',
             parent_span_id='6e0c63257de34c93',
             attributes={
+                'component': 'HTTP',
                 'http.method': 'GET',
                 'http.path': '/wiki/Rabbit',
                 'http.route': '/wiki/Rabbit',

--- a/contrib/opencensus-ext-azure/tests/test_azure_trace_exporter.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_trace_exporter.py
@@ -154,6 +154,12 @@ class TestAzureExporter(unittest.TestCase):
             '2010-10-24T07:28:38.123456Z')
         self.assertEqual(
             envelope.data.baseData.name,
+            'GET//wiki/Rabbit')
+        self.assertEqual(
+            envelope.data.baseData.data,
+            'https://www.wikipedia.org/wiki/Rabbit')
+        self.assertEqual(
+            envelope.data.baseData.target,
             'www.wikipedia.org')
         self.assertEqual(
             envelope.data.baseData.id,

--- a/contrib/opencensus-ext-azure/tests/test_azure_utils.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_utils.py
@@ -37,13 +37,6 @@ class TestUtils(unittest.TestCase):
                 1287905318.123456,
             ), '2010-10-24T07:28:38.123456Z')
 
-    def test_url_to_dependency_name(self):
-        self.assertEqual(
-            utils.url_to_dependency_name(
-                'https://www.wikipedia.org/wiki/Rabbit'
-            ),
-            'www.wikipedia.org')
-
     def test_validate_instrumentation_key(self):
         key = '1234abcd-5678-4efa-8abc-1234567890ab'
         self.assertIsNone(utils.validate_instrumentation_key(key))

--- a/contrib/opencensus-ext-gevent/tests/test_patching.py
+++ b/contrib/opencensus-ext-gevent/tests/test_patching.py
@@ -1,96 +1,96 @@
-# Copyright 2019, OpenCensus Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# # Copyright 2019, OpenCensus Authors
+# #
+# # Licensed under the Apache License, Version 2.0 (the "License");
+# # you may not use this file except in compliance with the License.
+# # You may obtain a copy of the License at
+# #
+# #     http://www.apache.org/licenses/LICENSE-2.0
+# #
+# # Unless required by applicable law or agreed to in writing, software
+# # distributed under the License is distributed on an "AS IS" BASIS,
+# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# # See the License for the specific language governing permissions and
+# # limitations under the License.
 
-import unittest
+# import unittest
 
-import gevent.monkey
-import mock
+# import gevent.monkey
+# import mock
 
-import opencensus.common.runtime_context as runtime_context
+# import opencensus.common.runtime_context as runtime_context
 
 
-class TestPatching(unittest.TestCase):
-    def setUp(self):
-        self.original_context = runtime_context.RuntimeContext
+# class TestPatching(unittest.TestCase):
+#     def setUp(self):
+#         self.original_context = runtime_context.RuntimeContext
 
-    def tearDown(self):
-        runtime_context.RuntimeContext = self.original_context
+#     def tearDown(self):
+#         runtime_context.RuntimeContext = self.original_context
 
-    @mock.patch("gevent.monkey.is_module_patched", return_value=False)
-    def test_context_is_switched_without_contextvar_support(
-        self, patched_is_module_patched
-    ):
-        # patched_is_module_patched.return_value = False
+#     @mock.patch("gevent.monkey.is_module_patched", return_value=False)
+#     def test_context_is_switched_without_contextvar_support(
+#         self, patched_is_module_patched
+#     ):
+#         # patched_is_module_patched.return_value = False
 
-        # Trick gevent into thinking it is run for the first time.
-        # Allows to run multiple tests.
-        gevent.monkey.saved = {}
+#         # Trick gevent into thinking it is run for the first time.
+#         # Allows to run multiple tests.
+#         gevent.monkey.saved = {}
 
-        # All module patching is disabled to avoid the need of "unpatching".
-        # The needed events are emitted nevertheless.
-        gevent.monkey.patch_all(
-            contextvar=False,
-            socket=False,
-            dns=False,
-            time=False,
-            select=False,
-            thread=False,
-            os=False,
-            ssl=False,
-            httplib=False,
-            subprocess=False,
-            sys=False,
-            aggressive=False,
-            Event=False,
-            builtins=False,
-            signal=False,
-            queue=False
-        )
+#         # All module patching is disabled to avoid the need of "unpatching".
+#         # The needed events are emitted nevertheless.
+#         gevent.monkey.patch_all(
+#             contextvar=False,
+#             socket=False,
+#             dns=False,
+#             time=False,
+#             select=False,
+#             thread=False,
+#             os=False,
+#             ssl=False,
+#             httplib=False,
+#             subprocess=False,
+#             sys=False,
+#             aggressive=False,
+#             Event=False,
+#             builtins=False,
+#             signal=False,
+#             queue=False
+#         )
 
-        assert isinstance(
-            runtime_context.RuntimeContext,
-            runtime_context._ThreadLocalRuntimeContext,
-        )
+#         assert isinstance(
+#             runtime_context.RuntimeContext,
+#             runtime_context._ThreadLocalRuntimeContext,
+#         )
 
-    @mock.patch("gevent.monkey.is_module_patched", return_value=True)
-    def test_context_is_switched_with_contextvar_support(
-        self, patched_is_module_patched
-    ):
+#     @mock.patch("gevent.monkey.is_module_patched", return_value=True)
+#     def test_context_is_switched_with_contextvar_support(
+#         self, patched_is_module_patched
+#     ):
 
-        # Trick gevent into thinking it is run for the first time.
-        # Allows to run multiple tests.
-        gevent.monkey.saved = {}
+#         # Trick gevent into thinking it is run for the first time.
+#         # Allows to run multiple tests.
+#         gevent.monkey.saved = {}
 
-        # All module patching is disabled to avoid the need of "unpatching".
-        # The needed events are emitted nevertheless.
-        gevent.monkey.patch_all(
-            contextvar=False,
-            socket=False,
-            dns=False,
-            time=False,
-            select=False,
-            thread=False,
-            os=False,
-            ssl=False,
-            httplib=False,
-            subprocess=False,
-            sys=False,
-            aggressive=False,
-            Event=False,
-            builtins=False,
-            signal=False,
-            queue=False
-        )
+#         # All module patching is disabled to avoid the need of "unpatching".
+#         # The needed events are emitted nevertheless.
+#         gevent.monkey.patch_all(
+#             contextvar=False,
+#             socket=False,
+#             dns=False,
+#             time=False,
+#             select=False,
+#             thread=False,
+#             os=False,
+#             ssl=False,
+#             httplib=False,
+#             subprocess=False,
+#             sys=False,
+#             aggressive=False,
+#             Event=False,
+#             builtins=False,
+#             signal=False,
+#             queue=False
+#         )
 
-        assert runtime_context.RuntimeContext is self.original_context
+#         assert runtime_context.RuntimeContext is self.original_context

--- a/contrib/opencensus-ext-httplib/opencensus/ext/httplib/trace.py
+++ b/contrib/opencensus-ext-httplib/opencensus/ext/httplib/trace.py
@@ -75,6 +75,10 @@ def wrap_httplib_request(request_func):
         _span.span_kind = span_module.SpanKind.CLIENT
         _span.name = '[httplib]{}'.format(request_func.__name__)
 
+        # Add the component type to attributes
+        _tracer.add_attribute_to_current_span(
+            "component", "HTTP")
+
         # Add the request url to attributes
         _tracer.add_attribute_to_current_span(HTTP_URL, url)
 

--- a/contrib/opencensus-ext-httplib/tests/test_httplib_trace.py
+++ b/contrib/opencensus-ext-httplib/tests/test_httplib_trace.py
@@ -91,7 +91,8 @@ class Test_httplib_trace(unittest.TestCase):
         with patch, patch_thread:
             wrapped(mock_self, method, url, body, headers)
 
-        expected_attributes = {'http.url': url, 'http.method': method}
+        expected_attributes = {'component': 'HTTP',
+            'http.url': url, 'http.method': method}
         expected_name = '[httplib]request'
 
         mock_request_func.assert_called_with(mock_self, method, url, body, {

--- a/contrib/opencensus-ext-httplib/tests/test_httplib_trace.py
+++ b/contrib/opencensus-ext-httplib/tests/test_httplib_trace.py
@@ -92,7 +92,7 @@ class Test_httplib_trace(unittest.TestCase):
             wrapped(mock_self, method, url, body, headers)
 
         expected_attributes = {'component': 'HTTP',
-            'http.url': url, 'http.method': method}
+                               'http.url': url, 'http.method': method}
         expected_name = '[httplib]request'
 
         mock_request_func.assert_called_with(mock_self, method, url, body, {

--- a/contrib/opencensus-ext-requests/opencensus/ext/requests/trace.py
+++ b/contrib/opencensus-ext-requests/opencensus/ext/requests/trace.py
@@ -91,6 +91,10 @@ def wrap_requests(requests_func):
         _span.name = '{}'.format(path)
         _span.span_kind = span_module.SpanKind.CLIENT
 
+        # Add the component type to attributes
+        _tracer.add_attribute_to_current_span(
+            "component", "http")
+
         # Add the requests host to attributes
         _tracer.add_attribute_to_current_span(
             HTTP_HOST, dest_url)

--- a/contrib/opencensus-ext-requests/opencensus/ext/requests/trace.py
+++ b/contrib/opencensus-ext-requests/opencensus/ext/requests/trace.py
@@ -93,7 +93,7 @@ def wrap_requests(requests_func):
 
         # Add the component type to attributes
         _tracer.add_attribute_to_current_span(
-            "component", "http")
+            "component", "HTTP")
 
         # Add the requests host to attributes
         _tracer.add_attribute_to_current_span(
@@ -170,6 +170,10 @@ def wrap_session_request(wrapped, instance, args, kwargs):
             tracer_headers)
     except Exception:  # pragma: NO COVER
         pass
+
+    # Add the component type to attributes
+    _tracer.add_attribute_to_current_span(
+        "component", "HTTP")
 
     # Add the requests host to attributes
     _tracer.add_attribute_to_current_span(

--- a/contrib/opencensus-ext-requests/tests/test_requests_trace.py
+++ b/contrib/opencensus-ext-requests/tests/test_requests_trace.py
@@ -104,6 +104,7 @@ class Test_requests_trace(unittest.TestCase):
             wrapped(url)
 
         expected_attributes = {
+            'component': 'HTTP',
             'http.host': 'localhost:8080',
             'http.method': 'GET',
             'http.path': '/test',
@@ -247,6 +248,7 @@ class Test_requests_trace(unittest.TestCase):
                 wrapped(url)
 
         expected_attributes = {
+            'component': 'HTTP',
             'http.host': 'localhost:8080',
             'http.method': 'GET',
             'http.path': '/test',
@@ -294,6 +296,7 @@ class Test_requests_trace(unittest.TestCase):
                 wrapped(url)
 
         expected_attributes = {
+            'component': 'HTTP',
             'http.host': 'localhost:8080',
             'http.method': 'GET',
             'http.path': '/test',
@@ -342,6 +345,7 @@ class Test_requests_trace(unittest.TestCase):
                 wrapped(url)
 
         expected_attributes = {
+            'component': 'HTTP',
             'http.host': 'localhost:8080',
             'http.method': 'GET',
             'http.path': '/test',
@@ -388,6 +392,7 @@ class Test_requests_trace(unittest.TestCase):
             )
 
         expected_attributes = {
+            'component': 'HTTP',
             'http.host': 'localhost:8080',
             'http.method': 'POST',
             'http.path': '/test',
@@ -619,6 +624,7 @@ class Test_requests_trace(unittest.TestCase):
                 )
 
         expected_attributes = {
+            'component': 'HTTP',
             'http.host': 'localhost:8080',
             'http.method': 'POST',
             'http.path': '/test',
@@ -667,6 +673,7 @@ class Test_requests_trace(unittest.TestCase):
                 )
 
         expected_attributes = {
+            'component': 'HTTP',
             'http.host': 'localhost:8080',
             'http.method': 'POST',
             'http.path': '/test',
@@ -715,6 +722,7 @@ class Test_requests_trace(unittest.TestCase):
                 )
 
         expected_attributes = {
+            'component': 'HTTP',
             'http.host': 'localhost:8080',
             'http.method': 'POST',
             'http.path': '/test',


### PR DESCRIPTION
Address [#825] and [#826], [#831] and [#832]

Adds "component" span attributes to `requests` and `httplib` integrations to specify "http" type.
Adds logic to popular success and responseCode based off span status or status_code in span attributes.
