### PR TITLE
Fix comment, AsyncTransport is the default

### DIFF
--- a/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-stackdriver/opencensus/ext/stackdriver/trace_exporter/__init__.py
@@ -175,8 +175,8 @@ class StackdriverExporter(base_exporter.Exporter):
     :param transport: Class for creating new transport objects. It should
                       extend from the base_exporter :class:`.Transport` type
                       and implement :meth:`.Transport.export`. Defaults to
-                      :class:`.SyncTransport`. The other option is
-                      :class:`.AsyncTransport`.
+                      :class:`.AsyncTransport`. The other option is
+                      :class:`.SyncTransport`.
     """
 
     def __init__(self, client=None, project_id=None,


### PR DESCRIPTION
Just a small comment change, noticed when I was looking through the code that the comment calls out the synchronous transport as the default but the argument defaults to the async one :)