### PR TITLE
Added RPC Measure and View Constants

### DIFF
--- a/opencensus/grpc/__init__.py
+++ b/opencensus/grpc/__init__.py
@@ -15,4 +15,3 @@
 
 # import rpc_measure_constants
 # import rpc_view_constants
-

--- a/opencensus/grpc/__init__.py
+++ b/opencensus/grpc/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2017, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# import rpc_measure_constants
+# import rpc_view_constants
+

--- a/opencensus/grpc/rpc_m_c_test.py
+++ b/opencensus/grpc/rpc_m_c_test.py
@@ -106,7 +106,7 @@ class RPCMCTest(unittest.TestCase):
             self.rpc_measure.grpc_server_received_bytes_per_method.name,
             "grpc.io/server/received_bytes_per_method",
             "grpc_server_received_bytes_per_method not set correctly")
-TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/opencensus/grpc/rpc_m_c_test.py
+++ b/opencensus/grpc/rpc_m_c_test.py
@@ -1,0 +1,93 @@
+import unittest
+# import rpc_measure_constants
+from opencensus.grpc import rpc_measure_constants
+
+
+class RPCMCTest(unittest.TestCase):
+    """
+    RPCMTest tests the rpc_measure_constants module
+    """
+
+    def setUp(self):
+        """
+        sets up a test rpc_measure_constant instance
+        """
+        self.rpc_measure = rpc_measure_constants.RPCMeasureConstants()
+
+    def test_client_measures(self):
+        """
+        tests the client measures
+        """
+        self.assertEqual(self.rpc_measure.grpc_client_sent_messages_per_rpc.unit,
+                         "1",
+                         "grpc_client_sent_messages_per_rpc not set correctly on init")
+        self.assertEqual(self.rpc_measure.grpc_client_sent_bytes_per_rpc.description,
+                         "Total bytes sent across all request messages per RPC",
+                         "grpc_client_sent_bytes_per_rpc not set correctly on init")
+        self.assertEqual(self.rpc_measure.grpc_client_received_messages_per_rpc.name,
+                         "grpc.io/client/received_messages_per_rpc",
+                         "grpc_client_received_messages_per_rpc not set correctly on init")
+        self.assertEqual(self.rpc_measure.grpc_client_received_bytes_per_rpc.unit,
+                         "by",
+                         "grpc_client_received_bytes_per_rpc not set correctly upon init")
+        self.assertEqual(self.rpc_measure.grpc_client_roundtrip_latency.name,
+                         "grpc.io/client/roundtrip_latency",
+                         "grpc_client_roundtrip_latency not initialized correctly")
+        self.assertEqual(self.rpc_measure.grpc_client_server_latency.name,
+                         "grpc.io/client/server_latency",
+                         "grpc_client_server_latency not set properly")
+        self.assertEqual(self.rpc_measure.grpc_client_started_rpcs.description,
+                         "Number of started client RPCs.",
+                         "grpc_client_started_rpcs not set properly")
+        self.assertEqual(self.rpc_measure.grpc_client_sent_messages_per_method.unit,
+                         "1",
+                         "grpc_client_sent_messages_per_method not set properly")
+        self.assertEqual(self.rpc_measure.grpc_client_received_messages_per_method.name,
+                         "grpc.io/client/received_messages_per_method",
+                         "grpc_client_received_messages_per_method not set properly")
+        self.assertEqual(self.rpc_measure.grpc_client_sent_bytes_per_method.description,
+                         "Total bytes sent per method, recorded real-time as bytes are sent.",
+                         "grpc_client_sent_bytes_per_method not set properly")
+        self.assertEqual(self.rpc_measure.grpc_client_received_bytes_per_method.unit,
+                         "by",
+                         "grpc_client_received_bytes_per_method not set properly")
+
+    def test_server_measures(self):
+        """
+        tests the server measures
+        """
+        self.assertEqual(self.rpc_measure.grpc_server_received_messages_per_rpc.name,
+                         "grpc.io/server/received_messages_per_rpc",
+                         "grpc_server_received_messages_per_rpc not set properly")
+        self.assertEqual(self.rpc_measure.grpc_server_received_bytes_per_rpc.description,
+                         "Total bytes received across all messages per RPC",
+                         "grpc_server_received_bytes_per_rpc not set properly")
+        self.assertEqual(self.rpc_measure.grpc_server_sent_messages_per_rpc.unit,
+                         "1",
+                         "grpc_server_sent_messages_per_rpc not set properly")
+        self.assertEqual(self.rpc_measure.grpc_server_sent_bytes_per_rpc.name,
+                         "grpc.io/server/sent_bytes_per_rpc",
+                         "grpc_server_sent_bytes_per_rpc not set properly")
+        self.assertEqual(self.rpc_measure.grpc_server_server_latency.description,
+                         "Time between first byte of request received to"
+                         " last byte of response sent or terminal error.",
+                         "grpc_server_server_latency not set properly")
+        self.assertEqual(self.rpc_measure.grpc_server_started_rpcs.unit,
+                         "1",
+                         "grpc_server_started_rpcs not set correctly")
+        self.assertEqual(self.rpc_measure.grpc_server_sent_messages_per_method.name,
+                         "grpc.io/server/sent_messages_per_method",
+                         "grpc_server_sent_messages_per_method not set correctly")
+        self.assertEqual(self.rpc_measure.grpc_server_received_messages_per_method.description,
+                         "Total messages received per method.",
+                         "grpc_server_received_messages_per_method not set correctly")
+        self.assertEqual(self.rpc_measure.grpc_server_sent_bytes_per_method.unit,
+                         "by",
+                         "grpc_server_sent_bytes_per_method not set correctly")
+        self.assertEqual(self.rpc_measure.grpc_server_received_bytes_per_method.name,
+                         "grpc.io/server/received_bytes_per_method",
+                         "grpc_server_received_bytes_per_method not set correctly")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/opencensus/grpc/rpc_m_c_test.py
+++ b/opencensus/grpc/rpc_m_c_test.py
@@ -1,5 +1,4 @@
 import unittest
-# import rpc_measure_constants
 from opencensus.grpc import rpc_measure_constants
 
 
@@ -56,38 +55,58 @@ class RPCMCTest(unittest.TestCase):
         """
         tests the server measures
         """
-        self.assertEqual(self.rpc_measure.grpc_server_received_messages_per_rpc.name,
-                         "grpc.io/server/received_messages_per_rpc",
-                         "grpc_server_received_messages_per_rpc not set properly")
-        self.assertEqual(self.rpc_measure.grpc_server_received_bytes_per_rpc.description,
-                         "Total bytes received across all messages per RPC",
-                         "grpc_server_received_bytes_per_rpc not set properly")
-        self.assertEqual(self.rpc_measure.grpc_server_sent_messages_per_rpc.unit,
-                         "1",
-                         "grpc_server_sent_messages_per_rpc not set properly")
-        self.assertEqual(self.rpc_measure.grpc_server_sent_bytes_per_rpc.name,
-                         "grpc.io/server/sent_bytes_per_rpc",
-                         "grpc_server_sent_bytes_per_rpc not set properly")
-        self.assertEqual(self.rpc_measure.grpc_server_server_latency.description,
-                         "Time between first byte of request received to"
-                         " last byte of response sent or terminal error.",
-                         "grpc_server_server_latency not set properly")
-        self.assertEqual(self.rpc_measure.grpc_server_started_rpcs.unit,
-                         "1",
-                         "grpc_server_started_rpcs not set correctly")
-        self.assertEqual(self.rpc_measure.grpc_server_sent_messages_per_method.name,
-                         "grpc.io/server/sent_messages_per_method",
-                         "grpc_server_sent_messages_per_method not set correctly")
-        self.assertEqual(self.rpc_measure.grpc_server_received_messages_per_method.description,
-                         "Total messages received per method.",
-                         "grpc_server_received_messages_per_method not set correctly")
-        self.assertEqual(self.rpc_measure.grpc_server_sent_bytes_per_method.unit,
-                         "by",
-                         "grpc_server_sent_bytes_per_method not set correctly")
-        self.assertEqual(self.rpc_measure.grpc_server_received_bytes_per_method.name,
-                         "grpc.io/server/received_bytes_per_method",
-                         "grpc_server_received_bytes_per_method not set correctly")
+        self.assertEqual(
+            self.rpc_measure.grpc_server_received_messages_per_rpc.name,
+            "grpc.io/server/received_messages_per_rpc",
+            "grpc_server_received_messages_per_rpc not set properly")
 
