### PR TITLE
Add google cloud core dependency to opencensus-ext-google-cloud-clientlibs

### DIFF
--- a/contrib/opencensus-ext-google-cloud-clientlibs/CHANGELOG.md
+++ b/contrib/opencensus-ext-google-cloud-clientlibs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added missing google-cloud-core dependency
+  [#1049](https://github.com/census-instrumentation/opencensus-python/pull/1049)
+
 ## 0.1.2
 Released 2019-04-24
 

--- a/contrib/opencensus-ext-google-cloud-clientlibs/setup.py
+++ b/contrib/opencensus-ext-google-cloud-clientlibs/setup.py
@@ -44,6 +44,8 @@ setup(
         'opencensus >= 0.8.dev0, < 1.0.0',
         'opencensus-ext-grpc >= 0.3.0, < 1.0.0',
         'opencensus-ext-requests >= 0.1.2, < 1.0.0',
+        'google-cloud-core ~= 1.7; python_version == "2.7" or python_version >= "3.6"',
+        'google-cloud-core ~= 1.4; python_version == "3.4" or python_version == "3.5"',
     ],
     extras_require={},
     license='Apache-2.0',

--- a/contrib/opencensus-ext-google-cloud-clientlibs/setup.py
+++ b/contrib/opencensus-ext-google-cloud-clientlibs/setup.py
@@ -44,8 +44,8 @@ setup(
         'opencensus >= 0.8.dev0, < 1.0.0',
         'opencensus-ext-grpc >= 0.3.0, < 1.0.0',
         'opencensus-ext-requests >= 0.1.2, < 1.0.0',
-        'google-cloud-core ~= 1.7; python_version == "2.7" or python_version >= "3.6"',
-        'google-cloud-core ~= 1.4; python_version == "3.4" or python_version == "3.5"',
+        'google-cloud-core ~= 1.7; python_version == "2.7" or python_version >= "3.6"',  # noqa: E501
+        'google-cloud-core ~= 1.4; python_version == "3.4" or python_version == "3.5"',  # noqa: E501
     ],
     extras_require={},
     license='Apache-2.0',


### PR DESCRIPTION
This dependency was not explicit before because it should be there if
you are using a google cloud clientlib. However, if you install this
package without the `google-cloud-core` package, you will see import
errors.

`google-cloud-core` dropped support for 3.4 and 3.5, but kept support
for 2.7. The version specifiers reflect this.
