### PR TITLE
Attach rate metrics via Heartbeat for Azure exporter

### DIFF
--- a/contrib/opencensus-ext-azure/examples/traces/simple.py
+++ b/contrib/opencensus-ext-azure/examples/traces/simple.py
@@ -23,3 +23,4 @@ tracer = Tracer(exporter=AzureExporter(), sampler=ProbabilitySampler(1.0))
 
 with tracer.span(name='foo'):
     print('Hello, World!')
+input(...)

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/exporter.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/exporter.py
@@ -62,7 +62,7 @@ class Worker(threading.Thread):
         self.dst = dst
         self._stopping = False
         super(Worker, self).__init__(
-            name="Trace Exporter Worker"
+            name="AzureExporter Worker"
         )
 
     def run(self):  # pragma: NO COVER

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/exporter.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/exporter.py
@@ -61,7 +61,9 @@ class Worker(threading.Thread):
         self.src = src
         self.dst = dst
         self._stopping = False
-        super(Worker, self).__init__()
+        super(Worker, self).__init__(
+            name="Trace Exporter Worker"
+        )
 
     def run(self):  # pragma: NO COVER
         # Indicate that this thread is an exporter thread.

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
@@ -81,6 +81,7 @@ class LocalFileStorage(object):
             maintenance_period=60,  # 1 minute
             retention_period=7*24*60*60,  # 7 days
             write_timeout=60,  # 1 minute
+            source=None,
     ):
         self.path = os.path.abspath(path)
         self.max_size = max_size
@@ -92,6 +93,7 @@ class LocalFileStorage(object):
         self._maintenance_task = PeriodicTask(
             interval=self.maintenance_period,
             function=self._maintenance_routine,
+            name='{} Storage Worker'.format(source)
         )
         self._maintenance_task.daemon = True
         self._maintenance_task.start()

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/__init__.py
@@ -153,5 +153,7 @@ def new_metrics_exporter(**options):
                                   interval=exporter.options.export_interval)
     from opencensus.ext.azure.metrics_exporter import heartbeat_metrics
     heartbeat_metrics.enable_heartbeat_metrics(
-            exporter.options.connection_string, exporter.options.instrumentation_key)
+        exporter.options.connection_string,
+        exporter.options.instrumentation_key
+    )
     return exporter

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/__init__.py
@@ -151,7 +151,7 @@ def new_metrics_exporter(**options):
     transport.get_exporter_thread(producers,
                                   exporter,
                                   interval=exporter.options.export_interval)
-    # from opencensus.ext.azure.metrics_exporter import heartbeat_metrics
-    # heartbeat_metrics.enable_heartbeat_metrics(
-    #         exporter.options.connection_string, exporter.options.instrumentation_key)
+    from opencensus.ext.azure.metrics_exporter import heartbeat_metrics
+    heartbeat_metrics.enable_heartbeat_metrics(
+            exporter.options.connection_string, exporter.options.instrumentation_key)
     return exporter

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/__init__.py
@@ -52,7 +52,9 @@ class MetricsExporter(TransportMixin, ProcessorMixin):
             max_size=self.options.storage_max_size,
             maintenance_period=self.options.storage_maintenance_period,
             retention_period=self.options.storage_retention_period,
+            source=self.__class__.__name__,
         )
+        self._atexit_handler = atexit.register(self.shutdown)
         super(MetricsExporter, self).__init__()
 
     def export_metrics(self, metrics):
@@ -133,6 +135,13 @@ class MetricsExporter(TransportMixin, ProcessorMixin):
         envelope.data = Data(baseData=data, baseType="MetricData")
         return envelope
 
+    def shutdown(self):
+        # flush metrics on exit
+        self.export_metrics(stats_module.stats.get_metrics())
+        if self._atexit_handler is not None:
+            atexit.unregister(self._atexit_handler)
+            self._atexit_handler = None
+
 
 def new_metrics_exporter(**options):
     exporter = MetricsExporter(**options)
@@ -142,5 +151,7 @@ def new_metrics_exporter(**options):
     transport.get_exporter_thread(producers,
                                   exporter,
                                   interval=exporter.options.export_interval)
