### PR TITLE
Specify `google-cloud-trace<1.0.0` in README

### DIFF
--- a/contrib/opencensus-ext-stackdriver/README.rst
+++ b/contrib/opencensus-ext-stackdriver/README.rst
@@ -32,8 +32,8 @@ This example shows how to report the traces to Stackdriver Trace:
 
 ::
 
-    pip install google-cloud-trace
-    pipenv install google-cloud-trace
+    pip install google-cloud-trace<1.0.0
+    pipenv install google-cloud-trace<1.0.0
 
 By default, traces are exported asynchronously, to reduce latency during
 your code's execution. If you would like to export data on the main thread


### PR DESCRIPTION
This library is not compatible with versions of google-cloud-trace >= 1.0.0. This should be taken care of by the setup.py, but add this just in case folks install `google-cloud-trace` first. https://github.com/census-instrumentation/opencensus-python/blob/812105e6021f47fbfa77fe7b32e1797a83bbe7ad/contrib/opencensus-ext-stackdriver/setup.py#L43