### PR TITLE
Azure Monitor metrics exporter atexit fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- PeriodicMetricTask flush on exit
+([#943](https://github.com/census-instrumentation/opencensus-python/pull/943))
+
 ## 0.7.10
 Released 2020-06-29
 

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/heartbeat_metrics/__init__.py
@@ -37,9 +37,10 @@ def enable_heartbeat_metrics(connection_string, ikey):
             )
             producer = AzureHeartbeatMetricsProducer()
             _HEARTBEAT_METRICS = producer
-            transport.get_exporter_thread([_HEARTBEAT_METRICS],
-                                          exporter,
-                                          exporter.options.export_interval)
+            exporter.exporter_thread = \
+                transport.get_exporter_thread([_HEARTBEAT_METRICS],
+                                              exporter,
+                                              exporter.options.export_interval)
 
 
 class AzureHeartbeatMetricsProducer(MetricProducer):

--- a/contrib/opencensus-ext-azure/tests/test_azure_metrics_exporter.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_metrics_exporter.py
@@ -202,7 +202,7 @@ class TestAzureMetricsExporter(unittest.TestCase):
                 '.transport.get_exporter_thread')
     def test_new_metrics_exporter(self, exporter_mock):
         with mock.patch('opencensus.ext.azure.metrics_exporter'
-                '.heartbeat_metrics.enable_heartbeat_metrics') as hb:
+                        '.heartbeat_metrics.enable_heartbeat_metrics') as hb:
             hb.return_value = None
             iKey = '12345678-1234-5678-abcd-12345678abcd'
             exporter = metrics_exporter.new_metrics_exporter(
@@ -215,13 +215,13 @@ class TestAzureMetricsExporter(unittest.TestCase):
             self.assertFalse(isinstance(exporter_mock.call_args[0][0][0],
                                         producer_class))
             self.assertTrue(isinstance(exporter_mock.call_args[0][0][1],
-                                    producer_class))
+                                       producer_class))
 
     @mock.patch('opencensus.ext.azure.metrics_exporter'
                 '.transport.get_exporter_thread')
     def test_new_metrics_exporter_no_standard_metrics(self, exporter_mock):
         with mock.patch('opencensus.ext.azure.metrics_exporter'
-                '.heartbeat_metrics.enable_heartbeat_metrics') as hb:
+                        '.heartbeat_metrics.enable_heartbeat_metrics') as hb:
             hb.return_value = None
             iKey = '12345678-1234-5678-abcd-12345678abcd'
             exporter = metrics_exporter.new_metrics_exporter(
@@ -235,16 +235,16 @@ class TestAzureMetricsExporter(unittest.TestCase):
                                         producer_class))
 
     @mock.patch('opencensus.ext.azure.metrics_exporter'
-                '.heartbeat_metrics.enable_heartbeat_metrics')
-    @mock.patch('opencensus.ext.azure.metrics_exporter'
                 '.transport.get_exporter_thread')
-    def test_new_metrics_exporter_heartbeat(self, exporter_mock, heartbeat_mock):
-        iKey = '12345678-1234-5678-abcd-12345678abcd'
-        exporter = metrics_exporter.new_metrics_exporter(
-            instrumentation_key=iKey)
+    def test_new_metrics_exporter_heartbeat(self, exporter_mock):
+        with mock.patch('opencensus.ext.azure.metrics_exporter'
+                        '.heartbeat_metrics.enable_heartbeat_metrics') as hb:
+            iKey = '12345678-1234-5678-abcd-12345678abcd'
+            exporter = metrics_exporter.new_metrics_exporter(
+                instrumentation_key=iKey)
 
-        self.assertEqual(exporter.options.instrumentation_key, iKey)
-        self.assertEqual(len(heartbeat_mock.call_args_list), 1)
-        self.assertEqual(len(heartbeat_mock.call_args[0]), 2)
-        self.assertEqual(heartbeat_mock.call_args[0][0], None)
-        self.assertEqual(heartbeat_mock.call_args[0][1], iKey)
+            self.assertEqual(exporter.options.instrumentation_key, iKey)
+            self.assertEqual(len(hb.call_args_list), 1)
+            self.assertEqual(len(hb.call_args[0]), 2)
+            self.assertEqual(hb.call_args[0][0], None)
+            self.assertEqual(hb.call_args[0][1], iKey)

--- a/opencensus/metrics/transport.py
+++ b/opencensus/metrics/transport.py
@@ -62,6 +62,8 @@ class PeriodicMetricTask(PeriodicTask):
             interval = DEFAULT_INTERVAL
 
         self.func = function
+        self.args = args
+        self.kwargs = kwargs
 
         def func(*aa, **kw):
             try:
@@ -81,6 +83,13 @@ class PeriodicMetricTask(PeriodicTask):
         # Used to suppress tracking of requests in this thread
         execution_context.set_is_exporter(True)
         super(PeriodicMetricTask, self).run()
+
+    def close(self):
+        try:
+            return self.func(*self.args, **self.kwargs)
+        except Exception as ex:
+            logger.exception("Error handling metric flush: {}".format(ex))
+        self.cancel()
 
 
 def get_exporter_thread(metric_producers, exporter, interval=None):

--- a/tests/unit/metrics/test_transport.py
+++ b/tests/unit/metrics/test_transport.py
@@ -58,6 +58,7 @@ class TestPeriodicMetricTask(unittest.TestCase):
         self.assertEqual(mock_func.call_count, 2)
         time.sleep(INTERVAL)
         self.assertEqual(mock_func.call_count, 3)
+        task.cancel()
 
     def test_periodic_task_cancel(self):
         mock_func = mock.Mock()
@@ -67,6 +68,14 @@ class TestPeriodicMetricTask(unittest.TestCase):
         self.assertEqual(mock_func.call_count, 1)
         task.cancel()
         time.sleep(INTERVAL)
+        self.assertEqual(mock_func.call_count, 1)
+
+    def test_periodic_task_close(self):
+        mock_func = mock.Mock()
+        task = transport.PeriodicMetricTask(100, mock_func)
+        task.start()
+        mock_func.assert_not_called()
+        task.close()
         self.assertEqual(mock_func.call_count, 1)
 
 


### PR DESCRIPTION
Implemented azure monitor metrics exporter storage + exporter worker shutdown on exit.
Also flushes telemetry for custom metrics + heartbeat metrics on exit.