### PR TITLE
Fix set trace attributes for django when host is not allowed

### DIFF
--- a/contrib/opencensus-ext-django/opencensus/ext/django/middleware.py
+++ b/contrib/opencensus-ext-django/opencensus/ext/django/middleware.py
@@ -208,7 +208,7 @@ class OpencensusMiddleware(MiddlewareMixin):
             span.span_kind = span_module.SpanKind.SERVER
             tracer.add_attribute_to_current_span(
                 attribute_key=HTTP_HOST,
-                attribute_value=request.get_host())
+                attribute_value=request._get_raw_host())
             tracer.add_attribute_to_current_span(
                 attribute_key=HTTP_METHOD,
                 attribute_value=request.method)
@@ -220,7 +220,7 @@ class OpencensusMiddleware(MiddlewareMixin):
                 attribute_value=str(request.path))
             tracer.add_attribute_to_current_span(
                 attribute_key=HTTP_URL,
-                attribute_value=str(request.build_absolute_uri()))
+                attribute_value=str(request.get_raw_uri()))
 
             # Add the span to thread local
             # in some cases (exceptions, timeouts) currentspan in


### PR DESCRIPTION
`request.get_host()` raises DisallowedHost exception if request came with HOST witch not configured
in ALLOWED_HOSTS setting.

Django provides special methods `request._get_raw_host()` and `request.get_raw_uri()` to get values
like `get_host()` and `build_absolute_uri()` but without checking by ALLOWED_HOSTS.

Without fix error will be like:

```
ERROR    opencensus.ext.django.middleware:middleware.py:235 Failed to trace request
Traceback (most recent call last):
  File "/home/konst/develop/opencensus-python/contrib/opencensus-ext-django/opencensus/ext/django/middleware.py", line 211, in process_request
    attribute_value=request.get_host())
  File "/home/konst/develop/opencensus-python/.nox/unit-2-7/lib/python2.7/site-packages/django/http/request.py", line 113, in get_host
    raise DisallowedHost(msg)
DisallowedHost: Invalid HTTP_HOST header: 'notallowedhost'. You may need to add u'notallowedhost' to ALLOWED_HOSTS.
```