### PR TITLE
Support setting cloud role name via envvar

### DIFF
--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/utils.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/utils.py
@@ -23,19 +23,35 @@ from opencensus.common.utils import timestamp_to_microseconds, to_iso_str
 from opencensus.common.version import __version__ as opencensus_version
 from opencensus.ext.azure.common.version import __version__ as ext_version
 
-azure_monitor_context = {
-    'ai.cloud.role': os.path.basename(sys.argv[0]) or 'Python Application',
-    'ai.cloud.roleInstance': platform.node(),
-    'ai.device.id': platform.node(),
-    'ai.device.locale': locale.getdefaultlocale()[0],
-    'ai.device.osVersion': platform.version(),
-    'ai.device.type': 'Other',
-    'ai.internal.sdkVersion': 'py{}:oc{}:ext{}'.format(
-        platform.python_version(),
-        opencensus_version,
-        ext_version,
-    ),
-}
+_azure_monitor_context = {}
+
+
+def get_azure_monitor_context(
+        role_name=(
+            os.getenv('APPLICATIONINSIGHTS_ROLE_NAME') or
+            os.path.basename(sys.argv[0]) or
+            'Python Application'),
+        role_instance=platform.node(),
+        device_id=platform.node(),
+        device_locale=locale.getdefaultlocale()[0],
+        device_osVersion=platform.version(),
+        device_type='Other',
+        internal_sdkVersion='py{}:oc{}:ext{}'.format(
+            platform.python_version(), opencensus_version, ext_version)):
+    global _azure_monitor_context
+
+    if not _azure_monitor_context:
+        _azure_monitor_context = {
+            'ai.cloud.role': role_name,
+            'ai.cloud.roleInstance': role_instance,
+            'ai.device.id': device_id,
+            'ai.device.locale': device_locale,
+            'ai.device.osVersion': device_osVersion,
+            'ai.device.type': device_type,
+            'ai.internal.sdkVersion': internal_sdkVersion,
+        }
+
+    return _azure_monitor_context
 
 
 def microseconds_to_duration(microseconds):

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/log_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/log_exporter/__init__.py
@@ -251,7 +251,7 @@ class AzureEventHandler(TransportMixin, ProcessorMixin, BaseLogHandler):
 def create_envelope(instrumentation_key, record):
     envelope = Envelope(
         iKey=instrumentation_key,
-        tags=dict(utils.azure_monitor_context),
+        tags=dict(utils.get_azure_monitor_context()),
         time=utils.timestamp_to_iso_str(record.created),
     )
     envelope.tags['ai.operation.id'] = getattr(

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/__init__.py
@@ -129,7 +129,7 @@ class MetricsExporter(TransportMixin, ProcessorMixin):
     def _create_envelope(self, data_point, timestamp, properties):
         envelope = Envelope(
             iKey=self.options.instrumentation_key,
-            tags=dict(utils.azure_monitor_context),
+            tags=dict(utils.get_azure_monitor_context()),
             time=timestamp.isoformat(),
         )
         if self._is_stats:

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/trace_exporter/__init__.py
@@ -82,7 +82,7 @@ class AzureExporter(BaseExporter, ProcessorMixin, TransportMixin):
     def span_data_to_envelope(self, sd):
         envelope = Envelope(
             iKey=self.options.instrumentation_key,
-            tags=dict(utils.azure_monitor_context),
+            tags=dict(utils.get_azure_monitor_context()),
             time=sd.start_time,
         )
 

--- a/contrib/opencensus-ext-azure/tests/test_azure_utils.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_utils.py
@@ -18,6 +18,7 @@ from opencensus.ext.azure.common import utils
 
 
 class TestUtils(unittest.TestCase):
+
     def test_microseconds_to_duration(self):
         us_to_duration = utils.microseconds_to_duration
         self.assertEqual(us_to_duration(0), '0.00:00:00.000')
@@ -132,3 +133,45 @@ class TestUtils(unittest.TestCase):
     def test_valid_key_section4_hex(self):
         key = '1234abcd-5678-4efa-cabc-1234567890ab'
         self.assertIsNone(utils.validate_instrumentation_key(key))
+
+    def test_correct_initialization_monitor_context(self):
+        role_name = 'test_role_name'
+        role_instance = 'test_role_instance'
+        device_id = 'test_device_id'
+        device_locale = 'test_device_locale'
+        device_osVersion = 'test_device_osVersion'
+        device_type = 'test_device_type'
+        internal_sdkVersion = 'test_internal_sdkVersion'
+
+        utils._azure_monitor_context = {}
+
+        context = utils.get_azure_monitor_context(
+            role_name=role_name,
+            role_instance=role_instance,
+            device_id=device_id,
+            device_locale=device_locale,
+            device_osVersion=device_osVersion,
+            device_type=device_type,
+            internal_sdkVersion=internal_sdkVersion)
+
+        self.assertEqual(context['ai.cloud.role'], role_name)
+        self.assertEqual(context['ai.cloud.roleInstance'], role_instance)
+        self.assertEqual(context['ai.device.id'], device_id)
+        self.assertEqual(context['ai.device.locale'], device_locale)
+        self.assertEqual(context['ai.device.osVersion'], device_osVersion)
+        self.assertEqual(context['ai.device.type'], device_type)
+        self.assertEqual(
+            context['ai.internal.sdkVersion'],
+            internal_sdkVersion)
+
+    def test_monitor_context_initialized_once(self):
+        role_name = "first"
+        other_role_name = "second"
+
+        utils._azure_monitor_context = {}
+        context = utils.get_azure_monitor_context(role_name=role_name)
+        self.assertEqual(context['ai.cloud.role'], role_name)
+
+        second_context = utils.get_azure_monitor_context(
+            role_name=other_role_name)
+        self.assertEqual(second_context['ai.cloud.role'], role_name)


### PR DESCRIPTION
# What we are trying to address
The changes in this PR allows devs to configure the logged cloud role name (in AppInsights) using an environment variable (APPLICATIONINSIGHTS_ROLE_NAME) - if specified. (related issue: <https://github.com/census-instrumentation/opencensus-python/issues/1052>)

# Description of Changes
- Created a method to retrieve the azure monitor context (increased testability)

# Ran it using
- using existing TOX ini/config (for all python envs)

