### PR TITLE
Only ping azuremetadataservice if vm retry

### DIFF
--- a/contrib/opencensus-ext-azure/CHANGELOG.md
+++ b/contrib/opencensus-ext-azure/CHANGELOG.md
@@ -8,6 +8,8 @@
   ([#935](https://github.com/census-instrumentation/opencensus-python/pull/935))
 - Add links in properties for trace exporter envelopes
   ([#936](https://github.com/census-instrumentation/opencensus-python/pull/936))
+- Fix attach rate metrics for VM to only ping data service on retry
+  ([#937](https://github.com/census-instrumentation/opencensus-python/pull/937))
 
 ## 1.0.4
 Released 2020-06-29

--- a/contrib/opencensus-ext-azure/CHANGELOG.md
+++ b/contrib/opencensus-ext-azure/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Add links in properties for trace exporter envelopes
   ([#936](https://github.com/census-instrumentation/opencensus-python/pull/936))
 - Fix attach rate metrics for VM to only ping data service on retry
-  ([#937](https://github.com/census-instrumentation/opencensus-python/pull/937))
+  ([#946](https://github.com/census-instrumentation/opencensus-python/pull/946))
 
 ## 1.0.4
 Released 2020-06-29

--- a/contrib/opencensus-ext-azure/tests/test_azure_heartbeat_metrics.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_heartbeat_metrics.py
@@ -230,7 +230,10 @@ class TestHeartbeatMetrics(unittest.TestCase):
             self.assertEqual(len(keys), 2)
 
     def test_heartbeat_metric_vm_retry(self):
-        with mock.patch('requests.get', throw(requests.exceptions.RequestException)):
+        with mock.patch(
+            'requests.get',
+            throw(requests.exceptions.RequestException)
+        ):
             metric = heartbeat_metrics.HeartbeatMetric()
             self.assertTrue(metric.vm_retry)
             keys = list(metric.properties.keys())

--- a/contrib/opencensus-ext-azure/tests/test_azure_heartbeat_metrics.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_heartbeat_metrics.py
@@ -186,7 +186,7 @@ class TestHeartbeatMetrics(unittest.TestCase):
                 )
             )
             metric = heartbeat_metrics.HeartbeatMetric()
-            self.assertTrue(metric.is_vm)
+            self.assertFalse(metric.vm_retry)
             self.assertEqual(metric.NAME, 'Heartbeat')
             keys = list(metric.properties.keys())
             values = list(metric.properties.values())
@@ -213,7 +213,7 @@ class TestHeartbeatMetrics(unittest.TestCase):
             throw(requests.exceptions.ConnectionError)
         ):
             metric = heartbeat_metrics.HeartbeatMetric()
-            self.assertFalse(metric.is_vm)
+            self.assertFalse(metric.vm_retry)
             self.assertEqual(metric.NAME, 'Heartbeat')
             keys = list(metric.properties.keys())
             self.assertEqual(len(keys), 2)
@@ -224,34 +224,31 @@ class TestHeartbeatMetrics(unittest.TestCase):
             throw(requests.Timeout)
         ):
             metric = heartbeat_metrics.HeartbeatMetric()
-            self.assertFalse(metric.is_vm)
+            self.assertFalse(metric.vm_retry)
             self.assertEqual(metric.NAME, 'Heartbeat')
             keys = list(metric.properties.keys())
             self.assertEqual(len(keys), 2)
 
-    def test_heartbeat_metric_vm_error_response(self):
-        with mock.patch('requests.get') as get:
-            get.return_value = MockResponse(
-                200,
-                json.dumps(
-                    {
-                        'vmId': 5,
-                        'subscriptionId': 3,
-                        'osType': 'Linux'
-                    }
-                )
-            )
+    def test_heartbeat_metric_vm_retry(self):
+        with mock.patch('requests.get', throw(requests.exceptions.RequestException)):
             metric = heartbeat_metrics.HeartbeatMetric()
-            self.assertTrue(metric.is_vm)
+            self.assertTrue(metric.vm_retry)
             keys = list(metric.properties.keys())
-            self.assertEqual(len(keys), 5)
-            with mock.patch(
-                'requests.get',
-                throw(Exception)
-            ):
-                metric.vm_data.clear()
-                self.assertTrue(metric.is_vm)
-                self.assertEqual(len(metric.vm_data), 0)
-                self.assertTrue(metric.is_vm)
+            self.assertEqual(len(keys), 2)
+            self.assertEqual(len(metric.vm_data), 0)
+            with mock.patch('requests.get') as get:
+                get.return_value = MockResponse(
+                    200,
+                    json.dumps(
+                        {
+                            'vmId': 5,
+                            'subscriptionId': 3,
+                            'osType': 'Linux'
+                        }
+                    )
+                )
+                metric.get_metrics()
+                self.assertFalse(metric.vm_retry)
+                self.assertEqual(len(metric.vm_data), 3)
                 keys = list(metric.properties.keys())
                 self.assertEqual(len(keys), 5)


### PR DESCRIPTION
Updated heartbeat for azure monitor exporters to only ping azuremetadataservice on vm retry and sets values one time. We now know that the fields do not change, so need to keep pinging after setting for first time (or not in a vm).