+        self.assertEqual(
+            self.rpc_measure.grpc_server_received_bytes_per_rpc.description,
+            "Total bytes received across all messages per RPC",
+            "grpc_server_received_bytes_per_rpc not set properly")
+
+        self.assertEqual(
+            self.rpc_measure.grpc_server_sent_messages_per_rpc.unit,
+            "1",
+            "grpc_server_sent_messages_per_rpc not set properly")
+
+        self.assertEqual(
+            self.rpc_measure.grpc_server_sent_bytes_per_rpc.name,
+            "grpc.io/server/sent_bytes_per_rpc",
+            "grpc_server_sent_bytes_per_rpc not set properly")
+
+        self.assertEqual(
+            self.rpc_measure.grpc_server_server_latency.description,
+            "Time between first byte of request received to"
+            " last byte of response sent or terminal error.",
+            "grpc_server_server_latency not set properly")
+
+        self.assertEqual(
+            self.rpc_measure.grpc_server_started_rpcs.unit,
+            "1",
+            "grpc_server_started_rpcs not set correctly")
+
+        self.assertEqual(
+            self.rpc_measure.grpc_server_sent_messages_per_method.name,
+            "grpc.io/server/sent_messages_per_method",
+            "grpc_server_sent_messages_per_method not set correctly")
+
+        self.assertEqual(
+            self.rpc_measure.grpc_server_received_messages_per_method.
+            description,
+            "Total messages received per method.",
+            "grpc_server_received_messages_per_method not set correctly")
+
+        self.assertEqual(
+            self.rpc_measure.grpc_server_sent_bytes_per_method.unit,
+            "by",
+            "grpc_server_sent_bytes_per_method not set correctly")
+
+        self.assertEqual(
+            self.rpc_measure.grpc_server_received_bytes_per_method.name,
+            "grpc.io/server/received_bytes_per_method",
+            "grpc_server_received_bytes_per_method not set correctly")
+TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT
 
 if __name__ == '__main__':
     unittest.main()

--- a/opencensus/grpc/rpc_measure_constants.py
+++ b/opencensus/grpc/rpc_measure_constants.py
@@ -5,6 +5,8 @@ from opencensus.stats.measure import MeasureFloat
 """
 Defines constants for collecting rpc stats
 """
+
+
 class RPCMeasureConstants:
     """
     Define constants used to define Measures below
@@ -16,19 +18,20 @@ class RPCMeasureConstants:
 
     def __init__(self):
         """
-        Define client and server tags 
+        Define client and server tags
         """
         # Client Tags
-        # gRPC server status code received, e.g. OK, CANCELLED, DEADLINE_EXCEEDED
+        # gRPC server status code received,
+        # e.g. OK, CANCELLED, DEADLINE_EXCEEDED
         self.grpc_client_status = tag_key.TagKey("grpc_client_status")
 
         # Full gRPC method name, including package, service and method,
         # e.g. google.bigtable.v2.Bigtable/CheckAndMutateRow
         self.grpc_client_method = tag_key.TagKey("grpc_client_method")
 
-
         # Server Tags
-        # gRPC server status code returned, e.g. OK, CANCELLED, DEADLINE_EXCEEDED
+        # gRPC server status code returned,
+        # e.g. OK, CANCELLED, DEADLINE_EXCEEDED
         self.grpc_server_status = tag_key.TagKey("grpc_server_status")
 
         # Full gRPC method name, including package, service and method,
@@ -36,9 +39,10 @@ class RPCMeasureConstants:
         self.grpc_server_method = tag_key.TagKey("grpc_server_method")
 
         """
-        Client Measures 
+        Client Measures
         """
-        # Number of messages sent in the RPC (always 1 for non-streaming RPCs)
+        # Number of messages sent in the RPC
+        # (always 1 for non-streaming RPCs)
         self.grpc_client_sent_messages_per_rpc = MeasureInt(
             name="grpc.io/client/sent_messages_per_rpc",
             description="Number of messages sent in the RPC",
@@ -47,35 +51,42 @@ class RPCMeasureConstants:
         # Total bytes sent across all request messages per RPC
         self.grpc_client_sent_bytes_per_rpc = MeasureFloat(
             name="grpc.io/client/sent_bytes_per_rpc",
-            description="Total bytes sent across all request messages per RPC",
+            description="Total bytes sent across all"
+                        " request messages per RPC",
             unit=self.byte)
 
-        # Number of response messages received per RPC (always 1 for non-streaming RPCs)
+        # Number of response messages received
+        # per RPC (always 1 for non-streaming RPCs)
         self.grpc_client_received_messages_per_rpc = MeasureInt(
             name="grpc.io/client/received_messages_per_rpc",
             description="Number of response messages received per RPC",
             unit=self.count)
 
-        # Total bytes received across all response messages per RPC
+        # Total bytes received across all
+        # response messages per RPC
         self.grpc_client_received_bytes_per_rpc = MeasureFloat(
             name="grpc.io/client/received_bytes_per_rpc",
-            description="Total bytes received across all response messages per RPC",
+            description="Total bytes received across all"
+                        " response messages per RPC",
             unit=self.byte)
 
-        # Time between first byte of request sent to last byte of response received, or terminal error
+        # Time between first byte of request sent to last
+        # byte of response received, or terminal error
         self.grpc_client_roundtrip_latency = MeasureFloat(
             name="grpc.io/client/roundtrip_latency",
             description="Time between first byte of request sent to"
                         " last byte of response received or terminal error.",
             unit=self.millisecond)
 
-        # Propagated from the server and should have the same value as "grpc.io/server/latency"
+        # Propagated from the server and should
+        # have the same value as "grpc.io/server/latency"
         self.grpc_client_server_latency = MeasureFloat(
             name="grpc.io/client/server_latency",
             description="Server latency in msecs",
             unit=self.millisecond)
 
-        # The total number of client RPCs ever opened, including those that have not completed
+        # The total number of client RPCs ever opened,
+        # including those that have not completed
         self.grpc_client_started_rpcs = MeasureInt(
             name="grpc.io/client/started_rpcs",
             description="Number of started client RPCs.",
@@ -93,13 +104,16 @@ class RPCMeasureConstants:
             description="Total messages received per method.",
             unit=self.count)
 
-        # Total bytes sent per method, recorded real-time as bytes are sent
+        # Total bytes sent per method,
+        # recorded real-time as bytes are sent
         self.grpc_client_sent_bytes_per_method = MeasureFloat(
             name="grpc.io/client/sent_bytes_per_method",
-            description="Total bytes sent per method, recorded real-time as bytes are sent.",
+            description="Total bytes sent per method, recorded"
+                        " real-time as bytes are sent.",
             unit=self.byte)
 
-        # Total bytes received per method, recorded real-time as bytes are received
+        # Total bytes received per method, recorded real-time
+        # as bytes are received
         self.grpc_client_received_bytes_per_method = MeasureFloat(
             name="grpc.io/client/received_bytes_per_method",
             description="Total bytes received per method,"
@@ -107,9 +121,10 @@ class RPCMeasureConstants:
             unit=self.byte)
 
         """