-    atexit.register(exporter.export_metrics, stats_module.stats.get_metrics())
+    # from opencensus.ext.azure.metrics_exporter import heartbeat_metrics
+    # heartbeat_metrics.enable_heartbeat_metrics(
+    #         exporter.options.connection_string, exporter.options.instrumentation_key)
     return exporter

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/__init__.py
@@ -25,6 +25,7 @@ from opencensus.metrics.export.metric_producer import MetricProducer
 _HEARTBEAT_METRICS = None
 _HEARTBEAT_LOCK = threading.Lock()
 
+
 def enable_heartbeat_metrics(connection_string, ikey):
     with _HEARTBEAT_LOCK:
         # Only start heartbeat if did not exist before
@@ -40,6 +41,7 @@ def enable_heartbeat_metrics(connection_string, ikey):
             transport.get_exporter_thread([_HEARTBEAT_METRICS],
                                           exporter,
                                           exporter.options.export_interval)
+
 
 def register_metrics():
     registry = Registry()

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/__init__.py
@@ -31,7 +31,7 @@ def enable_heartbeat_metrics(connection_string, ikey):
             exporter = MetricsExporter(
                 connection_string=connection_string,
                 instrumentation_key=ikey,
-                export_interval=2
+                export_interval=900.0,  # Send every 15 minutes
             )
             producer = AzureHeartbeatMetricsProducer()
             _HEARTBEAT_METRICS = producer

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/__init__.py
@@ -15,7 +15,9 @@
 import threading
 
 from opencensus.ext.azure.metrics_exporter import MetricsExporter
-from opencensus.ext.azure.metrics_exporter.heartbeat_metrics.heartbeat import HeartbeatMetric
+from opencensus.ext.azure.metrics_exporter.heartbeat_metrics.heartbeat import (
+    HeartbeatMetric,
+)
 from opencensus.metrics import transport
 from opencensus.metrics.export.gauge import Registry
 from opencensus.metrics.export.metric_producer import MetricProducer

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/__init__.py
@@ -1,0 +1,58 @@
+# Copyright 2020, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import threading
+
+from opencensus.ext.azure.metrics_exporter import MetricsExporter
+from opencensus.ext.azure.metrics_exporter.heartbeat_metrics.heartbeat import HeartbeatMetric
+from opencensus.metrics import transport
+from opencensus.metrics.export.gauge import Registry
+from opencensus.metrics.export.metric_producer import MetricProducer
+
+_HEARTBEAT_METRICS = None
+_HEARTBEAT_LOCK = threading.Lock()
+
+def enable_heartbeat_metrics(connection_string, ikey):
+    with _HEARTBEAT_LOCK:
+        # Only start heartbeat if did not exist before
+        global _HEARTBEAT_METRICS  # pylint: disable=global-statement
+        if _HEARTBEAT_METRICS is None:
+            exporter = MetricsExporter(
+                connection_string=connection_string,
+                instrumentation_key=ikey,
+                export_interval=2
+            )
+            producer = AzureHeartbeatMetricsProducer()
+            _HEARTBEAT_METRICS = producer
+            transport.get_exporter_thread([_HEARTBEAT_METRICS],
+                                          exporter,
+                                          exporter.options.export_interval)
+
+def register_metrics():
+    registry = Registry()
+    metric = HeartbeatMetric()
+    registry.add_gauge(metric())
+    return registry
+
+
+class AzureHeartbeatMetricsProducer(MetricProducer):
+    """Implementation of the producer of heartbeat metrics.
+
+    Includes Azure attach rate metrics, implemented using gauges.
+    """
+    def __init__(self):
+        self.registry = register_metrics()
+
+    def get_metrics(self):
+        return self.registry.get_metrics()

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/heartbeat.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/heartbeat.py
@@ -14,13 +14,14 @@
 
 import os
 import platform
-
 from collections import OrderedDict
+
 from opencensus.common.version import __version__ as opencensus_version
 from opencensus.ext.azure.common.version import __version__ as ext_version
 from opencensus.metrics.export.gauge import LongGauge
 from opencensus.metrics.label_key import LabelKey
 from opencensus.metrics.label_value import LabelValue
+
 
 class HeartbeatMetric:
     NAME = "Heartbeat"

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/heartbeat.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/heartbeat.py
@@ -23,7 +23,7 @@ from opencensus.metrics.label_key import LabelKey
 from opencensus.metrics.label_value import LabelValue
 
 class HeartbeatMetric:
