### PR TITLE
Update async_.py

### DIFF
--- a/opencensus/common/transports/async_.py
+++ b/opencensus/common/transports/async_.py
@@ -145,6 +145,7 @@ class _Worker(object):
             # auto-collection.
             execution_context.set_is_exporter(True)
             self._thread.start()
+            execution_context.set_is_exporter(False)
             atexit.register(self._export_pending_data)
 
     def stop(self):


### PR DESCRIPTION
Addesses issue https://github.com/census-instrumentation/opencensus-python/issues/892. The cause of this issue was because when initializing the exporter thread, the context variable "is_exporter" is set to true (presumably to be passed onto the child thread) but not set to false again after its passed. This PR just sets it to false again.