### PR TITLE
replace travis (part 1): add empty github workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,14 @@
+name: Build
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and test
+        run: echo "Hello world!"


### PR DESCRIPTION
Travis.com builds are not running. Travis.org builds are deprecated for google owned repos. So, switching to github workflows.

This PR just adds an empty job, because it won't actually run on this repo yet. Here is a run on my fork where it just prints hello :) https://github.com/aabmass/opencensus-python/actions/runs/401412533