-    NAME = "Heartbeatz"
+    NAME = "Heartbeat"
 
     def __init__(self):
         self.properties = OrderedDict()

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/heartbeat.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/heartbeat.py
@@ -29,7 +29,7 @@ class HeartbeatMetric:
     def __init__(self):
         self.properties = OrderedDict()
         self.properties[LabelKey("sdk", '')] = LabelValue(
-                'py{}:oc{}:ext{}'.format(
+            'py{}:oc{}:ext{}'.format(
                 platform.python_version(),
                 opencensus_version,
                 ext_version,
@@ -37,11 +37,15 @@ class HeartbeatMetric:
         )
         self.properties[LabelKey("osType", '')] = LabelValue(platform.system())
         if os.environ.get("WEBSITE_SITE_NAME") is not None:  # Web apps
-            self.properties[LabelKey("appSrv_SiteName", '')] = LabelValue(os.environ.get("WEBSITE_SITE_NAME"))
-            self.properties[LabelKey("appSrv_wsStamp", '')] = LabelValue(os.environ.get("WEBSITE_HOME_STAMPNAME", ''))
-            self.properties[LabelKey("appSrv_wsHost", '')] = LabelValue(os.environ.get("WEBSITE_HOSTNAME", ''))
+            self.properties[LabelKey("appSrv_SiteName", '')] = \
+            LabelValue(os.environ.get("WEBSITE_SITE_NAME"))
+            self.properties[LabelKey("appSrv_wsStamp", '')] = \
+            LabelValue(os.environ.get("WEBSITE_HOME_STAMPNAME", ''))
+            self.properties[LabelKey("appSrv_wsHost", '')] = \
+                LabelValue(os.environ.get("WEBSITE_HOSTNAME", ''))
         elif os.environ.get("FUNCTIONS_WORKER_RUNTIME") is not None:  # Function apps
-            self.properties[LabelKey("azfunction_appId", '')] = LabelValue(os.environ.get("WEBSITE_HOSTNAME"))
+            self.properties[LabelKey("azfunction_appId", '')] = \
+                LabelValue(os.environ.get("WEBSITE_HOSTNAME"))
 
     def __call__(self):
         """ Returns a derived gauge for the heartbeat metric.

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/heartbeat.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/heartbeat.py
@@ -23,7 +23,7 @@ from opencensus.metrics.label_key import LabelKey
 from opencensus.metrics.label_value import LabelValue
 
 class HeartbeatMetric:
-    NAME = "Heartbeat"
+    NAME = "Heartbeatz"
 
     def __init__(self):
         self.properties = OrderedDict()
@@ -35,12 +35,12 @@ class HeartbeatMetric:
             )
         )
         self.properties[LabelKey("osType", '')] = LabelValue(platform.system())
-        if os.environ.get("WEBSITE_SITE_NAME")is not None:  # Web apps
+        if os.environ.get("WEBSITE_SITE_NAME") is not None:  # Web apps
             self.properties[LabelKey("appSrv_SiteName", '')] = LabelValue(os.environ.get("WEBSITE_SITE_NAME"))
             self.properties[LabelKey("appSrv_wsStamp", '')] = LabelValue(os.environ.get("WEBSITE_HOME_STAMPNAME", ''))
             self.properties[LabelKey("appSrv_wsHost", '')] = LabelValue(os.environ.get("WEBSITE_HOSTNAME", ''))
-        else:
-            self.properties[LabelKey("test", '')] = LabelValue("test_value")
+        elif os.environ.get("FUNCTIONS_WORKER_RUNTIME") is not None:  # Function apps
+            self.properties[LabelKey("azfunction_appId", '')] = LabelValue(os.environ.get("WEBSITE_HOSTNAME"))
 
     def __call__(self):
         """ Returns a derived gauge for the heartbeat metric.

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/heartbeat.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/heartbeat.py
@@ -36,14 +36,16 @@ class HeartbeatMetric:
             )
         )
         self.properties[LabelKey("osType", '')] = LabelValue(platform.system())
-        if os.environ.get("WEBSITE_SITE_NAME") is not None:  # Web apps
+        if os.environ.get("WEBSITE_SITE_NAME") is not None:
+            # Web apps
             self.properties[LabelKey("appSrv_SiteName", '')] = \
-            LabelValue(os.environ.get("WEBSITE_SITE_NAME"))
+                LabelValue(os.environ.get("WEBSITE_SITE_NAME"))
             self.properties[LabelKey("appSrv_wsStamp", '')] = \
