### PR TITLE
run CI workflow on master branch commits as well

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: Build
 
 on:
+  push:
+    branches-ignore:
+    - 'release/*'
   pull_request:
     branches:
       - master


### PR DESCRIPTION
This will make it so commits to master branch in our repo will have the CI runs shown as well. I noticed Travis was doing this previously, and so does OTel