### PR TITLE
Implement max size logic for local storage for Azure exporters

### DIFF
--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
@@ -97,7 +97,7 @@ class Options(BaseObject):
         minimum_retry_interval=60,  # minimum retry interval in seconds
         proxy=None,
         storage_maintenance_period=60,
-        storage_max_size=100*1024*1024,  # 100MiB
+        storage_max_size=50*1024*1024,  # 50MiB
         storage_path=os.path.join(
             os.path.expanduser('~'),
             '.opencensus',

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
@@ -97,7 +97,7 @@ class Options(BaseObject):
         minimum_retry_interval=60,  # minimum retry interval in seconds
         proxy=None,
         storage_maintenance_period=60,
-        storage_max_size=100*1024*1024,
+        storage_max_size=100*1024*1024,  # 100MiB
         storage_path=os.path.join(
             os.path.expanduser('~'),
             '.opencensus',

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
@@ -1,9 +1,12 @@
 import datetime
 import json
+import logging
 import os
 import random
 
 from opencensus.common.schedule import PeriodicTask
+
+logger = logging.getLogger(__name__)
 
 
 def _fmt(timestamp):
@@ -77,7 +80,7 @@ class LocalFileStorage(object):
     def __init__(
             self,
             path,
-            max_size=100*1024*1024,  # 100MB
+            max_size=100*1024*1024,  # 100MiB
             maintenance_period=60,  # 1 minute
             retention_period=7*24*60*60,  # 7 days
             write_timeout=60,  # 1 minute
@@ -162,6 +165,8 @@ class LocalFileStorage(object):
         return None
 
     def put(self, data, lease_period=0, silent=False):
+        if not self._check_storage_size():
+            return None
         blob = LocalFileBlob(os.path.join(
             self.path,
             '{}-{}.blob'.format(
@@ -170,3 +175,22 @@ class LocalFileStorage(object):
             ),
         ))
         return blob.put(data, lease_period=lease_period, silent=silent)
+
+    def _check_storage_size(self):
+        size = 0
+        for dirpath, dirnames, filenames in os.walk(self.path):
+            for f in filenames:
+                fp = os.path.join(dirpath, f)
+                # skip if it is symbolic link
+                if not os.path.islink(fp):
+                    size += os.path.getsize(fp)
+                    if size >= self.max_size:
+                        logger.warning(
+                            "Persistent storage max capacity has been " \
+                            "reached. Currently at {}KB. Telemetry will be " \
+                            "lost. Please consider increasing the value of " \
+                            "'storage_max_size' in exporter config."
+                            .format(size/1024)
+                        )
+                        return False
+        return True

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
@@ -186,9 +186,9 @@ class LocalFileStorage(object):
                     size += os.path.getsize(fp)
                     if size >= self.max_size:
                         logger.warning(
-                            "Persistent storage max capacity has been " \
-                            "reached. Currently at {}KB. Telemetry will be " \
-                            "lost. Please consider increasing the value of " \
+                            "Persistent storage max capacity has been "
+                            "reached. Currently at {}KB. Telemetry will be "
+                            "lost. Please consider increasing the value of "
                             "'storage_max_size' in exporter config."
                             .format(size/1024)
                         )

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
@@ -186,8 +186,8 @@ class LocalFileStorage(object):
                     try:
                         size += os.path.getsize(fp)
                     except OSError:
-                        logger.error("Path " + fp + 
-                            " does not exist or is inaccessible.")
+                        logger.error("Path " + fp +
+                                     " does not exist or is inaccessible.")
                         continue
                     if size >= self.max_size:
                         logger.warning(

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
@@ -186,8 +186,9 @@ class LocalFileStorage(object):
                     try:
                         size += os.path.getsize(fp)
                     except OSError:
-                        logger.error("Path %s does not exist or is "
-                            "inaccessible.", fp)
+                        logger.error(
+                            "Path %s does not exist or is inaccessible.", fp
+                        )
                         continue
                     if size >= self.max_size:
                         logger.warning(

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
@@ -186,16 +186,16 @@ class LocalFileStorage(object):
                     try:
                         size += os.path.getsize(fp)
                     except OSError:
-                        logger.error("Path " + fp +
-                                     " does not exist or is inaccessible.")
+                        logger.error("Path %s does not exist or is "
+                            "inaccessible.", fp)
                         continue
                     if size >= self.max_size:
                         logger.warning(
                             "Persistent storage max capacity has been "
-                            "reached. Currently at {}KB. Telemetry will be "
+                            "reached. Currently at %fKB. Telemetry will be "
                             "lost. Please consider increasing the value of "
-                            "'storage_max_size' in exporter config."
-                            .format(size/1024)
+                            "'storage_max_size' in exporter config.",
+                            format(size/1024)
                         )
                         return False
         return True

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
@@ -80,7 +80,7 @@ class LocalFileStorage(object):
     def __init__(
             self,
             path,
-            max_size=100*1024*1024,  # 100MiB
+            max_size=50*1024*1024,  # 50MiB
             maintenance_period=60,  # 1 minute
             retention_period=7*24*60*60,  # 7 days
             write_timeout=60,  # 1 minute
@@ -183,7 +183,12 @@ class LocalFileStorage(object):
                 fp = os.path.join(dirpath, f)
                 # skip if it is symbolic link
                 if not os.path.islink(fp):
-                    size += os.path.getsize(fp)
+                    try:
+                        size += os.path.getsize(fp)
+                    except OSError:
+                        logger.error("Path " + fp + 
+                            " does not exist or is inaccessible.")
+                        continue
                     if size >= self.max_size:
                         logger.warning(
                             "Persistent storage max capacity has been "

--- a/contrib/opencensus-ext-azure/tests/test_storage.py
+++ b/contrib/opencensus-ext-azure/tests/test_storage.py
@@ -25,7 +25,7 @@ from opencensus.ext.azure.common.storage import (
     _seconds,
 )
 
-TEST_FOLDER = os.path.abspath('.test')
+TEST_FOLDER = os.path.abspath('.test.storage')
 
 
 def setUpModule():
@@ -115,6 +115,39 @@ class TestLocalFileStorage(unittest.TestCase):
             with mock.patch('os.rename', side_effect=throw(Exception)):
                 self.assertIsNone(stor.put(input, silent=True))
                 self.assertRaises(Exception, lambda: stor.put(input))
+
+    def test_put_max_size(self):
+        input = (1, 2, 3)
+        with LocalFileStorage(os.path.join(TEST_FOLDER, 'asd')) as stor:
+            size_mock = mock.Mock()
+            size_mock.return_value = False
+            stor._check_storage_size = size_mock
+            stor.put(input)
+            self.assertEqual(stor.get(), None)
+
+    def test_check_storage_size_full(self):
+        input = (1, 2, 3)
+        with LocalFileStorage(os.path.join(TEST_FOLDER, 'asd2'), 1) as stor:
+            stor.put(input)
+            self.assertFalse(stor._check_storage_size())
+
+    def test_check_storage_size_not_full(self):
+        input = (1, 2, 3)
+        with LocalFileStorage(os.path.join(TEST_FOLDER, 'asd3'), 1000) as stor:
+            stor.put(input)
+            self.assertTrue(stor._check_storage_size())
+
+    def test_check_storage_size_no_files(self):
+        with LocalFileStorage(os.path.join(TEST_FOLDER, 'asd3'), 1000) as stor:
+            self.assertTrue(stor._check_storage_size())
+
+    def test_check_storage_size_links(self):
+        input = (1, 2, 3)
+        with LocalFileStorage(os.path.join(TEST_FOLDER, 'asd4'), 1000) as stor:
+            stor.put(input)
+            with mock.patch('os.path.islink') as os_mock:
+                os_mock.return_value = True
+            self.assertTrue(stor._check_storage_size())
 
     def test_maintanence_routine(self):
         with mock.patch('os.makedirs') as m:

--- a/contrib/opencensus-ext-azure/tests/test_storage.py
+++ b/contrib/opencensus-ext-azure/tests/test_storage.py
@@ -149,6 +149,15 @@ class TestLocalFileStorage(unittest.TestCase):
                 os_mock.return_value = True
             self.assertTrue(stor._check_storage_size())
 
+    def test_check_storage_size_error(self):
+        input = (1, 2, 3)
+        with LocalFileStorage(os.path.join(TEST_FOLDER, 'asd5'), 1) as stor:
+            with mock.patch('os.path.getsize', side_effect=throw(OSError)):
+                stor.put(input)
+                with mock.patch('os.path.islink') as os_mock:
+                    os_mock.return_value = True
+                self.assertTrue(stor._check_storage_size())
+
     def test_maintanence_routine(self):
         with mock.patch('os.makedirs') as m:
             m.return_value = None

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py{27,34,35,36,37}-unit, py37-lint, py37-setup, py37-docs
 install_command = python -m pip install {opts} {packages}
 
 deps = 
-  py{27,34,35,36,37}-unit,py37-lint: mock
+  py{27,34,35,36,37}-unit,py37-lint: mock==3.0.5
   py{27,34,35,36,37}-unit,py37-lint: pytest==4.6.4
   py{27,34,35,36,37}-unit,py37-lint: pytest-cov
   py{27,34,35,36,37}-unit,py37-lint: retrying


### PR DESCRIPTION
Previously, `storage_max_size` configuration in exporters did not do anything.
Implements this logic in `storage` to stop storing files in local storage once max size has been reached (may have some spillage if the envelope is actually larger than the remaining size).

Runs size check everytime a `put` is called in storage, instead of saving the size of the folder. Keeping state will require us to handle concurrency issues and also introduces complications when adding/deleting.

See [dot net](https://github.com/microsoft/ApplicationInsights-dotnet/blob/e2752df59499dd364469fff7487470a4117e32d7/BASE/src/ServerTelemetryChannel/Implementation/TransmissionStorage.cs#L18-L25) and [java](https://github.com/microsoft/ApplicationInsights-Java/blob/master/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmissionFileSystemOutput.java#L140) implementations of this logic.