-            LabelValue(os.environ.get("WEBSITE_HOME_STAMPNAME", ''))
+                LabelValue(os.environ.get("WEBSITE_HOME_STAMPNAME", ''))
             self.properties[LabelKey("appSrv_wsHost", '')] = \
                 LabelValue(os.environ.get("WEBSITE_HOSTNAME", ''))
-        elif os.environ.get("FUNCTIONS_WORKER_RUNTIME") is not None:  # Function apps
+        elif os.environ.get("FUNCTIONS_WORKER_RUNTIME") is not None:
+            # Function apps
             self.properties[LabelKey("azfunction_appId", '')] = \
                 LabelValue(os.environ.get("WEBSITE_HOSTNAME"))
 

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/heartbeat.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/heartbeat.py
@@ -1,0 +1,57 @@
+# Copyright 2019, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import platform
+
+from collections import OrderedDict
+from opencensus.common.version import __version__ as opencensus_version
+from opencensus.ext.azure.common.version import __version__ as ext_version
+from opencensus.metrics.export.gauge import LongGauge
+from opencensus.metrics.label_key import LabelKey
+from opencensus.metrics.label_value import LabelValue
+
+class HeartbeatMetric:
+    NAME = "Heartbeat"
+
+    def __init__(self):
+        self.properties = OrderedDict()
+        self.properties[LabelKey("sdk", '')] = LabelValue(
+                'py{}:oc{}:ext{}'.format(
+                platform.python_version(),
+                opencensus_version,
+                ext_version,
+            )
+        )
+        self.properties[LabelKey("osType", '')] = LabelValue(platform.system())
+        if os.environ.get("WEBSITE_SITE_NAME")is not None:  # Web apps
+            self.properties[LabelKey("appSrv_SiteName", '')] = LabelValue(os.environ.get("WEBSITE_SITE_NAME"))
+            self.properties[LabelKey("appSrv_wsStamp", '')] = LabelValue(os.environ.get("WEBSITE_HOME_STAMPNAME", ''))
+            self.properties[LabelKey("appSrv_wsHost", '')] = LabelValue(os.environ.get("WEBSITE_HOSTNAME", ''))
+        else:
+            self.properties[LabelKey("test", '')] = LabelValue("test_value")
+
+    def __call__(self):
+        """ Returns a derived gauge for the heartbeat metric.
+
+        :rtype: :class:`opencensus.metrics.export.gauge.LongGauge`
+        :return: The gauge representing the heartbeat metric
+        """
+        gauge = LongGauge(
+            HeartbeatMetric.NAME,
+            'Heartbeat metric with custom dimensions',
+            'count',
+            list(self.properties.keys()))
+        gauge.get_or_create_time_series(list(self.properties.values()))
+        return gauge

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/trace_exporter/__init__.py
@@ -26,6 +26,7 @@ from opencensus.ext.azure.common.protocol import (
 )
 from opencensus.ext.azure.common.storage import LocalFileStorage
 from opencensus.ext.azure.common.transport import TransportMixin
+from opencensus.ext.azure.metrics_exporter import heartbeat_metrics
 from opencensus.trace.span import SpanKind
 
 try:
@@ -52,7 +53,10 @@ class AzureExporter(BaseExporter, ProcessorMixin, TransportMixin):
             max_size=self.options.storage_max_size,
             maintenance_period=self.options.storage_maintenance_period,
             retention_period=self.options.storage_retention_period,
+            source=self.__class__.__name__,
         )
+        heartbeat_metrics.enable_heartbeat_metrics(
+            self.options.connection_string, self.options.instrumentation_key)
         self._telemetry_processors = []
         super(AzureExporter, self).__init__(**options)
 

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/trace_exporter/__init__.py
@@ -55,10 +55,10 @@ class AzureExporter(BaseExporter, ProcessorMixin, TransportMixin):
             retention_period=self.options.storage_retention_period,
             source=self.__class__.__name__,
         )
-        heartbeat_metrics.enable_heartbeat_metrics(
-            self.options.connection_string, self.options.instrumentation_key)
         self._telemetry_processors = []
         super(AzureExporter, self).__init__(**options)
