### PR TITLE
Disable heartbeat metrics in azure exporters

### DIFF
--- a/contrib/opencensus-ext-azure/CHANGELOG.md
+++ b/contrib/opencensus-ext-azure/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Added queue capacity configuration for exporters
   ([#949](https://github.com/census-instrumentation/opencensus-python/pull/949))
 - Disable heartbeat metrics in exporters
-  ([#949](https://github.com/census-instrumentation/opencensus-python/pull/949))
+  ([#984](https://github.com/census-instrumentation/opencensus-python/pull/984))
 
 ## 1.0.4
 Released 2020-06-29

--- a/contrib/opencensus-ext-azure/CHANGELOG.md
+++ b/contrib/opencensus-ext-azure/CHANGELOG.md
@@ -12,6 +12,8 @@
   ([#946](https://github.com/census-instrumentation/opencensus-python/pull/946))
 - Added queue capacity configuration for exporters
   ([#949](https://github.com/census-instrumentation/opencensus-python/pull/949))
+- Disable heartbeat metrics in exporters
+  ([#949](https://github.com/census-instrumentation/opencensus-python/pull/949))
 
 ## 1.0.4
 Released 2020-06-29

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/log_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/log_exporter/__init__.py
@@ -30,7 +30,6 @@ from opencensus.ext.azure.common.protocol import (
 )
 from opencensus.ext.azure.common.storage import LocalFileStorage
 from opencensus.ext.azure.common.transport import TransportMixin
-from opencensus.ext.azure.metrics_exporter import heartbeat_metrics
 from opencensus.trace import execution_context
 
 logger = logging.getLogger(__name__)
@@ -60,8 +59,6 @@ class BaseLogHandler(logging.Handler):
         self._queue = Queue(capacity=self.options.queue_capacity)
         self._worker = Worker(self._queue, self)
         self._worker.start()
-        heartbeat_metrics.enable_heartbeat_metrics(
-            self.options.connection_string, self.options.instrumentation_key)
 
     def _export(self, batch, event=None):  # pragma: NO COVER
         try:

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/__init__.py
@@ -153,9 +153,4 @@ def new_metrics_exporter(**options):
                                     producers,
                                     exporter,
                                     interval=exporter.options.export_interval)
-    from opencensus.ext.azure.metrics_exporter import heartbeat_metrics
-    heartbeat_metrics.enable_heartbeat_metrics(
-        exporter.options.connection_string,
-        exporter.options.instrumentation_key
-    )
     return exporter

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/trace_exporter/__init__.py
@@ -28,7 +28,6 @@ from opencensus.ext.azure.common.protocol import (
 )
 from opencensus.ext.azure.common.storage import LocalFileStorage
 from opencensus.ext.azure.common.transport import TransportMixin
-from opencensus.ext.azure.metrics_exporter import heartbeat_metrics
 from opencensus.trace.span import SpanKind
 
 try:
@@ -60,8 +59,6 @@ class AzureExporter(BaseExporter, ProcessorMixin, TransportMixin):
         self._telemetry_processors = []
         super(AzureExporter, self).__init__(**options)
         atexit.register(self._stop, self.options.grace_period)
-        heartbeat_metrics.enable_heartbeat_metrics(
-            self.options.connection_string, self.options.instrumentation_key)
 
     def span_data_to_envelope(self, sd):
         envelope = Envelope(

--- a/contrib/opencensus-ext-azure/tests/test_azure_metrics_exporter.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_metrics_exporter.py
@@ -234,17 +234,17 @@ class TestAzureMetricsExporter(unittest.TestCase):
             self.assertFalse(isinstance(exporter_mock.call_args[0][0][0],
                                         producer_class))
 
-    @mock.patch('opencensus.ext.azure.metrics_exporter'
-                '.transport.get_exporter_thread')
-    def test_new_metrics_exporter_heartbeat(self, exporter_mock):
-        with mock.patch('opencensus.ext.azure.metrics_exporter'
-                        '.heartbeat_metrics.enable_heartbeat_metrics') as hb:
-            iKey = '12345678-1234-5678-abcd-12345678abcd'
-            exporter = metrics_exporter.new_metrics_exporter(
-                instrumentation_key=iKey)
+    # @mock.patch('opencensus.ext.azure.metrics_exporter'
+    #             '.transport.get_exporter_thread')
+    # def test_new_metrics_exporter_heartbeat(self, exporter_mock):
+    #     with mock.patch('opencensus.ext.azure.metrics_exporter'
+    #                     '.heartbeat_metrics.enable_heartbeat_metrics') as hb:
+    #         iKey = '12345678-1234-5678-abcd-12345678abcd'
+    #         exporter = metrics_exporter.new_metrics_exporter(
+    #             instrumentation_key=iKey)
 
-            self.assertEqual(exporter.options.instrumentation_key, iKey)
-            self.assertEqual(len(hb.call_args_list), 1)
-            self.assertEqual(len(hb.call_args[0]), 2)
-            self.assertEqual(hb.call_args[0][0], None)
-            self.assertEqual(hb.call_args[0][1], iKey)
+    #         self.assertEqual(exporter.options.instrumentation_key, iKey)
+    #         self.assertEqual(len(hb.call_args_list), 1)
+    #         self.assertEqual(len(hb.call_args[0]), 2)
+    #         self.assertEqual(hb.call_args[0][0], None)
+    #         self.assertEqual(hb.call_args[0][1], iKey)

--- a/contrib/opencensus-ext-azure/tests/test_azure_metrics_exporter.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_metrics_exporter.py
@@ -234,17 +234,18 @@ class TestAzureMetricsExporter(unittest.TestCase):
             self.assertFalse(isinstance(exporter_mock.call_args[0][0][0],
                                         producer_class))
 
-    # @mock.patch('opencensus.ext.azure.metrics_exporter'
-    #             '.transport.get_exporter_thread')
-    # def test_new_metrics_exporter_heartbeat(self, exporter_mock):
-    #     with mock.patch('opencensus.ext.azure.metrics_exporter'
-    #                     '.heartbeat_metrics.enable_heartbeat_metrics') as hb:
-    #         iKey = '12345678-1234-5678-abcd-12345678abcd'
-    #         exporter = metrics_exporter.new_metrics_exporter(
-    #             instrumentation_key=iKey)
+    @unittest.skip("Skip because disabling heartbeat metrics")
+    @mock.patch('opencensus.ext.azure.metrics_exporter'
+                '.transport.get_exporter_thread')
+    def test_new_metrics_exporter_heartbeat(self, exporter_mock):
+        with mock.patch('opencensus.ext.azure.metrics_exporter'
+                        '.heartbeat_metrics.enable_heartbeat_metrics') as hb:
+            iKey = '12345678-1234-5678-abcd-12345678abcd'
+            exporter = metrics_exporter.new_metrics_exporter(
+                instrumentation_key=iKey)
 
-    #         self.assertEqual(exporter.options.instrumentation_key, iKey)
-    #         self.assertEqual(len(hb.call_args_list), 1)
-    #         self.assertEqual(len(hb.call_args[0]), 2)
-    #         self.assertEqual(hb.call_args[0][0], None)
-    #         self.assertEqual(hb.call_args[0][1], iKey)
+            self.assertEqual(exporter.options.instrumentation_key, iKey)
+            self.assertEqual(len(hb.call_args_list), 1)
+            self.assertEqual(len(hb.call_args[0]), 2)
+            self.assertEqual(hb.call_args[0][0], None)
+            self.assertEqual(hb.call_args[0][1], iKey)


### PR DESCRIPTION
We have decided to use a different way to send attach rate metrics, which is not via heartbeat. Removing these from the exporters for now.