### PR TITLE
Add support to initialize azure exporters with proxies

### DIFF
--- a/contrib/opencensus-ext-azure/CHANGELOG.md
+++ b/contrib/opencensus-ext-azure/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Change default path of local storage
   ([#903](https://github.com/census-instrumentation/opencensus-python/pull/903))
+- Add support to initialize azure exporters with proxies
+  ([#902](https://github.com/census-instrumentation/opencensus-python/pull/902))
 
 ## 1.0.1
 Released 2019-11-26

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
@@ -56,6 +56,9 @@ def process_options(options):
                 TEMPDIR_PREFIX + TEMPDIR_SUFFIX
             )
 
+    if options.proxies is None:
+        options.proxies = '{}'
+
 
 def parse_connection_string(connection_string):
     if connection_string is None:
@@ -105,7 +108,7 @@ class Options(BaseObject):
         logging_sampling_rate=1.0,
         max_batch_size=100,
         minimum_retry_interval=60,  # minimum retry interval in seconds
-        proxy=None,
+        proxies=None,  # string maps url schemes to the url of the proxies
         storage_maintenance_period=60,
         storage_max_size=50*1024*1024,  # 50MiB
         storage_path=None,

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/transport.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/transport.py
@@ -52,6 +52,7 @@ class TransportMixin(object):
                     'Content-Type': 'application/json; charset=utf-8',
                 },
                 timeout=self.options.timeout,
+                proxies=json.loads(self.options.proxies),
             )
         except requests.Timeout:
             logger.warning(

--- a/contrib/opencensus-ext-azure/tests/test_azure_log_exporter.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_log_exporter.py
@@ -85,6 +85,17 @@ class TestAzureLogHandler(unittest.TestCase):
                 logging_sampling_rate=4.0,
             )
 
+    def test_init_handler_with_proxies(self):
+        handler = log_exporter.AzureLogHandler(
+            instrumentation_key='12345678-1234-5678-abcd-12345678abcd',
+            proxies='{"https":"https://test-proxy.com"}',
+        )
+
+        self.assertEqual(
+            handler.options.proxies,
+            '{"https":"https://test-proxy.com"}',
+        )
+
     @mock.patch('requests.post', return_value=mock.Mock())
     def test_exception(self, requests_mock):
         logger = logging.getLogger(self.id())

--- a/contrib/opencensus-ext-azure/tests/test_azure_trace_exporter.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_trace_exporter.py
@@ -45,6 +45,17 @@ class TestAzureExporter(unittest.TestCase):
         self.assertRaises(ValueError, lambda: trace_exporter.AzureExporter())
         Options._default.instrumentation_key = instrumentation_key
 
+    def test_init_exporter_with_proxies(self):
+        exporter = trace_exporter.AzureExporter(
+            instrumentation_key='12345678-1234-5678-abcd-12345678abcd',
+            proxies='{"https":"https://test-proxy.com"}',
+        )
+
+        self.assertEqual(
+            exporter.options.proxies,
+            '{"https":"https://test-proxy.com"}',
+        )
+
     @mock.patch('requests.post', return_value=mock.Mock())
     def test_emit_empty(self, request_mock):
         exporter = trace_exporter.AzureExporter(

--- a/contrib/opencensus-ext-azure/tests/test_options.py
+++ b/contrib/opencensus-ext-azure/tests/test_options.py
@@ -90,6 +90,24 @@ class TestOptions(unittest.TestCase):
         self.assertEqual(options.endpoint,
                          'https://dc.services.visualstudio.com/v2/track')
 
+    def test_process_options_proxies_default(self):
+        options = common.Options()
+        options.proxies = "{}"
+        common.process_options(options)
+
+        self.assertEqual(options.proxies, "{}")
+
+    def test_process_options_proxies_set_proxies(self):
+        options = common.Options()
+        options.connection_string = None
+        options.proxies = '{"https": "https://test-proxy.com"}'
+        common.process_options(options)
+
+        self.assertEqual(
+            options.proxies,
+            '{"https": "https://test-proxy.com"}'
+        )
+
     def test_parse_connection_string_none(self):
         cs = None
         result = common.parse_connection_string(cs)


### PR DESCRIPTION
Context:
Proxy functionality when instantiating azure exporters is currently unsupported so I had created issue https://github.com/census-instrumentation/opencensus-python/issues/896. To expedite this feature request, I created this PR which supports posting requests with proxies that are passed in. 

Testing:
* Tested locally to ensure proxy options were set. 
* Tested using nox 3.6 - all tests pass. Note that there are existing linting issues for files unrelated to this PR. To decouple changes, I did not address them in the PR. However, I can fix those linting issues if the maintainers prefer that in this PR. 
![flake_8_error](https://user-images.githubusercontent.com/4870764/84331978-95573b00-ab40-11ea-853e-5e92243ecfcc.png)

* Nox status
```
nox > Session docs was successful.
nox > Ran multiple sessions:
nox > * unit-2.7: failed
nox > * unit-3.5: success
nox > * unit-3.6: success
nox > * system-2.7: skipped
nox > * system-3.6: skipped
nox > * lint: failed
nox > * lint_setup_py: success
nox > * docs: success
```

Additional Notes:
* Running nox with python 2.7 fails on my computer when trying to install `contrib/opencensus-ext-grpc` - I'm still troubleshooting that but wanted to create this PR as it's been tested with python3 at least. If the maintainers could help run this PR on their local machine with nox to ensure python2 compatibility that would be super appreciated as well. 
