### PR TITLE
Update async_.py

### DIFF
--- a/opencensus/common/transports/async_.py
+++ b/opencensus/common/transports/async_.py
@@ -92,6 +92,7 @@ class _Worker(object):
         Pulls pending data off the queue and writes them in
         batches to the specified tracing backend using the exporter.
         """
+        execution_context.set_is_exporter(True)
         quit_ = False
 
         while True:
@@ -143,7 +144,6 @@ class _Worker(object):
             self._thread.daemon = True
             # Indicate that this thread is an exporter thread. Used for
             # auto-collection.
-            execution_context.set_is_exporter(True)
             self._thread.start()
             atexit.register(self._export_pending_data)
 


### PR DESCRIPTION
Addesses issue #892. The cause of this issue was because when initializing the exporter thread, the context variable "is_exporter" is set to true (presumably to be passed onto the child thread) but not set to false again after its passed. This PR just sets it to false again.