### PR TITLE
Add Fixed-rate sampling logic for Azure Log Exporter

### DIFF
--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
@@ -92,6 +92,7 @@ class Options(BaseObject):
         export_interval=15.0,
         grace_period=5.0,
         instrumentation_key=None,
+        logging_sampling_rate=1.0,
         max_batch_size=100,
         minimum_retry_interval=60,  # minimum retry interval in seconds
         proxy=None,

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/log_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/log_exporter/__init__.py
@@ -127,8 +127,7 @@ class AzureLogHandler(TransportMixin, BaseLogHandler):
     def __init__(self, **options):
         self.options = Options(**options)
         utils.validate_instrumentation_key(self.options.instrumentation_key)
-        if self.options.logging_sampling_rate < 0 or \
-           self.options.logging_sampling_rate > 1.0:
+        if not 0 <= self.options.logging_sampling_rate <= 1:
             raise ValueError('Sampling must be in the range: [0,1]')
         self.export_interval = self.options.export_interval
         self.max_batch_size = self.options.max_batch_size

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/log_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/log_exporter/__init__.py
@@ -127,6 +127,9 @@ class AzureLogHandler(TransportMixin, BaseLogHandler):
     def __init__(self, **options):
         self.options = Options(**options)
         utils.validate_instrumentation_key(self.options.instrumentation_key)
+        if self.options.logging_sampling_rate < 0 or \
+           self.options.logging_sampling_rate > 1.0:
+            raise ValueError('Sampling must be in the range: [0,1]')
         self.export_interval = self.options.export_interval
         self.max_batch_size = self.options.max_batch_size
         self.storage = LocalFileStorage(

--- a/contrib/opencensus-ext-azure/tests/test_azure_log_exporter.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_log_exporter.py
@@ -78,6 +78,12 @@ class TestAzureLogHandler(unittest.TestCase):
         self.assertRaises(ValueError, lambda: log_exporter.AzureLogHandler())
         Options._default.instrumentation_key = instrumentation_key
 
+    def test_invalid_sampling_rate(self):
+        self.assertRaises(ValueError, lambda: log_exporter.AzureLogHandler(
+            instrumentation_key='12345678-1234-5678-abcd-12345678abcd',
+            logging_sampling_rate=4.0,
+        ))
+
     @mock.patch('requests.post', return_value=mock.Mock())
     def test_exception(self, requests_mock):
         logger = logging.getLogger(self.id())

--- a/contrib/opencensus-ext-azure/tests/test_azure_log_exporter.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_log_exporter.py
@@ -79,10 +79,11 @@ class TestAzureLogHandler(unittest.TestCase):
         Options._default.instrumentation_key = instrumentation_key
 
     def test_invalid_sampling_rate(self):
-        self.assertRaises(ValueError, lambda: log_exporter.AzureLogHandler(
+        with self.assertRaises(ValueError) as err:
+            log_exporter.AzureLogHandler(
             instrumentation_key='12345678-1234-5678-abcd-12345678abcd',
             logging_sampling_rate=4.0,
-        ))
+        )
 
     @mock.patch('requests.post', return_value=mock.Mock())
     def test_exception(self, requests_mock):

--- a/contrib/opencensus-ext-azure/tests/test_azure_log_exporter.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_log_exporter.py
@@ -79,11 +79,11 @@ class TestAzureLogHandler(unittest.TestCase):
         Options._default.instrumentation_key = instrumentation_key
 
     def test_invalid_sampling_rate(self):
-        with self.assertRaises(ValueError) as err:
+        with self.assertRaises(ValueError):
             log_exporter.AzureLogHandler(
-            instrumentation_key='12345678-1234-5678-abcd-12345678abcd',
-            logging_sampling_rate=4.0,
-        )
+                instrumentation_key='12345678-1234-5678-abcd-12345678abcd',
+                logging_sampling_rate=4.0,
+            )
 
     @mock.patch('requests.post', return_value=mock.Mock())
     def test_exception(self, requests_mock):


### PR DESCRIPTION
Implements a `SamplingFilter` class for `AzureLogHandler`.
`SamplingFilter` extends from the Python `Filter` logging [class](https://docs.python.org/3/library/logging.html#filter-objects). Upon construction of the AzureLogHandler, a filter is added to the handler which filters out log records based off of a random number generated. The fixed rate is passed in to the `AzureLogHandler` by the `logging_sampling_rate` parameter which should be in the range [0,1.0]. The default rate if none passed is 1.0.

`AzureLogHandler(logging_sampling_rate=0.5)`