### PR TITLE
Support AAD authentication

### DIFF
--- a/contrib/opencensus-ext-azure/CHANGELOG.md
+++ b/contrib/opencensus-ext-azure/CHANGELOG.md
@@ -5,7 +5,9 @@
 - Fix `logger.exception` with no exception info throwing error
 ([#1006](https://github.com/census-instrumentation/opencensus-python/pull/1006))
 - Add `enable_local_storage` to turn on/off local storage + retry + flushing logic
-([#1006](https://github.com/census-instrumentation/opencensus-python/pull/1006))
+([#1016](https://github.com/census-instrumentation/opencensus-python/pull/1016))
+- Enable AAD authorization via TokenCredential
+([#1016](https://github.com/census-instrumentation/opencensus-python/pull/1016))
 
 ## 1.0.7
 Released 2021-01-25

--- a/contrib/opencensus-ext-azure/examples/traces/credential.py
+++ b/contrib/opencensus-ext-azure/examples/traces/credential.py
@@ -1,0 +1,32 @@
+# Copyright 2021, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from azure.identity import VisualStudioCodeCredential
+from opencensus.ext.azure.trace_exporter import AzureExporter
+from opencensus.trace.samplers import ProbabilitySampler
+from opencensus.trace.tracer import Tracer
+
+# This example uses VisualStudioCodeCredential, which authenticates
+# an Azure user signed into Visual Studio Code
+# See https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/identity/azure-identity/README.md#credential-classes
+# for different credential classes.
+credential = VisualStudioCodeCredential()
+
+# TODO: you need to specify the instrumentation key in a connection string
+# and place it in the APPLICATIONINSIGHTS_CONNECTION_STRING
+# environment variable.
+tracer = Tracer(exporter=AzureExporter(credential=credential), sampler=ProbabilitySampler(1.0))
+
+with tracer.span(name='foo'):
+    print('Hello, World!')
+input(...)

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
@@ -48,6 +48,14 @@ def process_options(options):
         or 'https://dc.services.visualstudio.com'
     options.endpoint = endpoint + '/v2/track'
 
+    # Authorization
+    # `azure.core.credentials.TokenCredential` class must be valid
+    if options.credential and \
+        not hasattr(options.credential, 'get_token'):
+        raise ValueError(
+            'Must pass in valid TokenCredential.'
+        )
+
     # storage path
     if options.storage_path is None:
         TEMPDIR_SUFFIX = options.instrumentation_key or ""
@@ -101,6 +109,7 @@ class Options(BaseObject):
 
     _default = BaseObject(
         connection_string=None,
+        credential=None,
         enable_local_storage=True,
         enable_standard_metrics=True,
         endpoint='https://dc.services.visualstudio.com/v2/track',

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/transport.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/transport.py
@@ -17,8 +17,11 @@ import logging
 
 import requests
 
-logger = logging.getLogger(__name__)
+from azure.core.exceptions import ClientAuthenticationError
+from azure.identity._exceptions import CredentialUnavailableError
 
+logger = logging.getLogger(__name__)
+_MONITOR_OAUTH_SCOPE = "https://monitor.azure.com/.default"
 
 class TransportMixin(object):
     def _transmit_from_storage(self):
@@ -45,13 +48,17 @@ class TransportMixin(object):
         if not envelopes:
             return 0
         try:
+            headers = {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json; charset=utf-8',
+            }
+            if self.options.credential:
+                token = self.options.credential.get_token(_MONITOR_OAUTH_SCOPE)
+                headers["Authorization"] = "Bearer {}".format(token.token)
             response = requests.post(
                 url=self.options.endpoint,
                 data=json.dumps(envelopes),
-                headers={
-                    'Accept': 'application/json',
-                    'Content-Type': 'application/json; charset=utf-8',
-                },
+                headers=headers,
                 timeout=self.options.timeout,
                 proxies=json.loads(self.options.proxies),
             )
@@ -59,11 +66,26 @@ class TransportMixin(object):
             logger.warning(
                 'Request time out. Ingestion may be backed up. Retrying.')
             return self.options.minimum_retry_interval
-        except Exception as ex:  # TODO: consider RequestException
+        except requests.RequestException as ex:
             logger.warning(
                 'Retrying due to transient client side error %s.', ex)
             # client side error (retryable)
             return self.options.minimum_retry_interval
+        except CredentialUnavailableError as ex:
+            logger.warning(
+                'Error with credential configuration %s', ex
+            )
+            return -1
+        except ClientAuthenticationError as ex:
+            logger.warning(
+                'Error getting token %s', ex
+            )
+            return self.options.minimum_retry_interval
+        except Exception as ex:
+            logger.warning(
+                'Error when sending request %s. Dropping telemetry.', ex)
+            # Extraneous error (non-retryable)
+            return -1
 
         text = 'N/A'
         data = None
@@ -119,6 +141,13 @@ class TransportMixin(object):
                 text,
             )
             # server side error (retryable)
+            return self.options.minimum_retry_interval
+        # Authentication error
+        if response.status_code == 401:
+            logger.warning(
+                'Unauthorized to send telemetry to this endpoint. Your '
+                'credentials may not have the correct permissions'
+            )
             return self.options.minimum_retry_interval
         logger.error(
             'Non-retryable server side error %s: %s.',

--- a/contrib/opencensus-ext-azure/setup.py
+++ b/contrib/opencensus-ext-azure/setup.py
@@ -39,6 +39,8 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
+        'azure-core >= 1.12.0, < 2.0.0',
+        'azure-identity >= 1.5.0 < 2.0.0',
         'opencensus >= 0.8.dev0, < 1.0.0',
         'psutil >= 5.6.3',
         'requests >= 2.19.0',


### PR DESCRIPTION
Support for AAD auth depends on `azure-core` and `azure-identity` only for the exception handling.

Refer to this [doc](https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/identity/azure-identity/README.md#error-handling) for when each exception is thrown. One is a retry case, another is a (possible) drop case.

Users must pass in a [TokenCredential](https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/core/azure-core/azure/core/credentials.py#L16) to exporter constructors to utilize this feature. Refer to [this](https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/identity/azure-identity/README.md#credential-classes) for a list of valid credential classes.