### PR TITLE
Remove coverage temporarily to unblock CI

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -52,7 +52,7 @@ def _install_dev_packages(session):
 def _install_test_dependencies(session):
     session.install('mock')
     session.install('pytest==4.6.4')
-    # session.install('pytest-cov')
+    # session.install('pytest-cov').
     session.install('retrying')
     session.install('unittest2')
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -52,7 +52,9 @@ def _install_dev_packages(session):
 def _install_test_dependencies(session):
     session.install('mock')
     session.install('pytest==4.6.4')
-    # session.install('pytest-cov').
+    # 842 - Unit tests failing on CI due to failed import for coverage
+    # Might have something to do with the CircleCI image
+    # session.install('pytest-cov')
     session.install('retrying')
     session.install('unittest2')
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -52,7 +52,7 @@ def _install_dev_packages(session):
 def _install_test_dependencies(session):
     session.install('mock')
     session.install('pytest==4.6.4')
-    session.install('pytest-cov')
+    # session.install('pytest-cov')
     session.install('retrying')
     session.install('unittest2')
 
@@ -71,13 +71,13 @@ def unit(session):
     session.run(
         'py.test',
         '--quiet',
-        '--cov=opencensus',
-        '--cov=context',
-        '--cov=contrib',
-        '--cov-append',
-        '--cov-config=.coveragerc',
-        '--cov-report=',
-        '--cov-fail-under=97',
+        # '--cov=opencensus',
+        # '--cov=context',
+        # '--cov=contrib',
+        # '--cov-append',
+        # '--cov-config=.coveragerc',
+        # '--cov-report=',
+        # '--cov-fail-under=97',
         'tests/unit/',
         'context/',
         'contrib/',
@@ -137,15 +137,15 @@ def lint_setup_py(session):
         'python', 'setup.py', 'check', '--restructuredtext', '--strict')
 
 
-@nox.session(python='3.6')
-def cover(session):
-    """Run the final coverage report.
-    This outputs the coverage report aggregating coverage from the unit
-    test runs (not system test runs), and then erases coverage data.
-    """
-    session.install('coverage', 'pytest-cov')
-    session.run('coverage', 'report', '--show-missing', '--fail-under=100')
-    session.run('coverage', 'erase')
+# @nox.session(python='3.6')
+# def cover(session):
+#     """Run the final coverage report.
+#     This outputs the coverage report aggregating coverage from the unit
+#     test runs (not system test runs), and then erases coverage data.
+#     """
+#     session.install('coverage', 'pytest-cov')
+#     session.run('coverage', 'report', '--show-missing', '--fail-under=100')
+#     session.run('coverage', 'erase')
 
 
 @nox.session(python='3.6')


### PR DESCRIPTION
Unit tests are failing for CircleCI due to failed import of `sqlite3` which is a dependency for `coverage`.
All Python environments fail except for `3.4`.

@c24t did some investigation and apparently using a different CircleCI image did not make the error show up, but this does not solve the issue. Removing coverage temporarily to unblock other PRs.

![image](https://user-images.githubusercontent.com/11580155/72461599-3b666b00-3784-11ea-98e8-35bb2c33724d.png)
