### PR TITLE
Configurable queue capacity for azure exporters

### DIFF
--- a/contrib/opencensus-ext-azure/CHANGELOG.md
+++ b/contrib/opencensus-ext-azure/CHANGELOG.md
@@ -10,6 +10,8 @@
   ([#936](https://github.com/census-instrumentation/opencensus-python/pull/936))
 - Fix attach rate metrics for VM to only ping data service on retry
   ([#946](https://github.com/census-instrumentation/opencensus-python/pull/946))
+- Added queue capacity configuration for exporters
+  ([#949](https://github.com/census-instrumentation/opencensus-python/pull/949))
 
 ## 1.0.4
 Released 2020-06-29

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
@@ -56,6 +56,7 @@ def process_options(options):
                 TEMPDIR_PREFIX + TEMPDIR_SUFFIX
             )
 
+    # proxies
     if options.proxies is None:
         options.proxies = '{}'
 
@@ -109,6 +110,7 @@ class Options(BaseObject):
         max_batch_size=100,
         minimum_retry_interval=60,  # minimum retry interval in seconds
         proxies=None,  # string maps url schemes to the url of the proxies
+        queue_capacity=8192,
         storage_maintenance_period=60,
         storage_max_size=50*1024*1024,  # 50MiB
         storage_path=None,

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/exporter.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/exporter.py
@@ -28,7 +28,7 @@ class BaseExporter(object):
         self.max_batch_size = options.max_batch_size
         # TODO: queue should be moved to tracer
         # too much refactor work, leave to the next PR
-        self._queue = Queue(capacity=8192)  # TODO: make this configurable
+        self._queue = Queue(capacity=options.queue_capacity)
         # TODO: worker should not be created in the base exporter
         self._worker = Worker(self._queue, self)
         self._worker.start()

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
@@ -133,7 +133,9 @@ class LocalFileStorage(object):
             if path.endswith('.tmp'):
                 if name < timeout_deadline:
                     try:
-                        os.remove(path)  # TODO: log data loss
+                        os.remove(path)
+                        logger.warning(
+                            'File write exceeded timeout. Dropping telemetry')
                     except Exception:
                         pass  # keep silent
             if path.endswith('.lock'):
@@ -148,7 +150,9 @@ class LocalFileStorage(object):
             if path.endswith('.blob'):
                 if name < retention_deadline:
                     try:
-                        os.remove(path)  # TODO: log data loss
+                        os.remove(path)
+                        logger.warning(
+                            'File write exceeded retention. Dropping telemetry')
                     except Exception:
                         pass  # keep silent
                 else:

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
@@ -152,7 +152,7 @@ class LocalFileStorage(object):
                     try:
                         os.remove(path)
                         logger.warning(
-                            'File write exceeded retention.
+                            'File write exceeded retention.' +
                             'Dropping telemetry')
                     except Exception:
                         pass  # keep silent

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
@@ -152,7 +152,8 @@ class LocalFileStorage(object):
                     try:
                         os.remove(path)
                         logger.warning(
-                            'File write exceeded retention. Dropping telemetry')
+                            'File write exceeded retention.
+                            'Dropping telemetry')
                     except Exception:
                         pass  # keep silent
                 else:

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/transport.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/transport.py
@@ -79,7 +79,6 @@ class TransportMixin(object):
             logger.info('Transmission succeeded: %s.', text)
             return 0
         if response.status_code == 206:  # Partial Content
-            # TODO: store the unsent data
             if data:
                 try:
                     resend_envelopes = []

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/log_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/log_exporter/__init__.py
@@ -57,7 +57,7 @@ class BaseLogHandler(logging.Handler):
         )
         self._telemetry_processors = []
         self.addFilter(SamplingFilter(self.options.logging_sampling_rate))
-        self._queue = Queue(capacity=8192)  # TODO: make this configurable
+        self._queue = Queue(capacity=self.options.queue_capacity)
         self._worker = Worker(self._queue, self)
         self._worker.start()
         heartbeat_metrics.enable_heartbeat_metrics(

--- a/contrib/opencensus-ext-azure/tests/test_azure_log_exporter.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_log_exporter.py
@@ -98,6 +98,22 @@ class TestAzureLogHandler(unittest.TestCase):
             '{"https":"https://test-proxy.com"}',
         )
 
+    def test_init_handler_with_queue_capacity(self):
+        handler = log_exporter.AzureLogHandler(
+            instrumentation_key='12345678-1234-5678-abcd-12345678abcd',
+            queue_capacity=500,
+        )
+
+        self.assertEqual(
+            handler.options.queue_capacity,
+            500
+        )
+
+        self.assertEqual(
+            handler._worker._src._queue.maxsize,
+            500
+        )
+
     @mock.patch('requests.post', return_value=mock.Mock())
     def test_exception(self, requests_mock):
         logger = logging.getLogger(self.id())
@@ -287,6 +303,22 @@ class TestAzureEventHandler(unittest.TestCase):
         self.assertEqual(
             handler.options.proxies,
             '{"https":"https://test-proxy.com"}',
+        )
+
+    def test_init_handler_with_queue_capacity(self):
+        handler = log_exporter.AzureEventHandler(
+            instrumentation_key='12345678-1234-5678-abcd-12345678abcd',
+            queue_capacity=500,
+        )
+
+        self.assertEqual(
+            handler.options.queue_capacity,
+            500
+        )
+
+        self.assertEqual(
+            handler._worker._src._queue.maxsize,
+            500
         )
 
     @mock.patch('requests.post', return_value=mock.Mock())

--- a/contrib/opencensus-ext-azure/tests/test_azure_log_exporter.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_log_exporter.py
@@ -315,7 +315,7 @@ class TestAzureEventHandler(unittest.TestCase):
             handler.options.queue_capacity,
             500
         )
-
+        # pylint: disable=protected-access
         self.assertEqual(
             handler._worker._src._queue.maxsize,
             500

--- a/contrib/opencensus-ext-azure/tests/test_azure_trace_exporter.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_trace_exporter.py
@@ -58,6 +58,22 @@ class TestAzureExporter(unittest.TestCase):
             '{"https":"https://test-proxy.com"}',
         )
 
+    def test_init_exporter_with_queue_capacity(self):
+        exporter = trace_exporter.AzureExporter(
+            instrumentation_key='12345678-1234-5678-abcd-12345678abcd',
+            queue_capacity=500,
+        )
+
+        self.assertEqual(
+            exporter.options.queue_capacity,
+            500
+        )
+
+        self.assertEqual(
+            exporter._worker.src._queue.maxsize,
+            500
+        )
+
     @mock.patch('requests.post', return_value=mock.Mock())
     def test_emit_empty(self, request_mock):
         exporter = trace_exporter.AzureExporter(

--- a/contrib/opencensus-ext-azure/tests/test_azure_trace_exporter.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_trace_exporter.py
@@ -68,7 +68,7 @@ class TestAzureExporter(unittest.TestCase):
             exporter.options.queue_capacity,
             500
         )
-
+        # pylint: disable=protected-access
         self.assertEqual(
             exporter._worker.src._queue.maxsize,
             500

--- a/opencensus/common/schedule/__init__.py
+++ b/opencensus/common/schedule/__init__.py
@@ -14,8 +14,11 @@
 
 from six.moves import queue
 
+import logging
 import threading
 import time
+
+logger = logging.getLogger(__name__)
 
 
 class PeriodicTask(threading.Thread):
@@ -128,7 +131,7 @@ class Queue(object):
         try:
             self._queue.put(item, block, timeout)
         except queue.Full:
-            pass  # TODO: log data loss
+            logger.warning('Queue is full. Dropping telemetry.')
 
     def puts(self, items, block=True, timeout=None):
         if block and timeout is not None:


### PR DESCRIPTION
The trace and log exporters utilize a queue to be added onto for whenever a span/log is created to be exported.
If queue is full, telemetry is dropped and a warning is logged.

This PR adds the ability to configure the max queue size, default is 8192.