+        heartbeat_metrics.enable_heartbeat_metrics(
+            self.options.connection_string, self.options.instrumentation_key)
 
     def span_data_to_envelope(self, sd):
         envelope = Envelope(

--- a/contrib/opencensus-ext-azure/tests/test_azure_heartbeat_metrics.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_heartbeat_metrics.py
@@ -1,0 +1,155 @@
+# Copyright 2019, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import platform
+import unittest
+
+import mock
+
+from opencensus.common.version import __version__ as opencensus_version
+from opencensus.ext.azure.common.version import __version__ as ext_version
+from opencensus.ext.azure.metrics_exporter import heartbeat_metrics
+from opencensus.metrics.label_key import LabelKey
+from opencensus.metrics.label_value import LabelValue
+
+
+class TestHeartbeatMetrics(unittest.TestCase):
+    def setUp(self):
+        # pylint: disable=protected-access
+        heartbeat_metrics._HEARTBEAT_METRICS = None
+
+
+    @mock.patch('opencensus.ext.azure.metrics_exporter'
+                '.heartbeat_metrics.register_metrics')
+    def test_producer_ctor(self, avail_mock):
+        heartbeat_metrics.AzureHeartbeatMetricsProducer()
+
+        self.assertEqual(len(avail_mock.call_args_list), 1)
+
+    def test_producer_get_metrics(self):
+        producer = heartbeat_metrics.AzureHeartbeatMetricsProducer()
+        metrics = producer.get_metrics()
+
+        self.assertEqual(len(metrics), 1)
+
+    def test_register_metrics(self):
+        registry = heartbeat_metrics.register_metrics()
+
+        self.assertEqual(len(registry.get_metrics()), 1)
+
+    @mock.patch('opencensus.metrics.transport.get_exporter_thread')
+    def test_enable_heartbeat_metrics(self, transport_mock):
+        ikey = '12345678-1234-5678-abcd-12345678abcd'
+        # pylint: disable=protected-access
+        self.assertIsNone(heartbeat_metrics._HEARTBEAT_METRICS)
+        heartbeat_metrics.enable_heartbeat_metrics(None, ikey)
+        self.assertTrue(isinstance(heartbeat_metrics._HEARTBEAT_METRICS,
+                                   heartbeat_metrics.AzureHeartbeatMetricsProducer))
+        transport_mock.assert_called()
+
+    @mock.patch('opencensus.metrics.transport.get_exporter_thread')
+    def test_enable_heartbeat_metrics_exits(self, transport_mock):
+        # pylint: disable=protected-access
+        producer = heartbeat_metrics.AzureHeartbeatMetricsProducer()
+        heartbeat_metrics._HEARTBEAT_METRICS = producer
+        heartbeat_metrics.enable_heartbeat_metrics(None, None)
+        self.assertEqual(heartbeat_metrics._HEARTBEAT_METRICS, producer)
+        transport_mock.assert_not_called()
+
+    def test_heartbeat_metric_init(self):
+        metric = heartbeat_metrics.HeartbeatMetric()
+
+        self.assertEqual(metric.NAME, 'Heartbeat')
+        keys = list(metric.properties.keys())
+        values = list(metric.properties.values())
+        self.assertEqual(len(keys), 2)
+        self.assertEqual(len(keys), len(values))
+        self.assertEqual(keys[0].key, "sdk")
+        self.assertEqual(keys[1].key, "osType")
+        self.assertEqual(values[0].value, 'py{}:oc{}:ext{}'.format(
+                platform.python_version(),
+                opencensus_version,
+                ext_version,
+            ))
+        self.assertEqual(values[1].value, platform.system())
+
+    @mock.patch.dict(os.environ,
+        {
+            "WEBSITE_SITE_NAME": "site_name",
+            "WEBSITE_HOME_STAMPNAME": "stamp_name",
+            "WEBSITE_HOSTNAME": "host_name",
+        }
+    )
+    def test_heartbeat_metric_init_webapp(self):
+        metric = heartbeat_metrics.HeartbeatMetric()
+
+        self.assertEqual(metric.NAME, 'Heartbeat')
+        keys = list(metric.properties.keys())
+        values = list(metric.properties.values())
+        self.assertEqual(len(keys), 5)
+        self.assertEqual(len(keys), len(values))
+        self.assertEqual(keys[0].key, "sdk")
+        self.assertEqual(keys[1].key, "osType")
+        self.assertEqual(values[0].value, 'py{}:oc{}:ext{}'.format(
+                platform.python_version(),
+                opencensus_version,
+                ext_version,
+            ))
+        self.assertEqual(values[1].value, platform.system())
+        self.assertEqual(keys[2].key, "appSrv_SiteName")
+        self.assertEqual(keys[3].key, "appSrv_wsStamp")
+        self.assertEqual(keys[4].key, "appSrv_wsHost")
+        self.assertEqual(values[2].value, "site_name")
+        self.assertEqual(values[3].value, "stamp_name")
+        self.assertEqual(values[4].value, "host_name")
+
+    @mock.patch.dict(os.environ,
+        {
+            "FUNCTIONS_WORKER_RUNTIME": "python",
+            "WEBSITE_HOSTNAME": "host_name",
+        }
+    )
+    def test_heartbeat_metric_init_functionapp(self):
+        metric = heartbeat_metrics.HeartbeatMetric()
+
+        self.assertEqual(metric.NAME, 'Heartbeat')
+        keys = list(metric.properties.keys())
+        values = list(metric.properties.values())
+        self.assertEqual(len(keys), 3)
+        self.assertEqual(len(keys), len(values))
+        self.assertEqual(keys[0].key, "sdk")
+        self.assertEqual(keys[1].key, "osType")
+        self.assertEqual(values[0].value, 'py{}:oc{}:ext{}'.format(
+                platform.python_version(),
+                opencensus_version,
+                ext_version,
+            ))
+        self.assertEqual(values[1].value, platform.system())
+        self.assertEqual(keys[2].key, "azfunction_appId")
+        self.assertEqual(values[2].value, "host_name")
+ 
+    def test_heartbeat_metric(self):
+        metric = heartbeat_metrics.HeartbeatMetric()
+        gauge = metric()
+
+        self.assertEqual(gauge.descriptor.name, 'Heartbeat')
+        self.assertEqual(gauge.descriptor.description,
+            'Heartbeat metric with custom dimensions')
+        self.assertEqual(gauge.descriptor.unit, 'count')
+        self.assertEqual(gauge.descriptor._type, 1)
+        self.assertEqual(gauge.descriptor.label_keys,
+            list(metric.properties.keys()))
+        self.assertEqual(gauge._len_label_keys,
+            len(metric.properties.keys()))

--- a/contrib/opencensus-ext-azure/tests/test_azure_heartbeat_metrics.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_heartbeat_metrics.py
@@ -21,15 +21,12 @@ import mock
 from opencensus.common.version import __version__ as opencensus_version
 from opencensus.ext.azure.common.version import __version__ as ext_version
 from opencensus.ext.azure.metrics_exporter import heartbeat_metrics
-from opencensus.metrics.label_key import LabelKey
-from opencensus.metrics.label_value import LabelValue
 
 
 class TestHeartbeatMetrics(unittest.TestCase):
     def setUp(self):
         # pylint: disable=protected-access
         heartbeat_metrics._HEARTBEAT_METRICS = None
-
 
     @mock.patch('opencensus.ext.azure.metrics_exporter'
                 '.heartbeat_metrics.register_metrics')
@@ -55,8 +52,12 @@ class TestHeartbeatMetrics(unittest.TestCase):
         # pylint: disable=protected-access
         self.assertIsNone(heartbeat_metrics._HEARTBEAT_METRICS)
         heartbeat_metrics.enable_heartbeat_metrics(None, ikey)
-        self.assertTrue(isinstance(heartbeat_metrics._HEARTBEAT_METRICS,
-                                   heartbeat_metrics.AzureHeartbeatMetricsProducer))
+        self.assertTrue(
+            isinstance(
+                heartbeat_metrics._HEARTBEAT_METRICS,
+                heartbeat_metrics.AzureHeartbeatMetricsProducer
+            )
+        )
         transport_mock.assert_called()
 
     @mock.patch('opencensus.metrics.transport.get_exporter_thread')
@@ -79,10 +80,10 @@ class TestHeartbeatMetrics(unittest.TestCase):
         self.assertEqual(keys[0].key, "sdk")
         self.assertEqual(keys[1].key, "osType")
         self.assertEqual(values[0].value, 'py{}:oc{}:ext{}'.format(
-                platform.python_version(),
-                opencensus_version,
-                ext_version,
-            ))
+            platform.python_version(),
+            opencensus_version,
+            ext_version,
+        ))
         self.assertEqual(values[1].value, platform.system())
 
     @mock.patch.dict(os.environ,
@@ -103,10 +104,10 @@ class TestHeartbeatMetrics(unittest.TestCase):
         self.assertEqual(keys[0].key, "sdk")
         self.assertEqual(keys[1].key, "osType")
         self.assertEqual(values[0].value, 'py{}:oc{}:ext{}'.format(
-                platform.python_version(),
-                opencensus_version,
-                ext_version,
-            ))
+            platform.python_version(),
+            opencensus_version,
+            ext_version,
+        ))
         self.assertEqual(values[1].value, platform.system())
         self.assertEqual(keys[2].key, "appSrv_SiteName")
         self.assertEqual(keys[3].key, "appSrv_wsStamp")
