### PR TITLE
Se02035/fix/use existing tracer for logging

### DIFF
--- a/contrib/opencensus-ext-logging/opencensus/ext/logging/trace.py
+++ b/contrib/opencensus-ext-logging/opencensus/ext/logging/trace.py
@@ -15,6 +15,7 @@
 import logging
 
 from opencensus.log import TraceLogger
+from opencensus.trace import execution_context
 
 
 def trace_integration(tracer=None):
@@ -26,7 +27,7 @@ def trace_integration(tracer=None):
     """
 
     if tracer is not None:
-        # Ensure that the execution context is updated and the 
+        # Ensure that the execution context is updated and the
         # TraceLogger uses it
         execution_context.set_opencensus_tracer(tracer)
 

--- a/contrib/opencensus-ext-logging/opencensus/ext/logging/trace.py
+++ b/contrib/opencensus-ext-logging/opencensus/ext/logging/trace.py
@@ -24,4 +24,10 @@ def trace_integration(tracer=None):
     with extra traceId, spanId, and traceSampled attributes from the opencensus
     context.
     """
+
+    if tracer is not None:
+        # Ensure that the execution context is updated and the 
+        # TraceLogger uses it
+        execution_context.set_opencensus_tracer(tracer)
+
     logging.setLoggerClass(TraceLogger)


### PR DESCRIPTION
# What we are trying to address

Fixes bug in the opencensus logging extension (bug: provided tracer instance will be ignored). If the provided tracer instance is ignored, then the logger won't use the tracer properties (e.g. correlation ids). As a result logs won't have the wrong correlation id. 

## Description of Changes

- Ensure that the execution context gets updated with the provided tracer instance (if there is one)
- Added an unit test to ensure that the execution context gets updated. 

## Additional Information
This PR is a fix for issue **https://github.com/census-instrumentation/opencensus-python/issues/1043**
