### PR TITLE
Implement TelemetryProcessors for Azure exporters

### DIFF
--- a/contrib/opencensus-ext-azure/README.rst
+++ b/contrib/opencensus-ext-azure/README.rst
@@ -89,7 +89,7 @@ WARNING: For this feature to work, you need to pass a dictionary to the custom_d
     properties = {'custom_dimensions': {'key_1': 'value_1', 'key_2': 'value_2'}}
     logger.warning('action', extra=properties)
 
-You can pass a callback function to the exporter to process telemetry before it is exported. Your callback function must
+You can pass a callback function to the exporter to process telemetry before it is exported. Your callback function can return `False` if you do not want this envelope exported. Your callback function must
 accept an [envelope](https://github.com/census-instrumentation/opencensus-python/blob/master/contrib/opencensus-ext-azure/opencensus/ext/azure/common/protocol.py#L86)
 data type as its parameter. You can see the schema for Azure Monitor data types in the envelopes [here](https://github.com/census-instrumentation/opencensus-python/blob/master/contrib/opencensus-ext-azure/opencensus/ext/azure/common/protocol.py).
 The `AzureLogHandler` handles `ExceptionData` and `MessageData` data types.
@@ -105,6 +105,7 @@ The `AzureLogHandler` handles `ExceptionData` and `MessageData` data types.
     # Callback function to append '_hello' to each log message telemetry
     def callback_function(envelope):
         envelope.data.baseData.message += '_hello'
+        return True
 
     handler = AzureLogHandler(connection_string='InstrumentationKey=<your-instrumentation_key-here>')
     handler.add_telemetry_processor(callback_function)
@@ -202,7 +203,7 @@ Below is a list of standard metrics that are currently available:
 - Process CPU Usage (percentage)
 - Process Private Bytes (bytes)
 
-You can pass a callback function to the exporter to process telemetry before it is exported. Your callback function must
+You can pass a callback function to the exporter to process telemetry before it is exported. Your callback function can return `False` if you do not want this envelope exported. Your callback function must
 accept an [envelope](https://github.com/census-instrumentation/opencensus-python/blob/master/contrib/opencensus-ext-azure/opencensus/ext/azure/common/protocol.py#L86)
 data type as its parameter. You can see the schema for Azure Monitor data types in the envelopes [here](https://github.com/census-instrumentation/opencensus-python/blob/master/contrib/opencensus-ext-azure/opencensus/ext/azure/common/protocol.py).
 The `MetricsExporter` handles `MetricData` data types.
@@ -231,9 +232,9 @@ The `MetricsExporter` handles `MetricData` data types.
                                     CARROTS_MEASURE,
                                     aggregation_module.CountAggregation())
 
-    # Callback function to add 100 to the value of each metric telemetry
+    # Callback function to only export the metric if value is greater than 0
     def callback_function(envelope):
-        envelope.data.baseData.metrics[0].value += 100
+        return envelope.data.baseData.metrics[0].value > 0
 
     def main():
         # Enable metrics
@@ -314,10 +315,10 @@ This example shows how to integrate with the `requests <https://2.python-request
     with tracer.span(name='parent'):
         response = requests.get(url='https://www.wikipedia.org/wiki/Rabbit')
 
-You can pass a callback function to the exporter to process telemetry before it is exported. Your callback function must
+You can pass a callback function to the exporter to process telemetry before it is exported. Your callback function can return `False` if you do not want this envelope exported. Your callback function must
 accept an [envelope](https://github.com/census-instrumentation/opencensus-python/blob/master/contrib/opencensus-ext-azure/opencensus/ext/azure/common/protocol.py#L86)
 data type as its parameter. You can see the schema for Azure Monitor data types in the envelopes [here](https://github.com/census-instrumentation/opencensus-python/blob/master/contrib/opencensus-ext-azure/opencensus/ext/azure/common/protocol.py).
-The `MetricsExporter` handles `MetricData` data types.
+The `AzureExporter` handles `Data` data types.
 
 .. code:: python
 
@@ -333,6 +334,7 @@ The `MetricsExporter` handles `MetricData` data types.
     # Callback function to add os_type: linux to span properties
     def callback_function(envelope):
         envelope.data.baseData.properties['os_type'] = 'linux'
+        return True
 
     exporter = AzureExporter(
         connection_string='InstrumentationKey=<your-instrumentation-key-here>'

--- a/contrib/opencensus-ext-azure/README.rst
+++ b/contrib/opencensus-ext-azure/README.rst
@@ -37,6 +37,8 @@ This example shows how to send a warning level log to Azure Monitor.
     logger.addHandler(AzureLogHandler(connection_string='InstrumentationKey=<your-instrumentation_key-here>'))
     logger.warning('Hello, World!')
 
+Correlation
+###########
 
 You can enrich the logs with trace IDs and span IDs by using the `logging integration <../opencensus-ext-logging>`_.
 
@@ -73,6 +75,9 @@ You can enrich the logs with trace IDs and span IDs by using the `logging integr
         logger.warning('In the span')
     logger.warning('After the span')
 
+Custom Properties
+#################
+
 You can also add custom properties to your log messages in the *extra* keyword argument using the custom_dimensions field.
 
 WARNING: For this feature to work, you need to pass a dictionary to the custom_dimensions field. If you pass arguments of any other type, the logger will ignore them.
@@ -88,6 +93,9 @@ WARNING: For this feature to work, you need to pass a dictionary to the custom_d
 
     properties = {'custom_dimensions': {'key_1': 'value_1', 'key_2': 'value_2'}}
     logger.warning('action', extra=properties)
+
+Modifying Logs
+##############
 
 * You can pass a callback function to the exporter to process telemetry before it is exported.
 * Your callback function can return `False` if you do not want this envelope exported.
@@ -170,6 +178,9 @@ The **Azure Monitor Metrics Exporter** allows you to export metrics to `Azure Mo
     if __name__ == "__main__":
         main()
 
+Standard Metrics
+################
+
 The exporter also includes a set of standard metrics that are exported to Azure Monitor by default.
 
 .. code:: python
@@ -204,6 +215,8 @@ Below is a list of standard metrics that are currently available:
 - Process CPU Usage (percentage)
 - Process Private Bytes (bytes)
 
+Modifying Metrics
+#################
 
 * You can pass a callback function to the exporter to process telemetry before it is exported.
 * Your callback function can return `False` if you do not want this envelope exported.
@@ -290,6 +303,9 @@ This example shows how to send a span "hello" to Azure Monitor.
     with tracer.span(name='hello'):
         print('Hello, World!')
 
+Integrations
+############
+
 OpenCensus also supports several `integrations <https://github.com/census-instrumentation/opencensus-python#integration>`_ which allows OpenCensus to integrate with third party libraries.
 
 This example shows how to integrate with the `requests <https://2.python-requests.org/en/master/>`_ library.
@@ -318,6 +334,8 @@ This example shows how to integrate with the `requests <https://2.python-request
     with tracer.span(name='parent'):
         response = requests.get(url='https://www.wikipedia.org/wiki/Rabbit')
 
+Modifying Traces
+################
 
 * You can pass a callback function to the exporter to process telemetry before it is exported.
 * Your callback function can return `False` if you do not want this envelope exported.

--- a/contrib/opencensus-ext-azure/README.rst
+++ b/contrib/opencensus-ext-azure/README.rst
@@ -89,6 +89,28 @@ WARNING: For this feature to work, you need to pass a dictionary to the custom_d
     properties = {'custom_dimensions': {'key_1': 'value_1', 'key_2': 'value_2'}}
     logger.warning('action', extra=properties)
 
+You can pass a callback function to the exporter to process telemetry before it is exported. Your callback function must
+accept an [envelope](https://github.com/microsoft/ApplicationInsights-Home/blob/master/EndpointSpecs/Schemas/Bond/Envelope.bond)
+data type as its parameter. You can see the schema for Azure Monitor data types in the envelopes [here](https://github.com/microsoft/ApplicationInsights-Home/tree/master/EndpointSpecs/Schemas/Bond).
+
+.. code:: python
+
+    import logging
+
+    from opencensus.ext.azure.log_exporter import AzureLogHandler
+
+    logger = logging.getLogger(__name__)
+
+    # Callback function to append '_hello' to each log message telemetry
+    def call_back_function(envelope):
+        envelope.data.baseData.message += '_hello'
+
+    handler = AzureLogHandler(connection_string='InstrumentationKey=<your-instrumentation_key-here>')
+    handler.add_telemetry_processor(call_back_function)
+    logger.addHandler(handler)
+    logger.warning('Hello, World!')
+
+
 Metrics
 ~~~~~~~
 

--- a/contrib/opencensus-ext-azure/README.rst
+++ b/contrib/opencensus-ext-azure/README.rst
@@ -90,8 +90,8 @@ WARNING: For this feature to work, you need to pass a dictionary to the custom_d
     logger.warning('action', extra=properties)
 
 You can pass a callback function to the exporter to process telemetry before it is exported. Your callback function must
-accept an [envelope](https://github.com/microsoft/ApplicationInsights-Home/blob/master/EndpointSpecs/Schemas/Bond/Envelope.bond)
-data type as its parameter. You can see the schema for Azure Monitor data types in the envelopes [here](https://github.com/microsoft/ApplicationInsights-Home/tree/master/EndpointSpecs/Schemas/Bond).
+accept an [envelope](https://github.com/census-instrumentation/opencensus-python/blob/master/contrib/opencensus-ext-azure/opencensus/ext/azure/common/protocol.py#L86)
+data type as its parameter. You can see the schema for Azure Monitor data types in the envelopes [here](https://github.com/census-instrumentation/opencensus-python/blob/master/contrib/opencensus-ext-azure/opencensus/ext/azure/common/protocol.py).
 The `AzureLogHandler` handles `ExceptionData` and `MessageData` data types.
 
 .. code:: python
@@ -103,11 +103,11 @@ The `AzureLogHandler` handles `ExceptionData` and `MessageData` data types.
     logger = logging.getLogger(__name__)
 
     # Callback function to append '_hello' to each log message telemetry
-    def call_back_function(envelope):
+    def callback_function(envelope):
         envelope.data.baseData.message += '_hello'
 
     handler = AzureLogHandler(connection_string='InstrumentationKey=<your-instrumentation_key-here>')
-    handler.add_telemetry_processor(call_back_function)
+    handler.add_telemetry_processor(callback_function)
     logger.addHandler(handler)
     logger.warning('Hello, World!')
 
@@ -203,8 +203,8 @@ Below is a list of standard metrics that are currently available:
 - Process Private Bytes (bytes)
 
 You can pass a callback function to the exporter to process telemetry before it is exported. Your callback function must
-accept an [envelope](https://github.com/microsoft/ApplicationInsights-Home/blob/master/EndpointSpecs/Schemas/Bond/Envelope.bond)
-data type as its parameter. You can see the schema for Azure Monitor data types in the envelopes [here](https://github.com/microsoft/ApplicationInsights-Home/tree/master/EndpointSpecs/Schemas/Bond).
+accept an [envelope](https://github.com/census-instrumentation/opencensus-python/blob/master/contrib/opencensus-ext-azure/opencensus/ext/azure/common/protocol.py#L86)
+data type as its parameter. You can see the schema for Azure Monitor data types in the envelopes [here](https://github.com/census-instrumentation/opencensus-python/blob/master/contrib/opencensus-ext-azure/opencensus/ext/azure/common/protocol.py).
 The `MetricsExporter` handles `MetricData` data types.
 
 .. code:: python
@@ -232,14 +232,14 @@ The `MetricsExporter` handles `MetricData` data types.
                                     aggregation_module.CountAggregation())
 
     # Callback function to add 100 to the value of each metric telemetry
-    def call_back_function(envelope):
+    def callback_function(envelope):
         envelope.data.baseData.metrics[0].value += 100
 
     def main():
         # Enable metrics
         # Set the interval in seconds in which you want to send metrics
         exporter = metrics_exporter.new_metrics_exporter(connection_string='InstrumentationKey=<your-instrumentation-key-here>')
-        exporter.add_telemetry_processor(call_back_function)
+        exporter.add_telemetry_processor(callback_function)
         view_manager.register_exporter(exporter)
 
         view_manager.register_view(CARROTS_VIEW)
@@ -315,8 +315,8 @@ This example shows how to integrate with the `requests <https://2.python-request
         response = requests.get(url='https://www.wikipedia.org/wiki/Rabbit')
 
 You can pass a callback function to the exporter to process telemetry before it is exported. Your callback function must
-accept an [envelope](https://github.com/microsoft/ApplicationInsights-Home/blob/master/EndpointSpecs/Schemas/Bond/Envelope.bond)
-data type as its parameter. You can see the schema for Azure Monitor data types in the envelopes [here](https://github.com/microsoft/ApplicationInsights-Home/tree/master/EndpointSpecs/Schemas/Bond).
+accept an [envelope](https://github.com/census-instrumentation/opencensus-python/blob/master/contrib/opencensus-ext-azure/opencensus/ext/azure/common/protocol.py#L86)
+data type as its parameter. You can see the schema for Azure Monitor data types in the envelopes [here](https://github.com/census-instrumentation/opencensus-python/blob/master/contrib/opencensus-ext-azure/opencensus/ext/azure/common/protocol.py).
 The `MetricsExporter` handles `MetricData` data types.
 
 .. code:: python
@@ -331,13 +331,13 @@ The `MetricsExporter` handles `MetricData` data types.
     config_integration.trace_integrations(['requests'])
 
     # Callback function to add os_type: linux to span properties
-    def call_back_function(envelope):
+    def callback_function(envelope):
         envelope.data.baseData.properties['os_type'] = 'linux'
 
     exporter = AzureExporter(
         connection_string='InstrumentationKey=<your-instrumentation-key-here>'
     )
-    exporter.add_telemetry_processor(call_back_function)
+    exporter.add_telemetry_processor(callback_function)
     tracer = Tracer(exporter=exporter, sampler=ProbabilitySampler(1.0))
     with tracer.span(name='parent'):
         response = requests.get(url='https://www.wikipedia.org/wiki/Rabbit')

--- a/contrib/opencensus-ext-azure/README.rst
+++ b/contrib/opencensus-ext-azure/README.rst
@@ -89,10 +89,11 @@ WARNING: For this feature to work, you need to pass a dictionary to the custom_d
     properties = {'custom_dimensions': {'key_1': 'value_1', 'key_2': 'value_2'}}
     logger.warning('action', extra=properties)
 
-You can pass a callback function to the exporter to process telemetry before it is exported. Your callback function can return `False` if you do not want this envelope exported. Your callback function must
-accept an [envelope](https://github.com/census-instrumentation/opencensus-python/blob/master/contrib/opencensus-ext-azure/opencensus/ext/azure/common/protocol.py#L86)
-data type as its parameter. You can see the schema for Azure Monitor data types in the envelopes [here](https://github.com/census-instrumentation/opencensus-python/blob/master/contrib/opencensus-ext-azure/opencensus/ext/azure/common/protocol.py).
-The `AzureLogHandler` handles `ExceptionData` and `MessageData` data types.
+* You can pass a callback function to the exporter to process telemetry before it is exported.
+* Your callback function can return `False` if you do not want this envelope exported.
+* Your callback function must accept an [envelope](https://github.com/census-instrumentation/opencensus-python/blob/master/contrib/opencensus-ext-azure/opencensus/ext/azure/common/protocol.py#L86) data type as its parameter.
+* You can see the schema for Azure Monitor data types in the envelopes [here](https://github.com/census-instrumentation/opencensus-python/blob/master/contrib/opencensus-ext-azure/opencensus/ext/azure/common/protocol.py).
+* The `AzureLogHandler` handles `ExceptionData` and `MessageData` data types.
 
 .. code:: python
 
@@ -203,10 +204,12 @@ Below is a list of standard metrics that are currently available:
 - Process CPU Usage (percentage)
 - Process Private Bytes (bytes)
 
-You can pass a callback function to the exporter to process telemetry before it is exported. Your callback function can return `False` if you do not want this envelope exported. Your callback function must
-accept an [envelope](https://github.com/census-instrumentation/opencensus-python/blob/master/contrib/opencensus-ext-azure/opencensus/ext/azure/common/protocol.py#L86)
-data type as its parameter. You can see the schema for Azure Monitor data types in the envelopes [here](https://github.com/census-instrumentation/opencensus-python/blob/master/contrib/opencensus-ext-azure/opencensus/ext/azure/common/protocol.py).
-The `MetricsExporter` handles `MetricData` data types.
+
+* You can pass a callback function to the exporter to process telemetry before it is exported.
+* Your callback function can return `False` if you do not want this envelope exported.
+* Your callback function must accept an [envelope](https://github.com/census-instrumentation/opencensus-python/blob/master/contrib/opencensus-ext-azure/opencensus/ext/azure/common/protocol.py#L86) data type as its parameter.
+* You can see the schema for Azure Monitor data types in the envelopes [here](https://github.com/census-instrumentation/opencensus-python/blob/master/contrib/opencensus-ext-azure/opencensus/ext/azure/common/protocol.py).
+* The `MetricsExporter` handles `MetricData` data types.
 
 .. code:: python
 
@@ -315,10 +318,12 @@ This example shows how to integrate with the `requests <https://2.python-request
     with tracer.span(name='parent'):
         response = requests.get(url='https://www.wikipedia.org/wiki/Rabbit')
 
-You can pass a callback function to the exporter to process telemetry before it is exported. Your callback function can return `False` if you do not want this envelope exported. Your callback function must
-accept an [envelope](https://github.com/census-instrumentation/opencensus-python/blob/master/contrib/opencensus-ext-azure/opencensus/ext/azure/common/protocol.py#L86)
-data type as its parameter. You can see the schema for Azure Monitor data types in the envelopes [here](https://github.com/census-instrumentation/opencensus-python/blob/master/contrib/opencensus-ext-azure/opencensus/ext/azure/common/protocol.py).
-The `AzureExporter` handles `Data` data types.
+
+* You can pass a callback function to the exporter to process telemetry before it is exported.
+* Your callback function can return `False` if you do not want this envelope exported.
+* Your callback function must accept an [envelope](https://github.com/census-instrumentation/opencensus-python/blob/master/contrib/opencensus-ext-azure/opencensus/ext/azure/common/protocol.py#L86) data type as its parameter.
+* You can see the schema for Azure Monitor data types in the envelopes [here](https://github.com/census-instrumentation/opencensus-python/blob/master/contrib/opencensus-ext-azure/opencensus/ext/azure/common/protocol.py).
+* The `AzureExporter` handles `Data` data types.
 
 .. code:: python
 

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/processor.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/processor.py
@@ -17,7 +17,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class ProcessorMixin:
+class ProcessorMixin(object):
     """ProcessorMixin adds the ability to process telemetry processors
 
     Telemetry processors are functions that are called before exporting of

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/processor.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/processor.py
@@ -55,6 +55,7 @@ class ProcessorMixin(object):
                 try:
                     if processor(envelope) is False:
                         accepted = False
+                        break
                 except Exception as ex:
                     logger.warning('Telemetry processor failed with: %s.', ex)
             if accepted:

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/processor.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/processor.py
@@ -1,0 +1,53 @@
+# Copyright 2019, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class ProcessorMixin:
+    """ProcessorMixin adds the ability to process telemetry processors
+
+    Telemetry processors are functions that are called before exporting of
+    telemetry to possibly modify the envelope contents.
+    """
+
+    def add_telemetry_processor(self, processor):
+        """Adds telemetry processor to the collection. Telemetry processors
+        will be called one by one before telemetry item is pushed for sending
+        and in the order they were added.
+
+        :param processor: The processor to add.
+        """
+        self._telemetry_processors.append(processor)
+
+    def clear_telemetry_processors(self):
+        """Removes all telemetry processors"""
+        self._telemetryProcessors = []
+
+    def apply_telemetry_processors(self, envelopes):
+        """Applies all telemetry processors in the order they were added.
+
+        Individual processors can throw exceptions and fail, but the applying
+        of all telemetry processors will proceed (not fast fail).
+
+        :param envelopes: The envelopes to apply each processor to.
+        """
+        for processor in self._telemetry_processors:
+            for envelope in envelopes:
+                try:
+                    processor(envelope)
+                except Exception as ex:
+                    logger.warning('Telemetry processor failed with: %s.', ex)

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/processor.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/processor.py
@@ -35,7 +35,7 @@ class ProcessorMixin(object):
 
     def clear_telemetry_processors(self):
         """Removes all telemetry processors"""
-        self._telemetryProcessors = []
+        self._telemetry_processors = []
 
     def apply_telemetry_processors(self, envelopes):
         """Applies all telemetry processors in the order they were added.

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/processor.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/processor.py
@@ -57,6 +57,6 @@ class ProcessorMixin(object):
                         accepted = False
                 except Exception as ex:
                     logger.warning('Telemetry processor failed with: %s.', ex)
-                if accepted:
-                    filtered_envelopes.append(envelope)
+            if accepted:
+                filtered_envelopes.append(envelope)
         return filtered_envelopes

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/log_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/log_exporter/__init__.py
@@ -136,7 +136,7 @@ class AzureLogHandler(TransportMixin, ProcessorMixin, BaseLogHandler):
         try:
             if batch:
                 envelopes = [self.log_record_to_envelope(x) for x in batch]
-                self.apply_telemetry_processors(envelopes)
+                envelopes = self.apply_telemetry_processors(envelopes)
                 result = self._transmit(envelopes)
                 if result > 0:
                     self.storage.put(envelopes, result)

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/__init__.py
@@ -19,6 +19,7 @@ import requests
 
 from opencensus.common import utils as common_utils
 from opencensus.ext.azure.common import Options, utils
+from opencensus.ext.azure.common.processor import ProcessorMixin
 from opencensus.ext.azure.common.protocol import (
     Data,
     DataPoint,
@@ -35,7 +36,7 @@ __all__ = ['MetricsExporter', 'new_metrics_exporter']
 logger = logging.getLogger(__name__)
 
 
-class MetricsExporter(object):
+class MetricsExporter(ProcessorMixin):
     """Metrics exporter for Microsoft Azure Monitor."""
 
     def __init__(self, options=None):
@@ -46,6 +47,8 @@ class MetricsExporter(object):
         if self.options.max_batch_size <= 0:
             raise ValueError('Max batch size must be at least 1.')
         self.max_batch_size = self.options.max_batch_size
+        self._telemetry_processors = []
+        super(MetricsExporter, self).__init__()
 
     def export_metrics(self, metrics):
         if metrics:
@@ -75,6 +78,7 @@ class MetricsExporter(object):
                 batched_envelopes = list(common_utils.window(
                     envelopes, self.max_batch_size))
                 for batch in batched_envelopes:
+                    self.apply_telemetry_processors(batch)
                     self._transmit_without_retry(batch)
 
     def create_data_points(self, time_series, metric_descriptor):

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/__init__.py
@@ -78,7 +78,7 @@ class MetricsExporter(ProcessorMixin):
                 batched_envelopes = list(common_utils.window(
                     envelopes, self.max_batch_size))
                 for batch in batched_envelopes:
-                    self.apply_telemetry_processors(batch)
+                    batch = self.apply_telemetry_processors(batch)
                     self._transmit_without_retry(batch)
 
     def create_data_points(self, time_series, metric_descriptor):

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/trace_exporter/__init__.py
@@ -129,7 +129,7 @@ class AzureExporter(BaseExporter, ProcessorMixin, TransportMixin):
         try:
             if batch:
                 envelopes = [self.span_data_to_envelope(sd) for sd in batch]
-                self.apply_telemetry_processors(envelopes)
+                envelopes = self.apply_telemetry_processors(envelopes)
                 result = self._transmit(envelopes)
                 if result > 0:
                     self.storage.put(envelopes, result)

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/trace_exporter/__init__.py
@@ -17,6 +17,7 @@ import logging
 from opencensus.common.schedule import QueueExitEvent
 from opencensus.ext.azure.common import Options, utils
 from opencensus.ext.azure.common.exporter import BaseExporter
+from opencensus.ext.azure.common.processor import ProcessorMixin
 from opencensus.ext.azure.common.protocol import (
     Data,
     Envelope,
@@ -32,7 +33,7 @@ logger = logging.getLogger(__name__)
 __all__ = ['AzureExporter']
 
 
-class AzureExporter(TransportMixin, BaseExporter):
+class AzureExporter(BaseExporter, ProcessorMixin, TransportMixin):
     """An exporter that sends traces to Microsoft Azure Monitor.
 
     :param options: Options for the exporter.
@@ -127,6 +128,7 @@ class AzureExporter(TransportMixin, BaseExporter):
         try:
             if batch:
                 envelopes = [self.span_data_to_envelope(sd) for sd in batch]
+                self.apply_telemetry_processors(envelopes)
                 result = self._transmit(envelopes)
                 if result > 0:
                     self.storage.put(envelopes, result)

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/trace_exporter/__init__.py
@@ -48,6 +48,7 @@ class AzureExporter(BaseExporter, ProcessorMixin, TransportMixin):
             maintenance_period=self.options.storage_maintenance_period,
             retention_period=self.options.storage_retention_period,
         )
+        self._telemetry_processors = []
         super(AzureExporter, self).__init__(**options)
 
     def span_data_to_envelope(self, sd):

--- a/contrib/opencensus-ext-azure/tests/test_processor.py
+++ b/contrib/opencensus-ext-azure/tests/test_processor.py
@@ -16,6 +16,7 @@ import unittest
 
 from opencensus.ext.azure.common.processor import ProcessorMixin
 
+
 # pylint: disable=W0212
 class TestProcessorMixin(unittest.TestCase):
     def test_add(self):

--- a/contrib/opencensus-ext-azure/tests/test_processor.py
+++ b/contrib/opencensus-ext-azure/tests/test_processor.py
@@ -36,6 +36,7 @@ class TestProcessorMixin(unittest.TestCase):
     def test_apply(self):
         mixin = ProcessorMixin()
         mixin._telemetry_processors = []
+
         def call_back_function(envelope):
             envelope.append('hello')
         mixin.add_telemetry_processor(call_back_function)
@@ -49,8 +50,10 @@ class TestProcessorMixin(unittest.TestCase):
     def test_apply_multiple(self):
         mixin = ProcessorMixin()
         mixin._telemetry_processors = []
+
         def call_back_function(envelope):
             envelope.append('hello')
+
         def call_back_function2(envelope):
             envelope.append('hello2')
         mixin.add_telemetry_processor(call_back_function)
@@ -65,8 +68,10 @@ class TestProcessorMixin(unittest.TestCase):
     def test_apply_exception(self):
         mixin = ProcessorMixin()
         mixin._telemetry_processors = []
+
         def call_back_function(envelope):
             raise ValueError()
+
         def call_back_function2(envelope):
             envelope.append('hello2')
         mixin.add_telemetry_processor(call_back_function)

--- a/contrib/opencensus-ext-azure/tests/test_processor.py
+++ b/contrib/opencensus-ext-azure/tests/test_processor.py
@@ -52,18 +52,18 @@ class TestProcessorMixin(unittest.TestCase):
         mixin._telemetry_processors = []
 
         def call_back_function(envelope):
-            envelope.append('hello')
+            envelope.append('_hello')
 
         def call_back_function2(envelope):
-            envelope.append('hello2')
+            envelope.append('_hello2')
         mixin.add_telemetry_processor(call_back_function)
         mixin.add_telemetry_processor(call_back_function2)
         envelope = ['add']
         mixin.apply_telemetry_processors([envelope])
         self.assertEqual(len(envelope), 3)
         self.assertEqual(envelope[0], 'add')
-        self.assertEqual(envelope[1], 'hello')
-        self.assertEqual(envelope[2], 'hello2')
+        self.assertEqual(envelope[1], '_hello')
+        self.assertEqual(envelope[2], '_hello2')
 
     def test_apply_exception(self):
         mixin = ProcessorMixin()
@@ -81,3 +81,14 @@ class TestProcessorMixin(unittest.TestCase):
         self.assertEqual(len(envelope), 2)
         self.assertEqual(envelope[0], 'add')
         self.assertEqual(envelope[1], 'hello2')
+
+    def test_apply_not_accepted(self):
+        mixin = ProcessorMixin()
+        mixin._telemetry_processors = []
+
+        def call_back_function(envelope):
+            return len(envelope) < 4
+        mixin.add_telemetry_processor(call_back_function)
+        envelopes = mixin.apply_telemetry_processors(['add', 'subtract'])
+        self.assertEqual(len(envelopes), 1)
+        self.assertEqual(envelopes[0], 'add')

--- a/contrib/opencensus-ext-azure/tests/test_processor.py
+++ b/contrib/opencensus-ext-azure/tests/test_processor.py
@@ -76,14 +76,14 @@ class TestProcessorMixin(unittest.TestCase):
         envelope = Envelope()
         envelope.baseType = 'type1'
         mixin.apply_telemetry_processors([envelope])
-        self.assertEqual(envelope[0], 'type1_world2')
+        self.assertEqual(envelope.baseType, 'type1_world2')
 
     def test_apply_not_accepted(self):
         mixin = ProcessorMixin()
         mixin._telemetry_processors = []
 
         def callback_function(envelope):
-            return len(envelope) < 4
+            return envelope.baseType == 'type2'
         mixin.add_telemetry_processor(callback_function)
         envelope = Envelope()
         envelope.baseType = 'type1'

--- a/contrib/opencensus-ext-azure/tests/test_processor.py
+++ b/contrib/opencensus-ext-azure/tests/test_processor.py
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import unittest
 
 from opencensus.ext.azure.common.processor import ProcessorMixin
 
-import mock
-
-
+# pylint: disable=W0212
 class TestProcessorMixin(unittest.TestCase):
     def test_add(self):
         mixin = ProcessorMixin()
@@ -78,4 +75,3 @@ class TestProcessorMixin(unittest.TestCase):
         self.assertEqual(len(envelope), 2)
         self.assertEqual(envelope[0], 'add')
         self.assertEqual(envelope[1], 'hello2')
-

--- a/contrib/opencensus-ext-azure/tests/test_processor.py
+++ b/contrib/opencensus-ext-azure/tests/test_processor.py
@@ -1,0 +1,81 @@
+# Copyright 2019, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+
+from opencensus.ext.azure.common.processor import ProcessorMixin
+
+import mock
+
+
+class TestProcessorMixin(unittest.TestCase):
+    def test_add(self):
+        mixin = ProcessorMixin()
+        mixin._telemetry_processors = []
+        mixin.add_telemetry_processor(lambda: True)
+        self.assertEqual(len(mixin._telemetry_processors), 1)
+
+    def test_clear(self):
+        mixin = ProcessorMixin()
+        mixin._telemetry_processors = []
+        mixin.add_telemetry_processor(lambda: True)
+        self.assertEqual(len(mixin._telemetry_processors), 1)
+        mixin.clear_telemetry_processors()
+        self.assertEqual(len(mixin._telemetry_processors), 0)
+
+    def test_apply(self):
+        mixin = ProcessorMixin()
+        mixin._telemetry_processors = []
+        def call_back_function(envelope):
+            envelope.append('hello')
+        mixin.add_telemetry_processor(call_back_function)
+        envelope = ['add', 'sub']
+        mixin.apply_telemetry_processors([envelope])
+        self.assertEqual(len(envelope), 3)
+        self.assertEqual(envelope[0], 'add')
+        self.assertEqual(envelope[1], 'sub')
+        self.assertEqual(envelope[2], 'hello')
+
+    def test_apply_multiple(self):
+        mixin = ProcessorMixin()
+        mixin._telemetry_processors = []
+        def call_back_function(envelope):
+            envelope.append('hello')
+        def call_back_function2(envelope):
+            envelope.append('hello2')
+        mixin.add_telemetry_processor(call_back_function)
+        mixin.add_telemetry_processor(call_back_function2)
+        envelope = ['add']
+        mixin.apply_telemetry_processors([envelope])
+        self.assertEqual(len(envelope), 3)
+        self.assertEqual(envelope[0], 'add')
+        self.assertEqual(envelope[1], 'hello')
+        self.assertEqual(envelope[2], 'hello2')
+
+    def test_apply_exception(self):
+        mixin = ProcessorMixin()
+        mixin._telemetry_processors = []
+        def call_back_function(envelope):
+            raise ValueError()
+        def call_back_function2(envelope):
+            envelope.append('hello2')
+        mixin.add_telemetry_processor(call_back_function)
+        mixin.add_telemetry_processor(call_back_function2)
+        envelope = ['add']
+        mixin.apply_telemetry_processors([envelope])
+        self.assertEqual(len(envelope), 2)
+        self.assertEqual(envelope[0], 'add')
+        self.assertEqual(envelope[1], 'hello2')
+


### PR DESCRIPTION
Implement TelemetryProcessors for Azure Exporters.

TelemetryProcessors allow users to define a callback function to modify the envelopes before they are sent to the Azure Monitor backend. They can also be used to omit envelopes from being exported. Refer to the `README` on how users can do this and what the schema for the payloads look like.

See [this article](https://docs.microsoft.com/en-us/azure/azure-monitor/app/api-filtering-sampling#javascript-web-applications) on how other SDKs are doing this in other languages for Azure Monitor.