@@ -132,15 +133,16 @@ class TestHeartbeatMetrics(unittest.TestCase):
         self.assertEqual(keys[0].key, "sdk")
         self.assertEqual(keys[1].key, "osType")
         self.assertEqual(values[0].value, 'py{}:oc{}:ext{}'.format(
-                platform.python_version(),
-                opencensus_version,
-                ext_version,
-            ))
+            platform.python_version(),
+            opencensus_version,
+            ext_version,
+        ))
         self.assertEqual(values[1].value, platform.system())
         self.assertEqual(keys[2].key, "azfunction_appId")
         self.assertEqual(values[2].value, "host_name")
- 
+
     def test_heartbeat_metric(self):
+        # pylint: disable=protected-access
         metric = heartbeat_metrics.HeartbeatMetric()
         gauge = metric()
 
@@ -149,7 +151,11 @@ class TestHeartbeatMetrics(unittest.TestCase):
             'Heartbeat metric with custom dimensions')
         self.assertEqual(gauge.descriptor.unit, 'count')
         self.assertEqual(gauge.descriptor._type, 1)
-        self.assertEqual(gauge.descriptor.label_keys,
-            list(metric.properties.keys()))
-        self.assertEqual(gauge._len_label_keys,
-            len(metric.properties.keys()))
+        self.assertEqual(
+            gauge.descriptor.label_keys,
+            list(metric.properties.keys())
+        )
+        self.assertEqual(
+            gauge._len_label_keys,
+            len(metric.properties.keys())
+        )

