### PR TITLE
upgrade opencensus-ext-stackdriver to use google-cloud-monitoring v2 library

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,6 @@ jobs:
         with:
           path: .tox
           # bump version prefix to fully reset caches
-          key: v2-tox-${{ matrix.python-version }}-${{ hashFiles('tox.ini') }}
+          key: v1-tox-${{ matrix.python-version }}-${{ hashFiles('tox.ini', '**/setup.py') }}
       - name: run tox
         run: tox -f ${{ matrix.python-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,6 @@ jobs:
         with:
           path: .tox
           # bump version prefix to fully reset caches
-          key: v1-tox-${{ matrix.python-version }}-${{ hashFiles('tox.ini') }}
+          key: v2-tox-${{ matrix.python-version }}-${{ hashFiles('tox.ini') }}
       - name: run tox
         run: tox -f ${{ matrix.python-version }}

--- a/contrib/opencensus-ext-stackdriver/setup.py
+++ b/contrib/opencensus-ext-stackdriver/setup.py
@@ -37,7 +37,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'google-cloud-monitoring >= 0.30.0, < 1.0.0',
+        'google-cloud-monitoring ~= 2.0',
         'google-cloud-trace >= 0.20.0, < 1.0.0',
         'rsa <= 4.0; python_version<="3.4"',
         'opencensus >= 0.8.dev0, < 1.0.0',

--- a/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_stats.py
+++ b/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_stats.py
@@ -852,10 +852,12 @@ class TestCreateTimeseries(unittest.TestCase):
         )
         self.assertEqual(value.distribution_value, expected_distb)
 
-        self.assertEqual(time_series.points[0].interval.start_time.seconds, 1545699663)
-        self.assertEqual(time_series.points[0].interval.start_time.nanos, 4053)
-        self.assertEqual(time_series.points[0].interval.end_time.seconds, 1545699723)
-        self.assertEqual(time_series.points[0].interval.end_time.nanos, 4053)
+        start_time_pb = time_series.points[0].interval.start_time.timestamp_pb()
+        end_time_pb = time_series.points[0].interval.end_time.timestamp_pb()
+        self.assertEqual(start_time_pb.seconds, 1545699663)
+        self.assertEqual(start_time_pb.nanos, 4053)
+        self.assertEqual(end_time_pb.seconds, 1545699723)
+        self.assertEqual(end_time_pb.nanos, 4053)
 
     @mock.patch('opencensus.ext.stackdriver.stats_exporter.'
                 'monitored_resource.get_instance')

--- a/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_stats.py
+++ b/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_stats.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import unittest
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import google.auth
 import mock
@@ -812,6 +812,9 @@ class TestCreateTimeseries(unittest.TestCase):
         v_data = measure_map.measure_to_view_map.get_view(
             VIDEO_SIZE_VIEW_NAME, None)
 
+        v_data._start_time = (
+            TEST_TIME - timedelta(minutes=1)
+        ).strftime(stackdriver.EPOCH_PATTERN)
         v_data = metric_utils.view_data_to_metric(v_data, TEST_TIME)
 
         time_series_list = exporter.create_time_series_list(v_data)
@@ -839,6 +842,11 @@ class TestCreateTimeseries(unittest.TestCase):
             bucket_counts=[0, 0, 1, 0]
         )
         self.assertEqual(value.distribution_value, expected_distb)
+
+        self.assertEqual(time_series.points[0].interval.start_time.seconds, 1545699663)
+        self.assertEqual(time_series.points[0].interval.start_time.nanos, 4053)
+        self.assertEqual(time_series.points[0].interval.end_time.seconds, 1545699723)
+        self.assertEqual(time_series.points[0].interval.end_time.nanos, 4053)
 
     @mock.patch('opencensus.ext.stackdriver.stats_exporter.'
                 'monitored_resource.get_instance')

--- a/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_stats.py
+++ b/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_stats.py
@@ -17,6 +17,7 @@ from datetime import datetime, timedelta
 
 import google.auth
 import mock
+from google.api import metric_pb2
 from google.cloud import monitoring_v3
 
 from opencensus.common import utils
@@ -433,12 +434,12 @@ class TestStackdriverStatsExporter(unittest.TestCase):
         sd_md = exporter.get_metric_descriptor(oc_md)
         self.assertEqual(
             sd_md.metric_kind,
-            monitoring_v3.enums.MetricDescriptor.MetricKind.GAUGE)
+            metric_pb2.MetricDescriptor.MetricKind.GAUGE)
         self.assertEqual(
             sd_md.value_type,
-            monitoring_v3.enums.MetricDescriptor.ValueType.INT64)
+            metric_pb2.MetricDescriptor.ValueType.INT64)
 
-        self.assertIsInstance(sd_md, monitoring_v3.types.MetricDescriptor)
+        self.assertIsInstance(sd_md, metric_pb2.MetricDescriptor)
         exporter.client.create_metric_descriptor.assert_not_called()
 
     def test_get_metric_descriptor_bad_type(self):
@@ -530,9 +531,13 @@ class TestStackdriverStatsExporter(unittest.TestCase):
         exporter.export_metrics([mm])
 
         self.assertEqual(exporter.client.create_time_series.call_count, 1)
-        sd_args = exporter.client.create_time_series.call_args[0][1]
+        sd_args = exporter.client.create_time_series.call_args.kwargs[
+            'time_series'
+        ]
         self.assertEqual(len(sd_args), 1)
