### PR TITLE
Change logger to module logger instance, rather than root logger

### DIFF
--- a/opencensus/stats/measure_to_view_map.py
+++ b/opencensus/stats/measure_to_view_map.py
@@ -19,6 +19,8 @@ from collections import defaultdict
 from opencensus.stats import metric_utils
 from opencensus.stats import view_data as view_data_module
 
+logger = logging.getLogger(__name__)
+
 
 class MeasureToViewMap(object):
     """Measure To View Map stores a map from names of Measures to
@@ -90,13 +92,13 @@ class MeasureToViewMap(object):
                 # ignore the views that are already registered
                 return
             else:
-                logging.warning(
+                logger.warning(
                     "A different view with the same name is already registered"
                 )  # pragma: NO COVER
         measure = view.measure
         registered_measure = self._registered_measures.get(measure.name)
         if registered_measure is not None and registered_measure != measure:
-            logging.warning(
+            logger.warning(
                 "A different measure with the same name is already registered")
         self._registered_views[view.name] = view
         if registered_measure is None:


### PR DESCRIPTION
Within every module of opencensus a logger object is initialized, except for stats/measure_to_view_map.py, where logging is done via the root logger. This Pull Request makes sure logging in stats/measure_to_view_map.py is done according the conventions of the rest of the project.