### PR TITLE
AsyncTransport: eagerly process queue on stop()

### DIFF
--- a/opencensus/common/transports/async_.py
+++ b/opencensus/common/transports/async_.py
@@ -145,16 +145,17 @@ class _Worker(object):
             # auto-collection.
             execution_context.set_is_exporter(True)
             self._thread.start()
-            atexit.register(self._export_pending_data)
+            atexit.register(self.stop)
 
     def stop(self):
         """Signals the background thread to stop.
 
         This does not terminate the background thread. It simply queues the
-        stop signal. If the main process exits before the background thread
+        stop signal, and tells the background thread to immediately consume any
+        remaining items. If the main process exits before the background thread
         processes the stop signal, it will be terminated without finishing
-        work. The ``grace_period`` parameter will give the background
-        thread some time to finish processing before this function returns.
+        work. The ``grace_period`` parameter will give the background thread
+        some time to finish processing before this function returns.
 
         :rtype: bool
         :returns: True if the thread terminated. False if the thread is still
@@ -165,20 +166,14 @@ class _Worker(object):
 
         with self._lock:
             self._queue.put_nowait(_WORKER_TERMINATOR)
+            # Stop blocking between export batches
+            self._event.set()
             self._thread.join(timeout=self._grace_period)
 
             success = not self.is_alive
             self._thread = None
 
             return success
-
-    def _export_pending_data(self):
-        """Callback that attempts to send pending data before termination."""
-        if not self.is_alive:
-            return
-        # Stop blocking between export batches
-        self._event.set()
-        self.stop()
 
     def enqueue(self, data):
         """Queues data to be written by the background thread."""
@@ -198,7 +193,7 @@ class AsyncTransport(base.Transport):
 
     :type grace_period: float
     :param grace_period: The amount of time to wait for pending data to
-                         be submitted when the process is shutting down.
+                         be submitted when the process is shutting down (sec).
 
     :type max_batch_size: int
     :param max_batch_size: The maximum number of items to send at a time
@@ -206,7 +201,7 @@ class AsyncTransport(base.Transport):
 
     :type wait_period: int
     :param wait_period: The amount of time to wait before sending the next
-                        batch of data.
+                        batch of data (sec).
     """
 
     def __init__(self, exporter,
@@ -227,5 +222,20 @@ class AsyncTransport(base.Transport):
         self.worker.enqueue(data)
 
     def flush(self):
-        """Submit any pending traces/stats."""
+        "Submit any pending traces/stats, blocking up to `wait_period` secs."
         self.worker.flush()
+
+    def stop(self):
+        """
+        Submit any pending traces/stats and shut down the transport.
+
+        Blocks for up to `grace_period` secs. Unlike :meth:`~.flush`, any
+        pending traces are immediately processed, instead of waiting for the
+        wait period to end. Once called, any subsequent calls to
+        :meth:`~.export` will be silently dropped.
+
+        :rtype: bool
+        :returns: True if the thread terminated. False if the thread is still
+                  running.
+        """
+        self.worker.stop()


### PR DESCRIPTION
Sometimes, you don't want to just rely on the `atexit` handler, but manually shut down the `AsyncTransport` in your application and be sure all the logs are flushed from it. Calling `.flush(); .stop()` is not ideal, because `flush` could block for an unnecessarily long time. This PR:

* sets the stop event in `_Worker.stop`, so the queue begins processing immediately
* removes `_Worker._export_pending_data`, which became redundant, and just uses `stop` as the atexit handler
* Exposes a public `stop` method on `AsyncTransport`
* Driveby: clarify `grace_period` and `wait_period` units in docstring