### PR TITLE
Use logging.exception() in opencensus.ext.jaeger.trace_exporter

### DIFF
--- a/contrib/opencensus-ext-jaeger/opencensus/ext/jaeger/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-jaeger/opencensus/ext/jaeger/trace_exporter/__init__.py
@@ -379,7 +379,7 @@ class Collector(base_exporter.Exporter):
                 logging.error("Traces cannot be uploaded;\
                         HTTP status code: {}, message {}".format(code, msg))
         except Exception as e:  # pragma: NO COVER
-            logging.error(getattr(e, 'message', e))
+            logging.exception("Failed to emit batch - {}".format(e))
 
         finally:
             if self.http_transport.isOpen():
@@ -458,7 +458,7 @@ class AgentClientUDP(base_exporter.Exporter):
                 udp_socket.sendto(buff, self.address)
 
         except Exception as e:  # pragma: NO COVER
-            logging.error(getattr(e, 'message', e))
+            logging.exception("Failed to emit batch - {}".format(e))
 
         finally:
             if udp_socket is not None:


### PR DESCRIPTION
This ensures a traceback is included when an error is caught and that there is a message describing what went wrong even if the error does not have a message. This makes debugging failed attempts to emit a message much easier.

Not all errors that could be caught by this handler have a useful message, e.g.
https://github.com/apache/thrift/blob/master/lib/py/src/transport/TTransport.py#L68

(It's also possible for error messages to define `__str__()` and not have a `message` attribute, but I don't think there are any examples of this case that this handler would catch.)

Logging output, before and after (using `logging.basicConfig()`):

<details>
<summary>Before</summary>
<pre>
<code>
ERROR:opencensus.ext.jaeger.trace_exporter:
ERROR:opencensus.ext.jaeger.trace_exporter:
ERROR:opencensus.ext.jaeger.trace_exporter:
ERROR:opencensus.ext.jaeger.trace_exporter:
ERROR:opencensus.ext.jaeger.trace_exporter:
ERROR:opencensus.ext.jaeger.trace_exporter:
ERROR:opencensus.ext.jaeger.trace_exporter:
</code>
</pre>
</details>

<details>
<summary>After</summary>
<pre>
<code>
ERROR:opencensus.ext.jaeger.trace_exporter:Failed to emit batch -
Traceback (most recent call last):
  File "/.../lib/python3.7/site-packages/opencensus/ext/jaeger/trace_exporter/__init__.py", line 373, in emit
    self.client.submitBatches([batch])
  File "/.../lib/python3.7/site-packages/opencensus/ext/jaeger/trace_exporter/gen/jaeger/jaeger.py", line 39, in submitBatches
    return self.recv_submitBatches()
  File "/.../lib/python3.7/site-packages/opencensus/ext/jaeger/trace_exporter/gen/jaeger/jaeger.py", line 52, in recv_submitBatches
    (fname, mtype, rseqid) = iprot.readMessageBegin()
  File "/.../lib/python3.7/site-packages/thrift/protocol/TBinaryProtocol.py", line 148, in readMessageBegin
    name = self.trans.readAll(sz)
  File "/.../lib/python3.7/site-packages/thrift/transport/TTransport.py", line 68, in readAll
    raise EOFError()
EOFError
ERROR:opencensus.ext.jaeger.trace_exporter:Failed to emit batch - 'NoneType' object has no attribute 'makefile'
Traceback (most recent call last):
  File "/.../lib/python3.7/site-packages/opencensus/ext/jaeger/trace_exporter/__init__.py", line 373, in emit
    self.client.submitBatches([batch])
  File "/.../lib/python3.7/site-packages/opencensus/ext/jaeger/trace_exporter/gen/jaeger/jaeger.py", line 38, in submitBatches
    self.send_submitBatches(batches)
  File "/.../lib/python3.7/site-packages/opencensus/ext/jaeger/trace_exporter/gen/jaeger/jaeger.py", line 48, in send_submitBatches
    self._oprot.trans.flush()
  File "/.../lib/python3.7/site-packages/thrift/transport/THttpClient.py", line 184, in flush
    self.__http_response = self.__http.getresponse()
  File "/usr/lib/python3.7/http/client.py", line 1340, in getresponse
    response = self.response_class(self.sock, method=self._method)
  File "/usr/lib/python3.7/http/client.py", line 244, in __init__
    self.fp = sock.makefile("rb")
