### PR TITLE
remove explicit mock dependency if available in unittest

### DIFF
--- a/contrib/opencensus-ext-azure/tests/test_azure_log_exporter.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_log_exporter.py
@@ -17,7 +17,10 @@ import os
 import shutil
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.ext.azure import log_exporter
 

--- a/contrib/opencensus-ext-azure/tests/test_azure_metrics_exporter.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_metrics_exporter.py
@@ -16,7 +16,10 @@ import os
 import unittest
 from datetime import datetime
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.common import utils
 from opencensus.ext.azure.common.protocol import DataPoint

--- a/contrib/opencensus-ext-azure/tests/test_azure_standard_metrics.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_standard_metrics.py
@@ -16,7 +16,10 @@ import collections
 import sys
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import requests
 
 from opencensus.ext.azure.metrics_exporter import standard_metrics

--- a/contrib/opencensus-ext-azure/tests/test_azure_statsbeat_metrics.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_statsbeat_metrics.py
@@ -17,7 +17,10 @@ import os
 import platform
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import requests
 
 from opencensus.ext.azure.common import Options

--- a/contrib/opencensus-ext-azure/tests/test_azure_trace_exporter.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_trace_exporter.py
@@ -17,7 +17,10 @@ import os
 import shutil
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.ext.azure import trace_exporter
 from opencensus.trace.link import Link