-        [sd_arg] = exporter.client.create_time_series.call_args[0][1]
+        [sd_arg] = exporter.client.create_time_series.call_args.kwargs[
+            'time_series'
+        ]
         self.assertEqual(sd_arg.points[0].value.int64_value, 123)
 
 
@@ -654,21 +659,25 @@ class TestAsyncStatsExport(unittest.TestCase):
             exporter.client.create_metric_descriptor.call_count,
             1)
         md_call_arg =\
-            exporter.client.create_metric_descriptor.call_args[0][1]
+            exporter.client.create_metric_descriptor.call_args.kwargs[
+                'metric_descriptor'
+            ]
         self.assertEqual(
             md_call_arg.metric_kind,
-            monitoring_v3.enums.MetricDescriptor.MetricKind.GAUGE
+            metric_pb2.MetricDescriptor.MetricKind.GAUGE
         )
         self.assertEqual(
             md_call_arg.value_type,
-            monitoring_v3.enums.MetricDescriptor.ValueType.INT64
+            metric_pb2.MetricDescriptor.ValueType.INT64
         )
 
         exporter.client.create_time_series.assert_called()
         self.assertEqual(
             exporter.client.create_time_series.call_count,
             1)
-        ts_call_arg = exporter.client.create_time_series.call_args[0][1]
+        ts_call_arg = exporter.client.create_time_series.call_args.kwargs[
+            'time_series'
+        ]
         self.assertEqual(len(ts_call_arg), 1)
         self.assertEqual(len(ts_call_arg[0].points), 1)
         self.assertEqual(ts_call_arg[0].points[0].value.int64_value, 123)
@@ -1032,7 +1041,7 @@ class TestCreateTimeseries(unittest.TestCase):
         self.assertIsNotNone(time_series.resource)
 
         self.assertEqual(len(time_series.points), 1)
-        expected_value = monitoring_v3.types.TypedValue()
+        expected_value = monitoring_v3.TypedValue()
         # TODO: #565
         expected_value.double_value = 25.0 * MiB
         self.assertEqual(time_series.points[0].value, expected_value)
@@ -1074,7 +1083,7 @@ class TestCreateTimeseries(unittest.TestCase):
         self.assertIsNotNone(time_series.resource)
 
         self.assertEqual(len(time_series.points), 1)
-        expected_value = monitoring_v3.types.TypedValue()
+        expected_value = monitoring_v3.TypedValue()
         expected_value.int64_value = 3
         self.assertEqual(time_series.points[0].value, expected_value)
 
@@ -1115,7 +1124,7 @@ class TestCreateTimeseries(unittest.TestCase):
         self.assertIsNotNone(time_series.resource)
 
         self.assertEqual(len(time_series.points), 1)
-        expected_value = monitoring_v3.types.TypedValue()
+        expected_value = monitoring_v3.TypedValue()
         expected_value.double_value = 25.7 * MiB
         self.assertEqual(time_series.points[0].value, expected_value)
 
@@ -1171,7 +1180,7 @@ class TestCreateTimeseries(unittest.TestCase):
         self.assertIsNotNone(time_series.resource)
 
         self.assertEqual(len(time_series.points), 1)
-        expected_value = monitoring_v3.types.TypedValue()
+        expected_value = monitoring_v3.TypedValue()
         expected_value.double_value = 2.2 + 25 * MiB
         self.assertEqual(time_series.points[0].value, expected_value)
 
@@ -1298,7 +1307,7 @@ class TestCreateTimeseries(unittest.TestCase):
         self.assertIsNotNone(time_series.resource)
 
         self.assertEqual(len(time_series.points), 1)
-        expected_value = monitoring_v3.types.TypedValue()
+        expected_value = monitoring_v3.TypedValue()
         # TODO: #565
         expected_value.double_value = 25.0 * MiB
         self.assertEqual(time_series.points[0].value, expected_value)

--- a/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_stats.py
+++ b/contrib/opencensus-ext-stackdriver/tests/test_stackdriver_stats.py
@@ -852,7 +852,9 @@ class TestCreateTimeseries(unittest.TestCase):
         )
         self.assertEqual(value.distribution_value, expected_distb)
 
-        start_time_pb = time_series.points[0].interval.start_time.timestamp_pb()
+        start_time_pb = (
+            time_series.points[0].interval.start_time.timestamp_pb()
+        )
         end_time_pb = time_series.points[0].interval.end_time.timestamp_pb()
         self.assertEqual(start_time_pb.seconds, 1545699663)
         self.assertEqual(start_time_pb.nanos, 4053)

--- a/tests/system/stats/stackdriver/stackdriver_stats_test.py
+++ b/tests/system/stats/stackdriver/stackdriver_stats_test.py
@@ -46,7 +46,7 @@ class TestBasicStats(unittest.TestCase):
 
     def check_sd_md(self, exporter, view_description):
         """Check that the metric descriptor was written to stackdriver."""
-        name = exporter.client.project_path(PROJECT)
+        name = exporter.client.common_project_path(PROJECT)
         list_metrics_descriptors = exporter.client.list_metric_descriptors(
             name)
 


### PR DESCRIPTION
Fixes #1046

See migration guide [here](https://googleapis.dev/python/monitoring/2.4.2/UPGRADING.html), which mostly covered everything.

In addition, the `google-cloud-monitoring` v2 library uses [proto-plus](https://github.com/googleapis/proto-plus-python) instead of raw generated protoc objects. These have slightly different usage, e.g. no `.add()` on repeated fields and different timestamp behavior.

I manually tested the exporter example and things are working