-        Server Measures 
+        Server Measures
         """
-        # Number of messages received in each RPC. Has value 1 for non-streaming RPCs
+        # Number of messages received in each RPC.
+        # Has value 1 for non-streaming RPCs
         self.grpc_server_received_messages_per_rpc = MeasureInt(
             name="grpc.io/server/received_messages_per_rpc",
             description="Number of messages received in each RPC",
@@ -118,10 +133,12 @@ class RPCMeasureConstants:
         # Total bytes received across all messages per RPC
         self.grpc_server_received_bytes_per_rpc = MeasureFloat(
             name="grpc.io/server/received_bytes_per_rpc",
-            description="Total bytes received across all messages per RPC",
+            description="Total bytes received across all"
+                        " messages per RPC",
             unit=self.byte)
 
-        # Number of messages sent in each RPC. Has value 1 for non-streaming RPCs
+        # Number of messages sent in each RPC.
+        # Has value 1 for non-streaming RPCs
         self.grpc_server_sent_messages_per_rpc = MeasureInt(
             name="grpc.io/server/sent_messages_per_rpc",
             description="Number of messages sent in each RPC",
@@ -130,17 +147,20 @@ class RPCMeasureConstants:
         # Total bytes sent in across all response messages per RPC
         self.grpc_server_sent_bytes_per_rpc = MeasureFloat(
             name="grpc.io/server/sent_bytes_per_rpc",
-            description="Total bytes sent across all response messages per RPC",
+            description="Total bytes sent across all response"
+                        " messages per RPC",
             unit=self.byte)
 
-        # Time between first byte of request received to last byte of response sent, or terminal error
+        # Time between first byte of request received to last byte of
+        # response sent, or terminal error
         self.grpc_server_server_latency = MeasureFloat(
             name="grpc.io/server/server_latency",
             description="Time between first byte of request received"
                         " to last byte of response sent or terminal error.",
             unit=self.millisecond)
 
-        # The total number of server RPCs ever opened, including those that have not completed
+        # The total number of server RPCs ever opened,
+        # including those that have not completed
         self.grpc_server_started_rpcs = MeasureInt(
             name="grpc.io/server/started_rpcs",
             description="Number of started server RPCs.",
@@ -161,11 +181,14 @@ class RPCMeasureConstants:
         # Total bytes sent per method, recorded real-time as bytes are sent
         self.grpc_server_sent_bytes_per_method = MeasureFloat(
             name="grpc.io/server/sent_bytes_per_method",
-            description="Total bytes sent per method, recorded real-time as bytes are sent.",
+            description="Total bytes sent per method, recorded"
+                        " real-time as bytes are sent.",
             unit=self.byte)
 
-        # Total bytes received per method, recorded real-time as bytes are received
+        # Total bytes received per method, recorded real-time as
+        # bytes are received
         self.grpc_server_received_bytes_per_method = MeasureFloat(
             name="grpc.io/server/received_bytes_per_method",
-            description="Total bytes received per method, recorded real-time as bytes are received.",
+            description="Total bytes received per method, recorded"
+                        " real-time as bytes are received.",
             unit=self.byte)

--- a/opencensus/grpc/rpc_measure_constants.py
+++ b/opencensus/grpc/rpc_measure_constants.py
@@ -1,0 +1,171 @@
+from opencensus.tags import tag_key
+from opencensus.stats.measure import MeasureInt
+from opencensus.stats.measure import MeasureFloat
+
+"""
+Defines constants for collecting rpc stats
+"""
+class RPCMeasureConstants:
+    """
+    Define constants used to define Measures below
+    see specs in documentation for opencensus-python
+    """
+    byte = "by"
+    count = "1"
+    millisecond = "ms"
+
+    def __init__(self):
+        """
+        Define client and server tags 
+        """
+        # Client Tags
+        # gRPC server status code received, e.g. OK, CANCELLED, DEADLINE_EXCEEDED
+        self.grpc_client_status = tag_key.TagKey("grpc_client_status")
+
+        # Full gRPC method name, including package, service and method,
+        # e.g. google.bigtable.v2.Bigtable/CheckAndMutateRow
+        self.grpc_client_method = tag_key.TagKey("grpc_client_method")
+
+
+        # Server Tags
+        # gRPC server status code returned, e.g. OK, CANCELLED, DEADLINE_EXCEEDED
+        self.grpc_server_status = tag_key.TagKey("grpc_server_status")
+
+        # Full gRPC method name, including package, service and method,
+        # e.g. com.exampleapi.v4.BookshelfService/Checkout
+        self.grpc_server_method = tag_key.TagKey("grpc_server_method")
+
+        """
+        Client Measures 
+        """
+        # Number of messages sent in the RPC (always 1 for non-streaming RPCs)
+        self.grpc_client_sent_messages_per_rpc = MeasureInt(
+            name="grpc.io/client/sent_messages_per_rpc",
+            description="Number of messages sent in the RPC",
+            unit=self.count)
+
+        # Total bytes sent across all request messages per RPC
+        self.grpc_client_sent_bytes_per_rpc = MeasureFloat(
+            name="grpc.io/client/sent_bytes_per_rpc",
+            description="Total bytes sent across all request messages per RPC",
+            unit=self.byte)
+
+        # Number of response messages received per RPC (always 1 for non-streaming RPCs)
+        self.grpc_client_received_messages_per_rpc = MeasureInt(
+            name="grpc.io/client/received_messages_per_rpc",
+            description="Number of response messages received per RPC",
+            unit=self.count)
+
+        # Total bytes received across all response messages per RPC
+        self.grpc_client_received_bytes_per_rpc = MeasureFloat(
+            name="grpc.io/client/received_bytes_per_rpc",
+            description="Total bytes received across all response messages per RPC",
+            unit=self.byte)
+
+        # Time between first byte of request sent to last byte of response received, or terminal error
+        self.grpc_client_roundtrip_latency = MeasureFloat(
+            name="grpc.io/client/roundtrip_latency",
+            description="Time between first byte of request sent to"
+                        " last byte of response received or terminal error.",
+            unit=self.millisecond)
+
+        # Propagated from the server and should have the same value as "grpc.io/server/latency"
+        self.grpc_client_server_latency = MeasureFloat(
+            name="grpc.io/client/server_latency",
+            description="Server latency in msecs",
+            unit=self.millisecond)
+
+        # The total number of client RPCs ever opened, including those that have not completed
+        self.grpc_client_started_rpcs = MeasureInt(
+            name="grpc.io/client/started_rpcs",
+            description="Number of started client RPCs.",
+            unit=self.count)
+
+        # Total messages sent per method
+        self.grpc_client_sent_messages_per_method = MeasureInt(
+            name="grpc.io/client/sent_messages_per_method",
+            description="Total messages sent per method.",
+            unit=self.count)
+
+        # Total messages received per method
+        self.grpc_client_received_messages_per_method = MeasureInt(
+            name="grpc.io/client/received_messages_per_method",
+            description="Total messages received per method.",
+            unit=self.count)
+
+        # Total bytes sent per method, recorded real-time as bytes are sent
+        self.grpc_client_sent_bytes_per_method = MeasureFloat(
+            name="grpc.io/client/sent_bytes_per_method",
+            description="Total bytes sent per method, recorded real-time as bytes are sent.",
+            unit=self.byte)
+
+        # Total bytes received per method, recorded real-time as bytes are received
+        self.grpc_client_received_bytes_per_method = MeasureFloat(
+            name="grpc.io/client/received_bytes_per_method",
+            description="Total bytes received per method,"
+                        " recorded real-time as bytes are received.",
+            unit=self.byte)
+
+        """
+        Server Measures 
+        """
+        # Number of messages received in each RPC. Has value 1 for non-streaming RPCs
+        self.grpc_server_received_messages_per_rpc = MeasureInt(
+            name="grpc.io/server/received_messages_per_rpc",
+            description="Number of messages received in each RPC",
+            unit=self.count)
+
+        # Total bytes received across all messages per RPC
+        self.grpc_server_received_bytes_per_rpc = MeasureFloat(
+            name="grpc.io/server/received_bytes_per_rpc",
+            description="Total bytes received across all messages per RPC",
+            unit=self.byte)
+
+        # Number of messages sent in each RPC. Has value 1 for non-streaming RPCs
+        self.grpc_server_sent_messages_per_rpc = MeasureInt(
+            name="grpc.io/server/sent_messages_per_rpc",
+            description="Number of messages sent in each RPC",
+            unit=self.count)
+
+        # Total bytes sent in across all response messages per RPC
+        self.grpc_server_sent_bytes_per_rpc = MeasureFloat(
+            name="grpc.io/server/sent_bytes_per_rpc",
+            description="Total bytes sent across all response messages per RPC",
+            unit=self.byte)
+
+        # Time between first byte of request received to last byte of response sent, or terminal error
+        self.grpc_server_server_latency = MeasureFloat(
+            name="grpc.io/server/server_latency",
+            description="Time between first byte of request received"
+                        " to last byte of response sent or terminal error.",
+            unit=self.millisecond)
+
+        # The total number of server RPCs ever opened, including those that have not completed
+        self.grpc_server_started_rpcs = MeasureInt(
+            name="grpc.io/server/started_rpcs",
+            description="Number of started server RPCs.",
+            unit=self.count)
+
+        # Total messages sent per method
+        self.grpc_server_sent_messages_per_method = MeasureInt(
+            name="grpc.io/server/sent_messages_per_method",
+            description="Total messages sent per method.",
+            unit=self.count)
+
+        # Total messages received per method
+        self.grpc_server_received_messages_per_method = MeasureInt(
+            name="grpc.io/server/received_messages_per_method",
+            description="Total messages received per method.",
+            unit=self.count)
+
+        # Total bytes sent per method, recorded real-time as bytes are sent
+        self.grpc_server_sent_bytes_per_method = MeasureFloat(
+            name="grpc.io/server/sent_bytes_per_method",
+            description="Total bytes sent per method, recorded real-time as bytes are sent.",
+            unit=self.byte)
+
+        # Total bytes received per method, recorded real-time as bytes are received
+        self.grpc_server_received_bytes_per_method = MeasureFloat(
+            name="grpc.io/server/received_bytes_per_method",
+            description="Total bytes received per method, recorded real-time as bytes are received.",
+            unit=self.byte)

--- a/opencensus/grpc/rpc_v_c_test.py
+++ b/opencensus/grpc/rpc_v_c_test.py
@@ -1,5 +1,4 @@
 import unittest
-#import rpc_view_constants
 from opencensus.grpc import rpc_view_constants
 
 
@@ -12,89 +11,124 @@ class RPCVCTests(unittest.TestCase):
         self.rpc_view = rpc_view_constants.RPCViewConstants()
 
     def test_client_measures(self):
-        self.assertEqual(self.rpc_view.grpc_client_sent_bytes_per_rpc_view.name,
-                         "grpc.io/client/sent_bytes_per_rpc",
-                         "grpc_client_sent_bytes_per_rpc_view not set correctly")
-        self.assertEqual(self.rpc_view.grpc_client_received_bytes_per_rpc_view.description,
-                         "Received bytes per RPC",
-                         "grpc_client_received_bytes_per_rpc_view not set correctly")
-        self.assertEqual(self.rpc_view.grpc_client_roundtrip_latency_view.measure.name,
-                         "grpc.io/client/roundtrip_latency",
-                         "grpc_client_roundtrip_latency_view not set correctly")
-        self.assertEqual(self.rpc_view.grpc_client_completed_rpc_view.measure.name,
-                         "grpc.io/client/roundtrip_latency",
-                         "grpc_client_completed_rpc_view not set correctly")
-        self.assertEqual(self.rpc_view.grpc_client_started_rpc_view.description,
-                         "Number of started client RPCs",
-                         "grpc_client_started_rpc_view not set correctly")
-        self.assertEqual(self.rpc_view.grpc_client_sent_messages_per_rpc_view.name,
-                         "grpc.io/client/sent_messages_per_rpc",
-                         "grpc_client_sent_messages_per_rpc_view not set correctly")
-        self.assertEqual(self.rpc_view.grpc_client_received_messages_per_rpc_view.description,
-                         "Number of response messages received per RPC",
-                         "grpc_client_received_messages_per_rpc_view not set correctly")
-        self.assertEqual(self.rpc_view.grpc_client_server_latency_view.measure.unit,
-                         "ms",
-                         "grpc_client_server_latency_view not set correctly")
-        self.assertEqual(self.rpc_view.grpc_client_sent_messages_per_method_view.name,
-                         "grpc.io/client/sent_messages_per_method",
-                         "grpc_client_sent_messages_per_method_view not set correctly")
-        self.assertEqual(self.rpc_view.grpc_client_received_messages_per_method_view.description,
-                         "Number of messages received",
-                         "grpc_client_received_messages_per_method_view not set correctly")
-        self.assertEqual(self.rpc_view.grpc_client_sent_bytes_per_method_view.measure.unit,
-                         "by",
-                         "grpc_client_sent_bytes_per_method_view not set correctly")
-        self.assertEqual(self.rpc_view.grpc_client_received_bytes_per_method_view.name,
-                         "grpc.io/client/received_bytes_per_method",
-                         "grpc_client_received_bytes_per_method_view not set correctly")
+        self.assertEqual(
+            self.rpc_view.grpc_client_sent_bytes_per_rpc_view.name,
+            "grpc.io/client/sent_bytes_per_rpc",
+            "grpc_client_sent_bytes_per_rpc_view not set correctly")
+
+        self.assertEqual(
+            self.rpc_view.grpc_client_received_bytes_per_rpc_view.description,
+            "Received bytes per RPC",
+            "grpc_client_received_bytes_per_rpc_view not set correctly")
+
+        self.assertEqual(
+            self.rpc_view.grpc_client_roundtrip_latency_view.measure.name,
+            "grpc.io/client/roundtrip_latency",
+            "grpc_client_roundtrip_latency_view not set correctly")
+
+        self.assertEqual(
+            self.rpc_view.grpc_client_completed_rpc_view.measure.name,
+            "grpc.io/client/roundtrip_latency",
+            "grpc_client_completed_rpc_view not set correctly")
+
+        self.assertEqual(
+            self.rpc_view.grpc_client_started_rpc_view.description,
+            "Number of started client RPCs",
+            "grpc_client_started_rpc_view not set correctly")
+
+        self.assertEqual(
+            self.rpc_view.grpc_client_sent_messages_per_rpc_view.name,
+            "grpc.io/client/sent_messages_per_rpc",
+            "grpc_client_sent_messages_per_rpc_view not set correctly")
+
+        self.assertEqual(
+            self.rpc_view.grpc_client_received_messages_per_rpc_view.
+            description,
+            "Number of response messages received per RPC",
+            "grpc_client_received_messages_per_rpc_view not set correctly")
+
+        self.assertEqual(
+            self.rpc_view.grpc_client_server_latency_view.measure.unit,
+            "ms",
+            "grpc_client_server_latency_view not set correctly")
+
+        self.assertEqual(
+            self.rpc_view.grpc_client_sent_messages_per_method_view.name,
+            "grpc.io/client/sent_messages_per_method",
+            "grpc_client_sent_messages_per_method_view not set correctly")
+
+        self.assertEqual(
+            self.rpc_view.grpc_client_received_messages_per_method_view.description,
+            "Number of messages received",
+            "grpc_client_received_messages_per_method_view not set correctly")
+
+        self.assertEqual(
+            self.rpc_view.grpc_client_sent_bytes_per_method_view.measure.unit,
+            "by",
+            "grpc_client_sent_bytes_per_method_view not set correctly")
+
+        self.assertEqual(
+            self.rpc_view.grpc_client_received_bytes_per_method_view.name,
+            "grpc.io/client/received_bytes_per_method",
+            "grpc_client_received_bytes_per_method_view not set correctly")
 
     def test_server_measures(self):
         # Test default server views
-        self.assertEqual(self.rpc_view.grpc_server_received_bytes_per_rpc.name,
-                         "grpc.io/server/received_bytes_per_rpc",
-                         "grpc_server_received_bytes_per_rpc view not set correctly")
+        self.assertEqual(
+            self.rpc_view.grpc_server_received_bytes_per_rpc.name,
+            "grpc.io/server/received_bytes_per_rpc",
+            "grpc_server_received_bytes_per_rpc view not set correctly")
 
-        self.assertEqual(self.rpc_view.grpc_server_sent_bytes_per_rpc.name,
-                         "grpc.io/server/sent_bytes_per_rpc",
-                         "grpc_server_sent_bytes_per_rpc view not set correctly")
+        self.assertEqual(
+            self.rpc_view.grpc_server_sent_bytes_per_rpc.name,
+            "grpc.io/server/sent_bytes_per_rpc",
+            "grpc_server_sent_bytes_per_rpc view not set correctly")
 
-        self.assertEqual(self.rpc_view.grpc_server_server_latency.name,
-                         "grpc.io/server/server_latency",
-                         "grpc_server_server_latency view not set correctly")
+        self.assertEqual(
+            self.rpc_view.grpc_server_server_latency.name,
+            "grpc.io/server/server_latency",
+            "grpc_server_server_latency view not set correctly")
 
-        self.assertEqual(self.rpc_view.grpc_server_completed_rpcs.name,
-                         "grpc.io/server/completed_rpcs",
-                         "grpc_server_completed_rpcs view not set correctly")
+        self.assertEqual(
+            self.rpc_view.grpc_server_completed_rpcs.name,
+            "grpc.io/server/completed_rpcs",
+            "grpc_server_completed_rpcs view not set correctly")
 
-        self.assertEqual(self.rpc_view.grpc_server_started_rpcs.name,
-                         "grpc.io/server/started_rpcs",
-                         "grpc_server_started_rpcs view not set correctly")
+        self.assertEqual(
+            self.rpc_view.grpc_server_started_rpcs.name,
+            "grpc.io/server/started_rpcs",
+            "grpc_server_started_rpcs view not set correctly")
 
         # Test extra server views
-        self.assertEqual(self.rpc_view.grpc_server_received_messages_per_rpc.name,
-                         "grpc.io/server/received_messages_per_rpc",
-                         "grpc_server_received_messages_per_rpc view not set correctly")
+        self.assertEqual(
+            self.rpc_view.grpc_server_received_messages_per_rpc.name,
+            "grpc.io/server/received_messages_per_rpc",
+            "grpc_server_received_messages_per_rpc view not set correctly")
 
-        self.assertEqual(self.rpc_view.grpc_server_sent_messages_per_rpc.name,
-                         "grpc.io/server/sent_messages_per_rpc",
-                         "grpc_server_sent_messages_per_rpc view not set correctly")
+        self.assertEqual(
+            self.rpc_view.grpc_server_sent_messages_per_rpc.name,
+            "grpc.io/server/sent_messages_per_rpc",
+            "grpc_server_sent_messages_per_rpc view not set correctly")
 
-        self.assertEqual(self.rpc_view.grpc_server_sent_messages_per_method.name,
-                         "grpc.io/server/sent_messages_per_method",
-                         "grpc_server_sent_messages_per_method view not set correctly")
+        self.assertEqual(
+            self.rpc_view.grpc_server_sent_messages_per_method.name,
+            "grpc.io/server/sent_messages_per_method",
+            "grpc_server_sent_messages_per_method view not set correctly")
 
-        self.assertEqual(self.rpc_view.grpc_server_received_messages_per_method.name,
-                         "grpc.io/server/received_messages_per_method",
-                         "grpc_server_received_messages_per_method view not set correctly")
+        self.assertEqual(
+            self.rpc_view.grpc_server_received_messages_per_method.name,
+            "grpc.io/server/received_messages_per_method",
+            "grpc_server_received_messages_per_method view not set correctly")
 
-        self.assertEqual(self.rpc_view.grpc_server_sent_bytes_per_method.name,
-                         "grpc.io/server/sent_bytes_per_method",
-                         "grpc_server_sent_bytes_per_method view not set correctly")
+        self.assertEqual(
+            self.rpc_view.grpc_server_sent_bytes_per_method.name,
+            "grpc.io/server/sent_bytes_per_method",
+            "grpc_server_sent_bytes_per_method view not set correctly")
 
-        self.assertEqual(self.rpc_view.grpc_server_received_bytes_per_method.name,
-                         "grpc.io/server/received_bytes_per_method",
-                         "grpc_server_received_bytes_per_method view not set correctly")
+        self.assertEqual(
+            self.rpc_view.grpc_server_received_bytes_per_method.name,
+            "grpc.io/server/received_bytes_per_method",
+            "grpc_server_received_bytes_per_method view not set correctly")
 
 
 if __name__ == '__main__':

--- a/opencensus/grpc/rpc_v_c_test.py
+++ b/opencensus/grpc/rpc_v_c_test.py
@@ -1,0 +1,101 @@
+import unittest
+#import rpc_view_constants
+from opencensus.grpc import rpc_view_constants
+
+
+class RPCVCTests(unittest.TestCase):
+    """
+    RPVMTest tests the rpc_view_constants module
+    """
+
+    def setUp(self):
+        self.rpc_view = rpc_view_constants.RPCViewConstants()
+
+    def test_client_measures(self):
+        self.assertEqual(self.rpc_view.grpc_client_sent_bytes_per_rpc_view.name,
+                         "grpc.io/client/sent_bytes_per_rpc",
+                         "grpc_client_sent_bytes_per_rpc_view not set correctly")
+        self.assertEqual(self.rpc_view.grpc_client_received_bytes_per_rpc_view.description,
+                         "Received bytes per RPC",
+                         "grpc_client_received_bytes_per_rpc_view not set correctly")
+        self.assertEqual(self.rpc_view.grpc_client_roundtrip_latency_view.measure.name,
+                         "grpc.io/client/roundtrip_latency",
+                         "grpc_client_roundtrip_latency_view not set correctly")
+        self.assertEqual(self.rpc_view.grpc_client_completed_rpc_view.measure.name,
+                         "grpc.io/client/roundtrip_latency",
+                         "grpc_client_completed_rpc_view not set correctly")
+        self.assertEqual(self.rpc_view.grpc_client_started_rpc_view.description,
+                         "Number of started client RPCs",
+                         "grpc_client_started_rpc_view not set correctly")
+        self.assertEqual(self.rpc_view.grpc_client_sent_messages_per_rpc_view.name,
+                         "grpc.io/client/sent_messages_per_rpc",
+                         "grpc_client_sent_messages_per_rpc_view not set correctly")
+        self.assertEqual(self.rpc_view.grpc_client_received_messages_per_rpc_view.description,
+                         "Number of response messages received per RPC",
+                         "grpc_client_received_messages_per_rpc_view not set correctly")
+        self.assertEqual(self.rpc_view.grpc_client_server_latency_view.measure.unit,
+                         "ms",
+                         "grpc_client_server_latency_view not set correctly")
+        self.assertEqual(self.rpc_view.grpc_client_sent_messages_per_method_view.name,
+                         "grpc.io/client/sent_messages_per_method",
+                         "grpc_client_sent_messages_per_method_view not set correctly")
+        self.assertEqual(self.rpc_view.grpc_client_received_messages_per_method_view.description,
+                         "Number of messages received",
+                         "grpc_client_received_messages_per_method_view not set correctly")
+        self.assertEqual(self.rpc_view.grpc_client_sent_bytes_per_method_view.measure.unit,
+                         "by",
+                         "grpc_client_sent_bytes_per_method_view not set correctly")
+        self.assertEqual(self.rpc_view.grpc_client_received_bytes_per_method_view.name,
+                         "grpc.io/client/received_bytes_per_method",
+                         "grpc_client_received_bytes_per_method_view not set correctly")
+
+    def test_server_measures(self):
+        # Test default server views
+        self.assertEqual(self.rpc_view.grpc_server_received_bytes_per_rpc.name,
+                         "grpc.io/server/received_bytes_per_rpc",
+                         "grpc_server_received_bytes_per_rpc view not set correctly")
+
+        self.assertEqual(self.rpc_view.grpc_server_sent_bytes_per_rpc.name,
+                         "grpc.io/server/sent_bytes_per_rpc",
+                         "grpc_server_sent_bytes_per_rpc view not set correctly")
+
+        self.assertEqual(self.rpc_view.grpc_server_server_latency.name,
+                         "grpc.io/server/server_latency",
+                         "grpc_server_server_latency view not set correctly")
+
+        self.assertEqual(self.rpc_view.grpc_server_completed_rpcs.name,
+                         "grpc.io/server/completed_rpcs",
+                         "grpc_server_completed_rpcs view not set correctly")
+
+        self.assertEqual(self.rpc_view.grpc_server_started_rpcs.name,
+                         "grpc.io/server/started_rpcs",
+                         "grpc_server_started_rpcs view not set correctly")
+
+        # Test extra server views
+        self.assertEqual(self.rpc_view.grpc_server_received_messages_per_rpc.name,
+                         "grpc.io/server/received_messages_per_rpc",
+                         "grpc_server_received_messages_per_rpc view not set correctly")
+
+        self.assertEqual(self.rpc_view.grpc_server_sent_messages_per_rpc.name,
+                         "grpc.io/server/sent_messages_per_rpc",
+                         "grpc_server_sent_messages_per_rpc view not set correctly")
+
+        self.assertEqual(self.rpc_view.grpc_server_sent_messages_per_method.name,
+                         "grpc.io/server/sent_messages_per_method",
+                         "grpc_server_sent_messages_per_method view not set correctly")
+
+        self.assertEqual(self.rpc_view.grpc_server_received_messages_per_method.name,
+                         "grpc.io/server/received_messages_per_method",
+                         "grpc_server_received_messages_per_method view not set correctly")
+
+        self.assertEqual(self.rpc_view.grpc_server_sent_bytes_per_method.name,
+                         "grpc.io/server/sent_bytes_per_method",
+                         "grpc_server_sent_bytes_per_method view not set correctly")
+
+        self.assertEqual(self.rpc_view.grpc_server_received_bytes_per_method.name,
+                         "grpc.io/server/received_bytes_per_method",
+                         "grpc_server_received_bytes_per_method view not set correctly")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/opencensus/grpc/rpc_view_constants.py
+++ b/opencensus/grpc/rpc_view_constants.py
@@ -9,41 +9,58 @@ from opencensus.grpc import rpc_measure_constants
 """
 Defines constants for exporting views on rpc stats
 """
+
+
 class RPCViewConstants:
     """
     Define variables used by constants below
     """
-    # Buckets for distributions in default views 
-    # Common histogram bucket boundaries for bytes received/sets Views (in bytes).
-    rpc_bytes_bucket_boundaries = [0, 1024, 2048, 4096, 16384, 65536, 262144, 4194304,
-                                   16777216, 67108864, 268435456, 1073741824, 4294967296]
+    # Buckets for distributions in default views
+    # Common histogram bucket boundaries for bytes
+    # received/sets Views (in bytes).
+    rpc_bytes_bucket_boundaries = [0, 1024, 2048, 4096, 16384, 65536,
+                                   262144, 4194304, 16777216, 67108864,
+                                   268435456, 1073741824, 4294967296]
 
-    # Common histogram bucket boundaries for latency and elapsed-time Views (in milliseconds).
-    rpc_millis_bucket_boundaries = [0.0, 0.01, 0.05, 0.1, 0.3, 0.6, 0.8, 1.0, 2.0, 3.0,
-                                    4.0, 5.0, 6.0, 8.0, 10.0, 13.0, 16.0, 20.0, 25.0,
-                                    30.0, 40.0, 50.0, 65.0, 80.0, 100.0, 130.0, 160.0,
-                                    200.0, 250.0, 300.0, 400.0, 500.0, 650.0, 800.0,
-                                    1000.0, 2000.0, 5000.0, 10000.0, 20000.0, 50000.0, 100000.0]
+    # Common histogram bucket boundaries for latency and
+    # elapsed-time Views (in milliseconds).
+    rpc_millis_bucket_boundaries = [0.0, 0.01, 0.05, 0.1, 0.3, 0.6,
+                                    0.8, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0,
+                                    8.0, 10.0, 13.0, 16.0, 20.0, 25.0,
+                                    30.0, 40.0, 50.0, 65.0, 80.0, 100.0,
+                                    130.0, 160.0, 200.0, 250.0, 300.0,
+                                    400.0, 500.0, 650.0, 800.0, 1000.0,
+                                    2000.0, 5000.0, 10000.0, 20000.0,
+                                    50000.0, 100000.0]
 
-    # Common histogram bucket boundaries for request/response count Views (no unit).
-    rpc_count_bucket_boundaries = [0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0,
-                                   512.0, 1024.0, 2048.0, 4096.0, 8192.0, 16384.0, 32768.0, 65536.0]
+    # Common histogram bucket boundaries for request/response
+    # count Views (no unit).
+    rpc_count_bucket_boundaries = [0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0,
+                                   64.0, 128.0, 256.0, 512.0, 1024.0,
+                                   2048.0, 4096.0, 8192.0, 16384.0,
+                                   32768.0, 65536.0]
 
     # Record sum and count stats at the same time.
     count = CountAggregation()
     sum = SumAggregation()
 
     # Set up aggregation object for rpc_bytes_bucket_boundaries
-    bytes_bucket_boundaries = bucket_boundaries.BucketBoundaries(rpc_bytes_bucket_boundaries)
-    aggregation_with_bytes_histogram = DistributionAggregation(bytes_bucket_boundaries.boundaries)
+    bytes_bucket_boundaries = bucket_boundaries.BucketBoundaries(
+        rpc_bytes_bucket_boundaries)
+    aggregation_with_bytes_histogram = DistributionAggregation(
+        bytes_bucket_boundaries.boundaries)
 
     # Set up aggregation object for rpc_millis_bucket_boundaries
-    millis_bucket_boundaries = bucket_boundaries.BucketBoundaries(rpc_millis_bucket_boundaries)
-    aggregation_with_millis_histogram = DistributionAggregation(millis_bucket_boundaries.boundaries)
+    millis_bucket_boundaries = bucket_boundaries.BucketBoundaries(
+        rpc_millis_bucket_boundaries)
+    aggregation_with_millis_histogram = DistributionAggregation(
+        millis_bucket_boundaries.boundaries)
 
     # Set up aggregation object for rpc_count_bucket_boundaries
-    count_bucket_boundaries = bucket_boundaries.BucketBoundaries(rpc_count_bucket_boundaries)
-    aggregation_with_count_histogram = DistributionAggregation(count_bucket_boundaries.boundaries)
+    count_bucket_boundaries = bucket_boundaries.BucketBoundaries(
+        rpc_count_bucket_boundaries)
+    aggregation_with_count_histogram = DistributionAggregation(
+        count_bucket_boundaries.boundaries)
 
     # Initialize an instance of RPC Measure Constants
     rpc_m_c = rpc_measure_constants.RPCMeasureConstants()
@@ -180,7 +197,6 @@ class RPCViewConstants:
         columns=[rpc_m_c.grpc_server_method],
         measure=rpc_m_c.grpc_server_started_rpcs,
         aggregation=count)
-
 
     # Extra Views
     # The following set of views are considered useful

--- a/opencensus/grpc/rpc_view_constants.py
+++ b/opencensus/grpc/rpc_view_constants.py
@@ -1,0 +1,228 @@
+from opencensus.stats.aggregation import CountAggregation
+from opencensus.stats.aggregation import SumAggregation
+from opencensus.stats.aggregation import DistributionAggregation
+from opencensus.stats import bucket_boundaries
+from opencensus.stats import view
+from opencensus.grpc import rpc_measure_constants
+# import rpc_measure_constants
+
+"""
+Defines constants for exporting views on rpc stats
+"""
+class RPCViewConstants:
+    """
+    Define variables used by constants below
+    """
+    # Buckets for distributions in default views 
+    # Common histogram bucket boundaries for bytes received/sets Views (in bytes).
+    rpc_bytes_bucket_boundaries = [0, 1024, 2048, 4096, 16384, 65536, 262144, 4194304,
+                                   16777216, 67108864, 268435456, 1073741824, 4294967296]
+
+    # Common histogram bucket boundaries for latency and elapsed-time Views (in milliseconds).
+    rpc_millis_bucket_boundaries = [0.0, 0.01, 0.05, 0.1, 0.3, 0.6, 0.8, 1.0, 2.0, 3.0,
+                                    4.0, 5.0, 6.0, 8.0, 10.0, 13.0, 16.0, 20.0, 25.0,
+                                    30.0, 40.0, 50.0, 65.0, 80.0, 100.0, 130.0, 160.0,
+                                    200.0, 250.0, 300.0, 400.0, 500.0, 650.0, 800.0,
+                                    1000.0, 2000.0, 5000.0, 10000.0, 20000.0, 50000.0, 100000.0]
+
+    # Common histogram bucket boundaries for request/response count Views (no unit).
+    rpc_count_bucket_boundaries = [0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0,
+                                   512.0, 1024.0, 2048.0, 4096.0, 8192.0, 16384.0, 32768.0, 65536.0]
+
+    # Record sum and count stats at the same time.
+    count = CountAggregation()
+    sum = SumAggregation()
+
+    # Set up aggregation object for rpc_bytes_bucket_boundaries
+    bytes_bucket_boundaries = bucket_boundaries.BucketBoundaries(rpc_bytes_bucket_boundaries)
+    aggregation_with_bytes_histogram = DistributionAggregation(bytes_bucket_boundaries.boundaries)
+
+    # Set up aggregation object for rpc_millis_bucket_boundaries
+    millis_bucket_boundaries = bucket_boundaries.BucketBoundaries(rpc_millis_bucket_boundaries)
+    aggregation_with_millis_histogram = DistributionAggregation(millis_bucket_boundaries.boundaries)
+
+    # Set up aggregation object for rpc_count_bucket_boundaries
+    count_bucket_boundaries = bucket_boundaries.BucketBoundaries(rpc_count_bucket_boundaries)
+    aggregation_with_count_histogram = DistributionAggregation(count_bucket_boundaries.boundaries)
+
+    # Initialize an instance of RPC Measure Constants
+    rpc_m_c = rpc_measure_constants.RPCMeasureConstants()
+
+    """
+    RPC Client Cumulative Views
+    """
+    # Default Views
+    # The following set of views are considered minimum
+    #  required to monitor client-side performance
+    grpc_client_sent_bytes_per_rpc_view = view.View(
+        name="grpc.io/client/sent_bytes_per_rpc",
+        description="Sent bytes per RPC",
+        columns=[rpc_m_c.grpc_client_method],
+        measure=rpc_m_c.grpc_client_sent_bytes_per_rpc,
+        aggregation=aggregation_with_bytes_histogram)
+
+    grpc_client_received_bytes_per_rpc_view = view.View(
+        name="grpc.io/client/received_bytes_per_rpc",
+        description="Received bytes per RPC",
+        columns=[rpc_m_c.grpc_client_method],
+        measure=rpc_m_c.grpc_client_received_bytes_per_rpc,
+        aggregation=aggregation_with_bytes_histogram)
+
+    grpc_client_roundtrip_latency_view = view.View(
+        name="grpc.io/client/roundtrip_latency",
+        description="Latency in msecs",
+        columns=[rpc_m_c.grpc_client_method],
+        measure=rpc_m_c.grpc_client_roundtrip_latency,
+        aggregation=aggregation_with_millis_histogram)
+
+    grpc_client_completed_rpc_view = view.View(
+        name="grpc.io/client/completed_rpcs",
+        description="Number of completed client RPCs",
+        columns=[rpc_m_c.grpc_client_method, rpc_m_c.grpc_client_status],
+        measure=rpc_m_c.grpc_client_roundtrip_latency,
+        aggregation=count)
+
+    grpc_client_started_rpc_view = view.View(
+        name="grpc.io/client/started_rpcs",
+        description="Number of started client RPCs",
+        columns=[rpc_m_c.grpc_client_method],
+        measure=rpc_m_c.grpc_client_started_rpcs,
+        aggregation=count)
+
+    # Extra Views
+    # The following set of views are considered useful
+    #  but not mandatory to monitor client side performance
+    grpc_client_sent_messages_per_rpc_view = view.View(
+        name="grpc.io/client/sent_messages_per_rpc",
+        description="Number of messages sent in the RPC",
+        columns=[rpc_m_c.grpc_client_method],
+        measure=rpc_m_c.grpc_client_sent_messages_per_rpc,
+        aggregation=aggregation_with_count_histogram)
+
+    grpc_client_received_messages_per_rpc_view = view.View(
+        name="grpc.io/client/received_messages_per_rpc",
+        description="Number of response messages received per RPC",
+        columns=[rpc_m_c.grpc_client_method],
+        measure=rpc_m_c.grpc_client_received_messages_per_rpc,
+        aggregation=aggregation_with_count_histogram)
+
+    grpc_client_server_latency_view = view.View(
+        name="grpc.io/client/server_latency",
+        description="Server latency in msecs",
+        columns=[rpc_m_c.grpc_client_method],
+        measure=rpc_m_c.grpc_client_server_latency,
+        aggregation=aggregation_with_millis_histogram)
+
+    grpc_client_sent_messages_per_method_view = view.View(
+        name="grpc.io/client/sent_messages_per_method",
+        description="Number of messages sent",
+        columns=[rpc_m_c.grpc_client_method],
+        measure=rpc_m_c.grpc_client_sent_messages_per_method,
+        aggregation=count)
+
+    grpc_client_received_messages_per_method_view = view.View(
+        name="grpc.io/client/received_messages_per_method",
+        description="Number of messages received",
+        columns=[rpc_m_c.grpc_client_method],
+        measure=rpc_m_c.grpc_client_received_messages_per_method,
+        aggregation=count)
+    grpc_client_sent_bytes_per_method_view = view.View(
+        name="grpc.io/client/sent_bytes_per_method",
+        description="Sent bytes per method",
+        columns=[rpc_m_c.grpc_client_method],
+        measure=rpc_m_c.grpc_client_sent_bytes_per_method,
+        aggregation=sum)
+
+    grpc_client_received_bytes_per_method_view = view.View(
+        name="grpc.io/client/received_bytes_per_method",
+        description="Received bytes per method",
+        columns=[rpc_m_c.grpc_client_method],
+        measure=rpc_m_c.grpc_client_received_bytes_per_method,
+        aggregation=sum)
+
+    """
+    RPC Server Cumulative Views
+    """
+    # Default Views
+    # The following set of views are considered minimum
+    #  required to monitor server-side performance
+    grpc_server_received_bytes_per_rpc = view.View(
+        name="grpc.io/server/received_bytes_per_rpc",
+        description="Received bytes per RPC",
+        columns=[rpc_m_c.grpc_server_method],
+        measure=rpc_m_c.grpc_server_received_bytes_per_rpc,
+        aggregation=sum)
+
+    grpc_server_sent_bytes_per_rpc = view.View(
+        name="grpc.io/server/sent_bytes_per_rpc",
+        description="Sent bytes per RPC",
+        columns=[rpc_m_c.grpc_server_method],
+        measure=rpc_m_c.grpc_server_sent_bytes_per_method,
+        aggregation=sum)
+
+    grpc_server_server_latency = view.View(
+        name="grpc.io/server/server_latency",
+        description="Latency in msecs",
+        columns=[rpc_m_c.grpc_server_method],
+        measure=rpc_m_c.grpc_server_server_latency,
+        aggregation=aggregation_with_millis_histogram)
+
+    grpc_server_completed_rpcs = view.View(
+        name="grpc.io/server/completed_rpcs",
+        description="Number of completed server RPCs",
+        columns=[rpc_m_c.grpc_server_method, rpc_m_c.grpc_server_status],
+        measure=rpc_m_c.grpc_server_server_latency,
+        aggregation=count)
+
+    grpc_server_started_rpcs = view.View(
+        name="grpc.io/server/started_rpcs",
+        description="Number of started server RPCs",
+        columns=[rpc_m_c.grpc_server_method],
+        measure=rpc_m_c.grpc_server_started_rpcs,
+        aggregation=count)
+
+
+    # Extra Views
+    # The following set of views are considered useful
+    #  but not mandatory to monitor server-side performance
+    grpc_server_received_messages_per_rpc = view.View(
+        name="grpc.io/server/received_messages_per_rpc",
+        description="Number of response messages received in each RPC",
+        columns=[rpc_m_c.grpc_server_method],
+        measure=rpc_m_c.grpc_server_received_messages_per_rpc,
+        aggregation=aggregation_with_count_histogram)
+
+    grpc_server_sent_messages_per_rpc = view.View(
+        name="grpc.io/server/sent_messages_per_rpc",
+        description="Number of messages sent in each RPC",
+        columns=[rpc_m_c.grpc_server_method],
+        measure=rpc_m_c.grpc_server_sent_messages_per_rpc,
+        aggregation=aggregation_with_count_histogram)
+
+    grpc_server_sent_messages_per_method = view.View(
+        name="grpc.io/server/sent_messages_per_method",
+        description="Number of messages sent",
+        columns=[rpc_m_c.grpc_server_method],
+        measure=rpc_m_c.grpc_server_sent_messages_per_method,
+        aggregation=count)
+
+    grpc_server_received_messages_per_method = view.View(
+        name="grpc.io/server/received_messages_per_method",
+        description="Number of messages received",
+        columns=[rpc_m_c.grpc_server_method],
+        measure=rpc_m_c.grpc_server_received_messages_per_method,
+        aggregation=count)
+
+    grpc_server_sent_bytes_per_method = view.View(
+        name="grpc.io/server/sent_bytes_per_method",
+        description="Sent bytes per method",
+        columns=[rpc_m_c.grpc_server_method],
+        measure=rpc_m_c.grpc_server_sent_bytes_per_method,
+        aggregation=sum)
+
+    grpc_server_received_bytes_per_method = view.View(
+        name="grpc.io/server/received_bytes_per_method",
+        description="Received bytes per method",
+        columns=[rpc_m_c.grpc_server_method],
+        measure=rpc_m_c.grpc_server_received_bytes_per_method,
+        aggregation=sum)


### PR DESCRIPTION
We (myself and @anamnavi) have been working on resolving issue #276 alongside Microsoft's Quantum Computing Team for code review, quality control, etc. in relation to RPC zpages written in Python.

As per the requirements of the opencensus [specs](https://github.com/census-instrumentation/opencensus-specs/blob/master/stats/gRPC.md) document, we implemented the RPC View and Measure Constants. You can find them within **opencensus/grpc** under the names **rpc_measure_constants.py** and **rpc_view_constants.py**. We have included test files under the names **rpc_m_c_test.py** and **rpc_v_c_test.py**, respectively.

For further inquiry, you can reach me at aasiyahf@gmail.com or anfeisal@ncsu.edu and @anamnavi at anam.naviyou@gmail.com or anavied@ncsu.edu.