### PR TITLE
Changing default transport for stackdriver exporter

### DIFF
--- a/contrib/opencensus-ext-stackdriver/CHANGELOG.md
+++ b/contrib/opencensus-ext-stackdriver/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+  - Change default transporter in stackdriver exporter
+  ([#929](https://github.com/census-instrumentation/opencensus-python/pull/929))
 
   - Add mean property for distribution values
   ([#919](https://github.com/census-instrumentation/opencensus-python/pull/919))

--- a/contrib/opencensus-ext-stackdriver/README.rst
+++ b/contrib/opencensus-ext-stackdriver/README.rst
@@ -35,7 +35,7 @@ This example shows how to report the traces to Stackdriver Trace:
     pip install google-cloud-trace
     pipenv install google-cloud-trace
 
-By default, traces are exported asynchronously, to avoid latency during
+By default, traces are exported asynchronously, to reduce latency during
 your code's execution. If you would like to export data on the main thread
 use the synchronous transporter:
 

--- a/contrib/opencensus-ext-stackdriver/README.rst
+++ b/contrib/opencensus-ext-stackdriver/README.rst
@@ -35,20 +35,19 @@ This example shows how to report the traces to Stackdriver Trace:
     pip install google-cloud-trace
     pipenv install google-cloud-trace
 
-By default, traces are exported synchronously, which introduces latency during
-your code's execution. To avoid blocking code execution, you can initialize
-your exporter to use a background thread.
+By default, traces are exported asynchronously, to avoid latency during
+your code's execution. If you would like to export data on the main thread
+use the synchronous transporter:
 
-This example shows how to configure OpenCensus to use a background thread:
 
 .. code:: python
 
-    from opencensus.common.transports.async_ import AsyncTransport
+    from opencensus.common.transports.sync import SyncTransport
     from opencensus.ext.stackdriver import trace_exporter as stackdriver_exporter
     from opencensus.trace import tracer as tracer_module
 
     exporter = stackdriver_exporter.StackdriverExporter(
-        project_id='your_cloud_project', transport=AsyncTransport)
+        project_id='your_cloud_project', transport=SyncTransport)
     tracer = tracer_module.Tracer(exporter=exporter)
 
 Stats

--- a/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/trace_exporter/__init__.py
@@ -23,7 +23,7 @@ from opencensus.common.monitored_resource import (
     k8s_utils,
     monitored_resource,
 )
-from opencensus.common.transports import sync
+from opencensus.common.transports.async_ import AsyncTransport
 from opencensus.common.version import __version__
 from opencensus.trace import attributes_helper, base_exporter, span_data
 from opencensus.trace.attributes import Attributes
@@ -180,7 +180,7 @@ class StackdriverExporter(base_exporter.Exporter):
     """
 
     def __init__(self, client=None, project_id=None,
-                 transport=sync.SyncTransport):
+                 transport=AsyncTransport):
         # The client will handle the case when project_id is None
         if client is None:
             client = Client(project=project_id)

--- a/opencensus/trace/span.py
+++ b/opencensus/trace/span.py
@@ -370,7 +370,7 @@ class Span(base_span.BaseSpan):
 
     def __iter__(self):
         """Iterate through the span tree."""
-        for span in chain(*(map(iter, self.children))):
+        for span in chain.from_iterable(map(iter, self.children)):
             yield span
         yield self
 


### PR DESCRIPTION
Changing default transporter to async as sync leads to latency issues. In addition will allow GCP Cloud Run clients to leverage atexit abilities of async exporter. Also addresses the following issue:
https://github.com/census-instrumentation/opencensus-python/issues/927

(This issue is addressed in two PR's. One for setting the default trace processor and the other for adding atexit handlers in the metrics exporter).