### PR TITLE
Attach rate metrics for VM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+## 0.7.10
+Released 2020-06-29
+
+- Updated `azure` module
+([#903](https://github.com/census-instrumentation/opencensus-python/pull/903),
+ [#925](https://github.com/census-instrumentation/opencensus-python/pull/925))
+
+- Updated `stackdriver` module
+([#919](https://github.com/census-instrumentation/opencensus-python/pull/919))
+
 ## 0.7.9
 Released 2020-06-17
 

--- a/context/opencensus-context/CHANGELOG.md
+++ b/context/opencensus-context/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## opencensus-ext-context 0.1.2
+
+## 0.1.2
+Released 2020-06-29
+
+- Release source distribution
+
 ## 0.1.1
 Released 2019-05-31
 

--- a/contrib/opencensus-ext-azure/CHANGELOG.md
+++ b/contrib/opencensus-ext-azure/CHANGELOG.md
@@ -2,8 +2,18 @@
 
 ## Unreleased
 
+- Attach rate metrics via Heartbeat for Web and Function apps
+  ([#930](https://github.com/census-instrumentation/opencensus-python/pull/930))
+- Attach rate metrics for VM
+  ([#935](https://github.com/census-instrumentation/opencensus-python/pull/935))
+
+## 1.0.4
+Released 2020-06-29
+
 - Remove dependency rate from standard metrics
   ([#903](https://github.com/census-instrumentation/opencensus-python/pull/903))
+- Implement customEvents using AzureEventHandler
+  ([#925](https://github.com/census-instrumentation/opencensus-python/pull/925))
 
 ## 1.0.3
 Released 2020-06-17
@@ -12,7 +22,6 @@ Released 2020-06-17
   ([#903](https://github.com/census-instrumentation/opencensus-python/pull/903))
 - Add support to initialize azure exporters with proxies
   ([#902](https://github.com/census-instrumentation/opencensus-python/pull/902))
-
 
 ## 1.0.2
 Released 2020-02-04

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/__init__.py
@@ -19,7 +19,6 @@ from opencensus.ext.azure.metrics_exporter.heartbeat_metrics.heartbeat import (
     HeartbeatMetric,
 )
 from opencensus.metrics import transport
-from opencensus.metrics.export.gauge import Registry
 from opencensus.metrics.export.metric_producer import MetricProducer
 
 _HEARTBEAT_METRICS = None
@@ -43,20 +42,13 @@ def enable_heartbeat_metrics(connection_string, ikey):
                                           exporter.options.export_interval)
 
 
-def register_metrics():
-    registry = Registry()
-    metric = HeartbeatMetric()
-    registry.add_gauge(metric())
-    return registry
-
-
 class AzureHeartbeatMetricsProducer(MetricProducer):
     """Implementation of the producer of heartbeat metrics.
 
     Includes Azure attach rate metrics, implemented using gauges.
     """
     def __init__(self):
-        self.registry = register_metrics()
+        self._heartbeat = HeartbeatMetric()
 
     def get_metrics(self):
-        return self.registry.get_metrics()
+        return self._heartbeat.get_metrics()

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/heartbeat.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/heartbeat.py
@@ -16,15 +16,15 @@ import datetime
 import json
 import os
 import platform
-import requests
 from collections import OrderedDict
+
+import requests
 
 from opencensus.common.version import __version__ as opencensus_version
 from opencensus.ext.azure.common.version import __version__ as ext_version
 from opencensus.metrics.export.gauge import LongGauge
 from opencensus.metrics.label_key import LabelKey
 from opencensus.metrics.label_value import LabelValue
-
 
 _AIMS_URI = "http://169.254.169.254/metadata/instance/compute"
 _AIMS_API_VERSION = "api-version=2017-12-01"

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/heartbeat.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/heartbeat.py
@@ -54,11 +54,12 @@ class HeartbeatMetric:
             # Only need to update if in vm (properties could change)
             self.properties.clear()
             self.update_properties()
-            self.heartbeat.clear()
-            # pylint: disable=protected-access
-            self.heartbeat.descriptor._label_keys = \
-                list(self.properties.keys())
-            self.heartbeat._len_label_keys = len(list(self.properties.keys()))
+            self.heartbeat = LongGauge(
+                HeartbeatMetric.NAME,
+                'Heartbeat metric with custom dimensions',
+                'count',
+                list(self.properties.keys()),
+            )
             self.heartbeat.get_or_create_time_series(
                 list(self.properties.values())
             )
@@ -104,6 +105,8 @@ class HeartbeatMetric:
             # Not in VM
             self.is_vm = False
             return False
+        except requests.exceptions.RequestException:
+            pass  # retry
 
         self.is_vm = True
         try:

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/heartbeat.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/heartbeat.py
@@ -101,6 +101,7 @@ class HeartbeatMetric:
             response = requests.get(request_url, headers={"MetaData":"True"})
         except requests.exceptions.ConnectionError:
             # Not in VM
+            self.is_vm = False
             return False
         
         self.is_vm = True

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/heartbeat.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/heartbeat.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
+import json
 import os
 import platform
+import requests
 from collections import OrderedDict
 
 from opencensus.common.version import __version__ as opencensus_version
@@ -23,11 +26,45 @@ from opencensus.metrics.label_key import LabelKey
 from opencensus.metrics.label_value import LabelValue
 
 
+_AIMS_URI = "http://169.254.169.254/metadata/instance/compute"
+_AIMS_API_VERSION = "api-version=2017-12-01"
+_AIMS_FORMAT = "format=json"
+
+
 class HeartbeatMetric:
     NAME = "Heartbeat"
 
     def __init__(self):
+        self.vm_data = {}
+        self.is_vm = False
         self.properties = OrderedDict()
+        self.update_properties()
+        self.heartbeat = LongGauge(
+            HeartbeatMetric.NAME,
+            'Heartbeat metric with custom dimensions',
+            'count',
+            list(self.properties.keys()),
+        )
+        self.heartbeat.get_or_create_time_series(
+            list(self.properties.values())
+        )
+
+    def get_metrics(self):
+        if self.is_vm:
+            # Only need to update if in vm (properties could change)
+            self.properties.clear()
+            self.update_properties()
+            self.heartbeat.clear()
+            # pylint: disable=protected-access
+            self.heartbeat.descriptor._label_keys = \
+                list(self.properties.keys())
+            self.heartbeat._len_label_keys = len(list(self.properties.keys()))
+            self.heartbeat.get_or_create_time_series(
+                list(self.properties.values())
+            )
+        return [self.heartbeat.get_metric(datetime.datetime.utcnow())]
+
+    def update_properties(self):
         self.properties[LabelKey("sdk", '')] = LabelValue(
             'py{}:oc{}:ext{}'.format(
                 platform.python_version(),
@@ -48,17 +85,30 @@ class HeartbeatMetric:
             # Function apps
             self.properties[LabelKey("azfunction_appId", '')] = \
                 LabelValue(os.environ.get("WEBSITE_HOSTNAME"))
+        elif self.get_azure_compute_metadata():
+            # VM
+            if self.vm_data:
+                self.properties[LabelKey("azInst_vmId", '')] = \
+                    LabelValue(self.vm_data.get("vmId", ''))
+                self.properties[LabelKey("azInst_subscriptionId", '')] = \
+                    LabelValue(self.vm_data.get("subscriptionId", ''))
+                self.properties[LabelKey("azInst_osType", '')] = \
+                    LabelValue(self.vm_data.get("osType", ''))   
 
-    def __call__(self):
-        """ Returns a derived gauge for the heartbeat metric.
+    def get_azure_compute_metadata(self):
+        try:
+            request_url = "{0}?{1}&{2}".format(_AIMS_URI, _AIMS_API_VERSION, _AIMS_FORMAT)
+            response = requests.get(request_url, headers={"MetaData":"True"})
+        except requests.exceptions.ConnectionError:
+            # Not in VM
+            return False
+        
+        self.is_vm = True
+        try:
+            text = response.text
+            self.vm_data = json.loads(text)
+        except Exception:  # pylint: disable=broad-except
+            # Error in reading response body, retry
+            pass
 
-        :rtype: :class:`opencensus.metrics.export.gauge.LongGauge`
-        :return: The gauge representing the heartbeat metric
-        """
-        gauge = LongGauge(
-            HeartbeatMetric.NAME,
-            'Heartbeat metric with custom dimensions',
-            'count',
-            list(self.properties.keys()))
-        gauge.get_or_create_time_series(list(self.properties.values()))
-        return gauge
+        return True

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/heartbeat.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/heartbeat.py
@@ -93,17 +93,18 @@ class HeartbeatMetric:
                 self.properties[LabelKey("azInst_subscriptionId", '')] = \
                     LabelValue(self.vm_data.get("subscriptionId", ''))
                 self.properties[LabelKey("azInst_osType", '')] = \
-                    LabelValue(self.vm_data.get("osType", ''))   
+                    LabelValue(self.vm_data.get("osType", ''))
 
     def get_azure_compute_metadata(self):
         try:
-            request_url = "{0}?{1}&{2}".format(_AIMS_URI, _AIMS_API_VERSION, _AIMS_FORMAT)
-            response = requests.get(request_url, headers={"MetaData":"True"})
+            request_url = "{0}?{1}&{2}".format(
+                _AIMS_URI, _AIMS_API_VERSION, _AIMS_FORMAT)
+            response = requests.get(request_url, headers={"MetaData": "True"})
         except requests.exceptions.ConnectionError:
             # Not in VM
             self.is_vm = False
             return False
-        
+
         self.is_vm = True
         try:
             text = response.text

--- a/contrib/opencensus-ext-azure/tests/test_azure_heartbeat_metrics.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_heartbeat_metrics.py
@@ -30,6 +30,7 @@ class MockResponse(object):
         self.status_code = status_code
         self.text = text
 
+
 def throw(exc_type, *args, **kwargs):
     def func(*_args, **_kwargs):
         raise exc_type(*args, **kwargs)
@@ -45,8 +46,12 @@ class TestHeartbeatMetrics(unittest.TestCase):
         producer = heartbeat_metrics.AzureHeartbeatMetricsProducer()
         # pylint: disable=protected-access
         metric = producer._heartbeat
-        self.assertTrue(isinstance(metric,
-            heartbeat_metrics.heartbeat.HeartbeatMetric))
+        self.assertTrue(
+            isinstance(
+                metric,
+                heartbeat_metrics.heartbeat.HeartbeatMetric
+            )
+        )
 
     def test_producer_get_metrics(self):
         producer = heartbeat_metrics.AzureHeartbeatMetricsProducer()
@@ -170,7 +175,8 @@ class TestHeartbeatMetrics(unittest.TestCase):
 
     def test_heartbeat_metric_init_vm(self):
         with mock.patch('requests.get') as get:
-            get.return_value = MockResponse(200,
+            get.return_value = MockResponse(
+                200,
                 json.dumps(
                     {
                         'vmId': 5,
@@ -202,8 +208,10 @@ class TestHeartbeatMetrics(unittest.TestCase):
             self.assertEqual(values[4].value, "Linux")
 
     def test_heartbeat_metric_not_vm(self):
-        with mock.patch('requests.get',
-            throw(requests.exceptions.ConnectionError)):
+        with mock.patch(
+            'requests.get',
+            throw(requests.exceptions.ConnectionError)
+        ):
             metric = heartbeat_metrics.HeartbeatMetric()
             self.assertFalse(metric.is_vm)
             self.assertEqual(metric.NAME, 'Heartbeat')
@@ -212,7 +220,8 @@ class TestHeartbeatMetrics(unittest.TestCase):
 
     def test_heartbeat_metric_vm_error_response(self):
         with mock.patch('requests.get') as get:
-            get.return_value = MockResponse(200,
+            get.return_value = MockResponse(
+                200,
                 json.dumps(
                     {
                         'vmId': 5,
@@ -225,8 +234,10 @@ class TestHeartbeatMetrics(unittest.TestCase):
             self.assertTrue(metric.is_vm)
             keys = list(metric.properties.keys())
             self.assertEqual(len(keys), 5)
-            with mock.patch('requests.get',
-                throw(Exception)):
+            with mock.patch(
+                'requests.get',
+                throw(Exception)
+            ):
                 metric.vm_data.clear()
                 self.assertTrue(metric.is_vm)
                 self.assertEqual(len(metric.vm_data), 0)

--- a/contrib/opencensus-ext-azure/tests/test_azure_heartbeat_metrics.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_heartbeat_metrics.py
@@ -14,11 +14,11 @@
 
 import json
 import os
-import requests
 import platform
 import unittest
 
 import mock
+import requests
 
 from opencensus.common.version import __version__ as opencensus_version
 from opencensus.ext.azure.common.version import __version__ as ext_version

--- a/contrib/opencensus-ext-stackdriver/CHANGELOG.md
+++ b/contrib/opencensus-ext-stackdriver/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## 0.7.3
+Released 2020-06-29
+
   - Add mean property for distribution values
   ([#919](https://github.com/census-instrumentation/opencensus-python/pull/919))
 


### PR DESCRIPTION
Continuation of [#930].

Detects whether current app is hosted in an Azure VM. We utilize [AzureMetaDataService](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service) to retrieve vm information. We need to periodically retrieve this (not only on load) because this information can change.