--- a/contrib/opencensus-ext-azure/tests/test_storage.py
+++ b/contrib/opencensus-ext-azure/tests/test_storage.py
@@ -16,7 +16,10 @@ import os
 import shutil
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.ext.azure.common.storage import (
     LocalFileBlob,

--- a/contrib/opencensus-ext-azure/tests/test_transport_mixin.py
+++ b/contrib/opencensus-ext-azure/tests/test_transport_mixin.py
@@ -17,7 +17,10 @@ import os
 import shutil
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import requests
 from azure.core.exceptions import ClientAuthenticationError
 from azure.identity._exceptions import CredentialUnavailableError

--- a/contrib/opencensus-ext-dbapi/tests/test_dbapi_trace.py
+++ b/contrib/opencensus-ext-dbapi/tests/test_dbapi_trace.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.ext.dbapi import trace
 

--- a/contrib/opencensus-ext-django/tests/test_django_db_middleware.py
+++ b/contrib/opencensus-ext-django/tests/test_django_db_middleware.py
@@ -16,7 +16,10 @@ import unittest
 from collections import namedtuple
 
 import django
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 from django.test.utils import teardown_test_environment
 

--- a/contrib/opencensus-ext-django/tests/test_django_middleware.py
+++ b/contrib/opencensus-ext-django/tests/test_django_middleware.py
@@ -16,7 +16,10 @@ import sys
 import traceback
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 from django.test import RequestFactory
 from django.test.utils import teardown_test_environment
 

--- a/contrib/opencensus-ext-flask/tests/test_flask_middleware.py
+++ b/contrib/opencensus-ext-flask/tests/test_flask_middleware.py
@@ -18,7 +18,10 @@
 import unittest
 
 import flask
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 from google.rpc import code_pb2
 from werkzeug.exceptions import NotFound
 

--- a/contrib/opencensus-ext-google-cloud-clientlibs/tests/test_google_cloud_clientlibs_trace.py
+++ b/contrib/opencensus-ext-google-cloud-clientlibs/tests/test_google_cloud_clientlibs_trace.py
@@ -15,7 +15,10 @@
 import unittest
 
 import grpc
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.ext.google_cloud_clientlibs import trace
 

--- a/contrib/opencensus-ext-grpc/tests/test_client_interceptor.py
+++ b/contrib/opencensus-ext-grpc/tests/test_client_interceptor.py
@@ -17,7 +17,10 @@ import threading
 import unittest
 
 import grpc
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 from google.api_core import bidi
 from google.protobuf import proto_builder
 from grpc.framework.foundation import logging_pool

--- a/contrib/opencensus-ext-grpc/tests/test_server_interceptor.py
+++ b/contrib/opencensus-ext-grpc/tests/test_server_interceptor.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 from google.rpc import code_pb2
 
 from opencensus.ext.grpc import server_interceptor

--- a/contrib/opencensus-ext-httplib/tests/test_httplib_trace.py
+++ b/contrib/opencensus-ext-httplib/tests/test_httplib_trace.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.ext.httplib import trace
 from opencensus.trace import span as span_module

--- a/contrib/opencensus-ext-jaeger/tests/test_jaeger_exporter.py
+++ b/contrib/opencensus-ext-jaeger/tests/test_jaeger_exporter.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.ext.jaeger import trace_exporter
 from opencensus.ext.jaeger.trace_exporter.gen.jaeger import jaeger

--- a/contrib/opencensus-ext-mysql/tests/test_mysql_trace.py
+++ b/contrib/opencensus-ext-mysql/tests/test_mysql_trace.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.ext.mysql import trace
 

--- a/contrib/opencensus-ext-ocagent/tests/test_stats_exporter.py
+++ b/contrib/opencensus-ext-ocagent/tests/test_stats_exporter.py
@@ -21,7 +21,10 @@ from concurrent import futures
 from datetime import datetime
 
 import grpc
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 from google.protobuf import timestamp_pb2
 
 from opencensus.common import resource, utils

--- a/contrib/opencensus-ext-ocagent/tests/test_trace_exporter.py
+++ b/contrib/opencensus-ext-ocagent/tests/test_trace_exporter.py
@@ -18,7 +18,10 @@ import socket
 import unittest
 
 import grpc
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.common.version import __version__
 from opencensus.ext.ocagent.trace_exporter import TraceExporter

--- a/contrib/opencensus-ext-postgresql/tests/test_postgresql_trace.py
+++ b/contrib/opencensus-ext-postgresql/tests/test_postgresql_trace.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.ext.postgresql import trace
 

--- a/contrib/opencensus-ext-prometheus/tests/test_prometheus_stats.py
+++ b/contrib/opencensus-ext-prometheus/tests/test_prometheus_stats.py
@@ -15,7 +15,10 @@
 import unittest
 from datetime import datetime
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 from prometheus_client.core import Sample
 
 from opencensus.ext.prometheus import stats_exporter as prometheus

--- a/contrib/opencensus-ext-pymongo/tests/test_pymongo_trace.py
+++ b/contrib/opencensus-ext-pymongo/tests/test_pymongo_trace.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.ext.pymongo import trace
 

--- a/contrib/opencensus-ext-pymysql/tests/test_pymysql_trace.py
+++ b/contrib/opencensus-ext-pymysql/tests/test_pymysql_trace.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.ext.pymysql import trace
 

--- a/contrib/opencensus-ext-pyramid/tests/test_pyramid_config.py
+++ b/contrib/opencensus-ext-pyramid/tests/test_pyramid_config.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.ext.pyramid import config
 

--- a/contrib/opencensus-ext-pyramid/tests/test_pyramid_middleware.py
+++ b/contrib/opencensus-ext-pyramid/tests/test_pyramid_middleware.py
@@ -17,7 +17,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 from pyramid.registry import Registry
 from pyramid.response import Response
 from pyramid.testing import DummyRequest

--- a/contrib/opencensus-ext-requests/tests/test_requests_trace.py
+++ b/contrib/opencensus-ext-requests/tests/test_requests_trace.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import requests
 
 from opencensus.ext.requests import trace

--- a/contrib/opencensus-ext-sqlalchemy/tests/test_sqlalchemy_trace.py
+++ b/contrib/opencensus-ext-sqlalchemy/tests/test_sqlalchemy_trace.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.ext.sqlalchemy import trace
 from opencensus.trace import span as span_module

--- a/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_exporter.py
+++ b/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_exporter.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.common.version import __version__
 from opencensus.ext.stackdriver import trace_exporter

--- a/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_stats.py
+++ b/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_stats.py
@@ -16,7 +16,10 @@ import unittest
 from datetime import datetime, timedelta
 
 import google.auth
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 from google.api import metric_pb2
 from google.cloud import monitoring_v3
 

--- a/contrib/opencensus-ext-threading/tests/test_threading_trace.py
+++ b/contrib/opencensus-ext-threading/tests/test_threading_trace.py
@@ -17,7 +17,10 @@ import unittest
 from concurrent.futures import ThreadPoolExecutor
 from multiprocessing.pool import Pool
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.ext.threading import trace
 from opencensus.trace import execution_context, tracer

--- a/contrib/opencensus-ext-zipkin/tests/test_zipkin_exporter.py
+++ b/contrib/opencensus-ext-zipkin/tests/test_zipkin_exporter.py
@@ -15,7 +15,10 @@
 import unittest
 from datetime import datetime
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.ext.zipkin import trace_exporter
 from opencensus.trace import span_context

--- a/tests/system/stats/stackdriver/stackdriver_stats_test.py
+++ b/tests/system/stats/stackdriver/stackdriver_stats_test.py
@@ -17,7 +17,10 @@ import random
 import sys
 import time
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 from google.cloud import monitoring_v3
 
 from opencensus.ext.stackdriver import stats_exporter as stackdriver

--- a/tests/unit/common/monitored_resource_util/test_aws_identity_doc_utils.py
+++ b/tests/unit/common/monitored_resource_util/test_aws_identity_doc_utils.py
@@ -15,7 +15,10 @@
 import json
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.common.monitored_resource import aws_identity_doc_utils
 

--- a/tests/unit/common/monitored_resource_util/test_gcp_metadata_config.py
+++ b/tests/unit/common/monitored_resource_util/test_gcp_metadata_config.py
@@ -15,7 +15,10 @@
 import os
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.common.monitored_resource import gcp_metadata_config
 

--- a/tests/unit/common/monitored_resource_util/test_k8s_utils.py
+++ b/tests/unit/common/monitored_resource_util/test_k8s_utils.py
@@ -15,7 +15,10 @@
 import os
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.common.monitored_resource import k8s_utils
 

--- a/tests/unit/common/monitored_resource_util/test_monitored_resource.py
+++ b/tests/unit/common/monitored_resource_util/test_monitored_resource.py
@@ -16,7 +16,10 @@ import os
 import sys
 from contextlib import contextmanager
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.common.monitored_resource import monitored_resource
 

--- a/tests/unit/common/test_http_handler.py
+++ b/tests/unit/common/test_http_handler.py
@@ -16,7 +16,10 @@ import json
 import socket
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.common.http_handler import get_request
 

--- a/tests/unit/common/test_resource.py
+++ b/tests/unit/common/test_resource.py
@@ -17,7 +17,10 @@
 import os
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.common import resource as resource_module
 from opencensus.common.resource import Resource

--- a/tests/unit/common/test_utils.py
+++ b/tests/unit/common/test_utils.py
@@ -29,7 +29,10 @@ import gc
 import unittest
 import weakref
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.common import utils
 

--- a/tests/unit/common/transports/test_async.py
+++ b/tests/unit/common/transports/test_async.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.common.transports import async_
 

--- a/tests/unit/common/transports/test_sync.py
+++ b/tests/unit/common/transports/test_sync.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.common.transports import sync
 

--- a/tests/unit/log/test_log.py
+++ b/tests/unit/log/test_log.py
@@ -16,7 +16,10 @@ import logging
 import sys
 from contextlib import contextmanager
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus import log
 

--- a/tests/unit/metrics/export/test_cumulative.py
+++ b/tests/unit/metrics/export/test_cumulative.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 from opencensus.metrics.export import cumulative, gauge, metric_descriptor
 from opencensus.metrics.export import value as value_module

--- a/tests/unit/metrics/export/test_gauge.py
+++ b/tests/unit/metrics/export/test_gauge.py
@@ -15,7 +15,10 @@
 import gc
 import unittest
 
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 from opencensus.metrics.export import gauge, metric_descriptor
 from opencensus.metrics.export import value as value_module

--- a/tests/unit/metrics/test_transport.py
+++ b/tests/unit/metrics/test_transport.py
@@ -16,7 +16,10 @@ import gc
 import sys
 import time
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.metrics import transport
 

--- a/tests/unit/stats/test_aggregation.py
+++ b/tests/unit/stats/test_aggregation.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.metrics.export import value
 from opencensus.stats import aggregation as aggregation_module

--- a/tests/unit/stats/test_aggregation_data.py
+++ b/tests/unit/stats/test_aggregation_data.py
@@ -16,7 +16,10 @@ import time
 import unittest
 from datetime import datetime
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.metrics.export import point
 from opencensus.metrics.export import value as value_module

--- a/tests/unit/stats/test_base_stats.py
+++ b/tests/unit/stats/test_base_stats.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.stats import base_exporter
 

--- a/tests/unit/stats/test_measure_to_view_map.py
+++ b/tests/unit/stats/test_measure_to_view_map.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.stats import measure_to_view_map as measure_to_view_map_module
 from opencensus.stats.aggregation import CountAggregation

--- a/tests/unit/stats/test_measurement_map.py
+++ b/tests/unit/stats/test_measurement_map.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.stats import measurement_map as measurement_map_module
 from opencensus.tags import Tag, TagContext, TagMap

--- a/tests/unit/stats/test_metric_utils.py
+++ b/tests/unit/stats/test_metric_utils.py
@@ -15,7 +15,10 @@
 import datetime
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.metrics.export import metric_descriptor, point, value
 from opencensus.stats import (

--- a/tests/unit/stats/test_stats_recorder.py
+++ b/tests/unit/stats/test_stats_recorder.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.stats import execution_context
 from opencensus.stats import stats_recorder as stats_recorder_module

--- a/tests/unit/stats/test_view.py
+++ b/tests/unit/stats/test_view.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.metrics.export import metric_descriptor
 from opencensus.stats import aggregation, measure

--- a/tests/unit/stats/test_view_data.py
+++ b/tests/unit/stats/test_view_data.py
@@ -15,7 +15,10 @@
 import unittest
 from datetime import datetime
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.common import utils
 from opencensus.stats import aggregation as aggregation_module

--- a/tests/unit/stats/test_view_manager.py
+++ b/tests/unit/stats/test_view_manager.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.stats import execution_context
 from opencensus.stats import view_manager as view_manager_module

--- a/tests/unit/trace/exporters/test_logging_exporter.py
+++ b/tests/unit/trace/exporters/test_logging_exporter.py
@@ -15,7 +15,10 @@
 import logging
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.trace import logging_exporter, span_context
 from opencensus.trace import span_data as span_data_module

--- a/tests/unit/trace/propagation/test_b3_format.py
+++ b/tests/unit/trace/propagation/test_b3_format.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.trace.propagation import b3_format
 from opencensus.trace.span_context import INVALID_SPAN_ID

--- a/tests/unit/trace/propagation/test_binary_format.py
+++ b/tests/unit/trace/propagation/test_binary_format.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.trace.propagation import binary_format
 

--- a/tests/unit/trace/propagation/test_text_format.py
+++ b/tests/unit/trace/propagation/test_text_format.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.trace.propagation import text_format
 

--- a/tests/unit/trace/samplers/test_always_off.py
+++ b/tests/unit/trace/samplers/test_always_off.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 class TestAlwaysOffSampler(unittest.TestCase):

--- a/tests/unit/trace/samplers/test_always_on.py
+++ b/tests/unit/trace/samplers/test_always_on.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 class TestAlwaysOnSampler(unittest.TestCase):

--- a/tests/unit/trace/samplers/test_base_sampler.py
+++ b/tests/unit/trace/samplers/test_base_sampler.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 class TestBaseSampler(unittest.TestCase):

--- a/tests/unit/trace/samplers/test_probability.py
+++ b/tests/unit/trace/samplers/test_probability.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.trace import samplers
 

--- a/tests/unit/trace/test_attributes.py
+++ b/tests/unit/trace/test_attributes.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.trace import attributes as attributes_module
 

--- a/tests/unit/trace/test_base_span.py
+++ b/tests/unit/trace/test_base_span.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.trace.base_span import BaseSpan
 

--- a/tests/unit/trace/test_blank_span.py
+++ b/tests/unit/trace/test_blank_span.py
@@ -15,7 +15,10 @@
 import datetime
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.common import utils
 from opencensus.trace.link import Link

--- a/tests/unit/trace/test_config_integration.py
+++ b/tests/unit/trace/test_config_integration.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.trace import config_integration
 

--- a/tests/unit/trace/test_execution_context.py
+++ b/tests/unit/trace/test_execution_context.py
@@ -15,7 +15,10 @@
 import threading
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.trace import execution_context
 

--- a/tests/unit/trace/test_ext_utils.py
+++ b/tests/unit/trace/test_ext_utils.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 from google.rpc import code_pb2
 
 from opencensus.trace import utils

--- a/tests/unit/trace/test_link.py
+++ b/tests/unit/trace/test_link.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.trace import link as link_module
 

--- a/tests/unit/trace/test_span.py
+++ b/tests/unit/trace/test_span.py
@@ -16,7 +16,10 @@ import datetime
 import unittest
 from collections import OrderedDict
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 from google.rpc import code_pb2
 
 from opencensus.common import utils

--- a/tests/unit/trace/test_stack_trace.py
+++ b/tests/unit/trace/test_stack_trace.py
@@ -15,7 +15,10 @@
 import sys
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.trace import stack_trace as stack_trace_module
 

--- a/tests/unit/trace/test_time_event.py
+++ b/tests/unit/trace/test_time_event.py
@@ -15,7 +15,10 @@
 import unittest
 from datetime import datetime
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.trace import time_event as time_event_module
 

--- a/tests/unit/trace/test_tracer.py
+++ b/tests/unit/trace/test_tracer.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.trace import samplers, span_data
 from opencensus.trace import tracer as tracer_module

--- a/tests/unit/trace/tracers/test_context_tracer.py
+++ b/tests/unit/trace/tracers/test_context_tracer.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opencensus.trace import execution_context, span
 from opencensus.trace.tracers import context_tracer


### PR DESCRIPTION
Python >= 3.3 provides mock through unittest.mock. No need to explicitly install the PyPI package (soo to be deprecated by newer pythons)