--- a/contrib/opencensus-ext-azure/tests/test_azure_heartbeat_metrics.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_heartbeat_metrics.py
@@ -86,7 +86,8 @@ class TestHeartbeatMetrics(unittest.TestCase):
         ))
         self.assertEqual(values[1].value, platform.system())
 
-    @mock.patch.dict(os.environ,
+    @mock.patch.dict(
+        os.environ,
         {
             "WEBSITE_SITE_NAME": "site_name",
             "WEBSITE_HOME_STAMPNAME": "stamp_name",
@@ -116,7 +117,8 @@ class TestHeartbeatMetrics(unittest.TestCase):
         self.assertEqual(values[3].value, "stamp_name")
         self.assertEqual(values[4].value, "host_name")
 
-    @mock.patch.dict(os.environ,
+    @mock.patch.dict(
+        os.environ,
         {
             "FUNCTIONS_WORKER_RUNTIME": "python",
             "WEBSITE_HOSTNAME": "host_name",
@@ -147,8 +149,10 @@ class TestHeartbeatMetrics(unittest.TestCase):
         gauge = metric()
 
         self.assertEqual(gauge.descriptor.name, 'Heartbeat')
-        self.assertEqual(gauge.descriptor.description,
-            'Heartbeat metric with custom dimensions')
+        self.assertEqual(
+            gauge.descriptor.description,
+            'Heartbeat metric with custom dimensions'
+        )
         self.assertEqual(gauge.descriptor.unit, 'count')
         self.assertEqual(gauge.descriptor._type, 1)
         self.assertEqual(

--- a/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_stats.py
+++ b/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_stats.py
@@ -542,7 +542,7 @@ class MockPeriodicMetricTask(object):
     Simulate calling export asynchronously from another thread synchronously
     from this one.
     """
-    def __init__(self, interval=None, function=None, args=None, kwargs=None):
+    def __init__(self, interval=None, function=None, args=None, kwargs=None, name=None):
         self.function = function
         self.logger = mock.Mock()
         self.start = mock.Mock()

--- a/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_stats.py
+++ b/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_stats.py
@@ -542,7 +542,14 @@ class MockPeriodicMetricTask(object):
     Simulate calling export asynchronously from another thread synchronously
     from this one.
     """
-    def __init__(self, interval=None, function=None, args=None, kwargs=None, name=None):
+    def __init__(
+        self,
+        interval=None,
+        function=None,
+        args=None,
+        kwargs=None,
+        name=None
+    ):
         self.function = function
         self.logger = mock.Mock()
         self.start = mock.Mock()

--- a/opencensus/common/schedule/__init__.py
+++ b/opencensus/common/schedule/__init__.py
@@ -34,8 +34,8 @@ class PeriodicTask(threading.Thread):
     :param args: The kwargs passed in while calling `function`.
     """
 
-    def __init__(self, interval, function, args=None, kwargs=None):
-        super(PeriodicTask, self).__init__()
+    def __init__(self, interval, function, args=None, kwargs=None, name=None):
+        super(PeriodicTask, self).__init__(name=name)
         self.interval = interval
         self.function = function
         self.args = args or []

--- a/opencensus/common/schedule/__init__.py
+++ b/opencensus/common/schedule/__init__.py
@@ -31,7 +31,10 @@ class PeriodicTask(threading.Thread):
     :param args: The args passed in while calling `function`.
 
     :type kwargs: dict
-    :param args: The kwargs passed in while calling `function`.
+    :param kwargs: The kwargs passed in while calling `function`.
+
+    :type name: str
+    :param name: The source of the worker. Used for naming.
     """
 
     def __init__(self, interval, function, args=None, kwargs=None, name=None):

--- a/opencensus/metrics/transport.py
+++ b/opencensus/metrics/transport.py
@@ -50,7 +50,14 @@ class PeriodicMetricTask(PeriodicTask):
 
     daemon = True
 
-    def __init__(self, interval=None, function=None, args=None, kwargs=None, name=None):
+    def __init__(
+        self,
+        interval=None,
+        function=None,
+        args=None,
+        kwargs=None,
+        name=None
+    ):
         if interval is None:
             interval = DEFAULT_INTERVAL
 
@@ -117,6 +124,10 @@ def get_exporter_thread(metric_producers, exporter, interval=None):
 
         export(itertools.chain(*all_gets))
 
-    tt = PeriodicMetricTask(interval, export_all, name=exporter.__class__.__name__)
+    tt = PeriodicMetricTask(
+        interval,
+        export_all,
+        name=exporter.__class__.__name__
+    )
     tt.start()
     return tt

--- a/opencensus/metrics/transport.py
+++ b/opencensus/metrics/transport.py
@@ -43,11 +43,14 @@ class PeriodicMetricTask(PeriodicTask):
 
     :type kwargs: dict
     :param args: The kwargs passed in while calling `function`.
+
+    :type name: str
+    :param name: The source of the worker. Used for naming.
     """
 
     daemon = True
 
-    def __init__(self, interval=None, function=None, args=None, kwargs=None):
+    def __init__(self, interval=None, function=None, args=None, kwargs=None, name=None):
         if interval is None:
             interval = DEFAULT_INTERVAL
 
@@ -62,7 +65,9 @@ class PeriodicMetricTask(PeriodicTask):
             except Exception:
                 logger.exception("Error handling metric export")
 
-        super(PeriodicMetricTask, self).__init__(interval, func, args, kwargs)
+        super(PeriodicMetricTask, self).__init__(
+            interval, func, args, kwargs, '{} Worker'.format(name)
+        )
 
     def run(self):
         # Indicate that this thread is an exporter thread.
@@ -112,6 +117,6 @@ def get_exporter_thread(metric_producers, exporter, interval=None):
 
         export(itertools.chain(*all_gets))
 
-    tt = PeriodicMetricTask(interval, export_all)
+    tt = PeriodicMetricTask(interval, export_all, name=exporter.__class__.__name__)
     tt.start()
     return tt


### PR DESCRIPTION
Azure exporters will now emit a "heartbeat" metric every 15minutes. The payload is a simple customMetric telemetry with certain customDimensions filled in depending on the environment that the application is running in (azure web app, function, app, VM, AKS). For now, the only defined environments are web apps and functions apps.

We want the heartbeat metrics producer to be a singleton that is run if ANY of the exporters are instantiated, so we set it as a global variable with a locking mechanism. Heartbeat is also not configurable and cannot be turned off. 

Also, due to the vast amount of threads running, added names to the workers so it'll be easier to identify which thread is for what purpose.

@hectorhdzg 