AttributeError: 'NoneType' object has no attribute 'makefile'
ERROR:opencensus.ext.jaeger.trace_exporter:Failed to emit batch -
Traceback (most recent call last):
  File "/.../lib/python3.7/site-packages/opencensus/ext/jaeger/trace_exporter/__init__.py", line 373, in emit
    self.client.submitBatches([batch])
  File "/.../lib/python3.7/site-packages/opencensus/ext/jaeger/trace_exporter/gen/jaeger/jaeger.py", line 39, in submitBatches
    return self.recv_submitBatches()
  File "/.../lib/python3.7/site-packages/opencensus/ext/jaeger/trace_exporter/gen/jaeger/jaeger.py", line 52, in recv_submitBatches
    (fname, mtype, rseqid) = iprot.readMessageBegin()
  File "/.../lib/python3.7/site-packages/thrift/protocol/TBinaryProtocol.py", line 148, in readMessageBegin
    name = self.trans.readAll(sz)
  File "/.../lib/python3.7/site-packages/thrift/transport/TTransport.py", line 68, in readAll
    raise EOFError()
EOFError
ERROR:opencensus.ext.jaeger.trace_exporter:Failed to emit batch -
Traceback (most recent call last):
  File "/.../lib/python3.7/site-packages/opencensus/ext/jaeger/trace_exporter/__init__.py", line 373, in emit
    self.client.submitBatches([batch])
  File "/.../lib/python3.7/site-packages/opencensus/ext/jaeger/trace_exporter/gen/jaeger/jaeger.py", line 39, in submitBatches
    return self.recv_submitBatches()
  File "/.../lib/python3.7/site-packages/opencensus/ext/jaeger/trace_exporter/gen/jaeger/jaeger.py", line 52, in recv_submitBatches
    (fname, mtype, rseqid) = iprot.readMessageBegin()
  File "/.../lib/python3.7/site-packages/thrift/protocol/TBinaryProtocol.py", line 148, in readMessageBegin
    name = self.trans.readAll(sz)
  File "/.../lib/python3.7/site-packages/thrift/transport/TTransport.py", line 68, in readAll
    raise EOFError()
EOFError
ERROR:opencensus.ext.jaeger.trace_exporter:Failed to emit batch -
Traceback (most recent call last):
  File "/.../lib/python3.7/site-packages/opencensus/ext/jaeger/trace_exporter/__init__.py", line 373, in emit
    self.client.submitBatches([batch])
  File "/.../lib/python3.7/site-packages/opencensus/ext/jaeger/trace_exporter/gen/jaeger/jaeger.py", line 39, in submitBatches
    return self.recv_submitBatches()
  File "/.../lib/python3.7/site-packages/opencensus/ext/jaeger/trace_exporter/gen/jaeger/jaeger.py", line 52, in recv_submitBatches
    (fname, mtype, rseqid) = iprot.readMessageBegin()
  File "/.../lib/python3.7/site-packages/thrift/protocol/TBinaryProtocol.py", line 148, in readMessageBegin
    name = self.trans.readAll(sz)
  File "/.../lib/python3.7/site-packages/thrift/transport/TTransport.py", line 68, in readAll
    raise EOFError()
EOFError
ERROR:opencensus.ext.jaeger.trace_exporter:Failed to emit batch -
Traceback (most recent call last):
  File "/.../lib/python3.7/site-packages/opencensus/ext/jaeger/trace_exporter/__init__.py", line 373, in emit
    self.client.submitBatches([batch])
  File "/.../lib/python3.7/site-packages/opencensus/ext/jaeger/trace_exporter/gen/jaeger/jaeger.py", line 39, in submitBatches
    return self.recv_submitBatches()
  File "/.../lib/python3.7/site-packages/opencensus/ext/jaeger/trace_exporter/gen/jaeger/jaeger.py", line 52, in recv_submitBatches
    (fname, mtype, rseqid) = iprot.readMessageBegin()
  File "/.../lib/python3.7/site-packages/thrift/protocol/TBinaryProtocol.py", line 148, in readMessageBegin
    name = self.trans.readAll(sz)
  File "/.../lib/python3.7/site-packages/thrift/transport/TTransport.py", line 68, in readAll
    raise EOFError()
EOFError
ERROR:opencensus.ext.jaeger.trace_exporter:Failed to emit batch -
Traceback (most recent call last):
  File "/.../lib/python3.7/site-packages/opencensus/ext/jaeger/trace_exporter/__init__.py", line 373, in emit
    self.client.submitBatches([batch])
  File "/.../lib/python3.7/site-packages/opencensus/ext/jaeger/trace_exporter/gen/jaeger/jaeger.py", line 39, in submitBatches
    return self.recv_submitBatches()
  File "/.../lib/python3.7/site-packages/opencensus/ext/jaeger/trace_exporter/gen/jaeger/jaeger.py", line 52, in recv_submitBatches
    (fname, mtype, rseqid) = iprot.readMessageBegin()
  File "/.../lib/python3.7/site-packages/thrift/protocol/TBinaryProtocol.py", line 148, in readMessageBegin
    name = self.trans.readAll(sz)
  File "/.../lib/python3.7/site-packages/thrift/transport/TTransport.py", line 68, in readAll
    raise EOFError()
EOFError
</code>
</pre>
</details>

