### PR TITLE
Default FileExporter file_mode to a

### DIFF
--- a/opencensus/trace/file_exporter.py
+++ b/opencensus/trace/file_exporter.py
@@ -36,13 +36,13 @@ class FileExporter(base_exporter.Exporter):
 
     :type file_mode: str
     :param file_mode: The file mode to open the output file with.
-                      Defaults to w+
+                      Defaults to a
 
     """
 
     def __init__(self, file_name=DEFAULT_FILENAME,
                  transport=sync.SyncTransport,
-                 file_mode='w+'):
+                 file_mode='a'):
         self.file_name = file_name
         self.transport = transport(self)
         self.file_mode = file_mode


### PR DESCRIPTION
The current default, `w+`, overwrites the contents of the file on the first write. Since `emit` opens and writes to the file every time it's called, this effectively rewrites the file on every `emit`. Perhaps this is intended behavior, but it took me a while to understand why there was only one span written to my file, even though I could tell multiple were being emitted. I didn't have my [Python file mode tables](https://docs.python.org/3/library/functions.html#open) memorized, so at first glance `w+` sounded like "write mode, + for append", and I overlooked it while debugging.

I think `a` (append) would be a more intuitive default.