### PR TITLE
Add functionality to track integrations being used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added integration tracking functionality
+([#915](https://github.com/census-instrumentation/opencensus-python/pull/915))
+
 # 0.7.13
 Released 2021-05-13
 
@@ -31,7 +34,7 @@ Released 2020-06-29
 Released 2020-06-17
 
 - Hotfix for breaking change
-  ([#915](https://github.com/census-instrumentation/opencensus-python/pull/915),
+  ([#915](https://github.com/census-instrumentation/opencensus-python/pull/915))
 
 ## 0.7.8
 Released 2020-06-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Added integration tracking functionality
-([#915](https://github.com/census-instrumentation/opencensus-python/pull/915))
+([#1065](https://github.com/census-instrumentation/opencensus-python/pull/1065))
 
 # 0.7.13
 Released 2021-05-13

--- a/contrib/opencensus-ext-django/opencensus/ext/django/middleware.py
+++ b/contrib/opencensus-ext-django/opencensus/ext/django/middleware.py
@@ -32,11 +32,11 @@ from opencensus.trace import (
     print_exporter,
     samplers,
 )
+from opencensus.trace import integrations
 from opencensus.trace import span as span_module
 from opencensus.trace import status as status_module
 from opencensus.trace import tracer as tracer_module
 from opencensus.trace import utils
-from opencensus.trace.integrations import _Integrations
 from opencensus.trace.propagation import trace_context_http_header_format
 
 HTTP_HOST = attributes_helper.COMMON_ATTRIBUTES['HTTP_HOST']
@@ -173,7 +173,8 @@ class OpencensusMiddleware(MiddlewareMixin):
         if django.VERSION >= (2,):  # pragma: NO COVER
             connection.execute_wrappers.append(_trace_db_call)
 
-        execution_context.add_integration(_Integrations.DJANGO)
+        # pylint: disable=protected-access
+        integrations.add_integration(integrations._Integrations.DJANGO)
 
     def process_request(self, request):
         """Called on each request, before Django decides which view to execute.

--- a/contrib/opencensus-ext-django/opencensus/ext/django/middleware.py
+++ b/contrib/opencensus-ext-django/opencensus/ext/django/middleware.py
@@ -36,6 +36,7 @@ from opencensus.trace import span as span_module
 from opencensus.trace import status as status_module
 from opencensus.trace import tracer as tracer_module
 from opencensus.trace import utils
+from opencensus.trace.integrations import _Integrations
 from opencensus.trace.propagation import trace_context_http_header_format
 
 HTTP_HOST = attributes_helper.COMMON_ATTRIBUTES['HTTP_HOST']
@@ -171,6 +172,8 @@ class OpencensusMiddleware(MiddlewareMixin):
 
         if django.VERSION >= (2,):  # pragma: NO COVER
             connection.execute_wrappers.append(_trace_db_call)
+
+        execution_context.add_integration(_Integrations.DJANGO)
 
     def process_request(self, request):
         """Called on each request, before Django decides which view to execute.

--- a/contrib/opencensus-ext-django/opencensus/ext/django/middleware.py
+++ b/contrib/opencensus-ext-django/opencensus/ext/django/middleware.py
@@ -29,10 +29,10 @@ from opencensus.common import configuration
 from opencensus.trace import (
     attributes_helper,
     execution_context,
+    integrations,
     print_exporter,
     samplers,
 )
-from opencensus.trace import integrations
 from opencensus.trace import span as span_module
 from opencensus.trace import status as status_module
 from opencensus.trace import tracer as tracer_module

--- a/contrib/opencensus-ext-flask/opencensus/ext/flask/flask_middleware.py
+++ b/contrib/opencensus-ext-flask/opencensus/ext/flask/flask_middleware.py
@@ -27,11 +27,11 @@ from opencensus.trace import (
     print_exporter,
     samplers,
 )
+from opencensus.trace import integrations
 from opencensus.trace import span as span_module
 from opencensus.trace import stack_trace, status
 from opencensus.trace import tracer as tracer_module
 from opencensus.trace import utils
-from opencensus.trace.integrations import _Integrations
 from opencensus.trace.propagation import trace_context_http_header_format
 
 HTTP_HOST = attributes_helper.COMMON_ATTRIBUTES['HTTP_HOST']
@@ -120,7 +120,8 @@ class FlaskMiddleware(object):
 
         self.setup_trace()
 
-        execution_context.add_integration(_Integrations.FLASK)
+        # pylint: disable=protected-access
+        integrations.add_integration(integrations._Integrations.FLASK)
 
     def setup_trace(self):
         self.app.before_request(self._before_request)

--- a/contrib/opencensus-ext-flask/opencensus/ext/flask/flask_middleware.py
+++ b/contrib/opencensus-ext-flask/opencensus/ext/flask/flask_middleware.py
@@ -24,10 +24,10 @@ from opencensus.common import configuration
 from opencensus.trace import (
     attributes_helper,
     execution_context,
+    integrations,
     print_exporter,
     samplers,
 )
-from opencensus.trace import integrations
 from opencensus.trace import span as span_module
 from opencensus.trace import stack_trace, status
 from opencensus.trace import tracer as tracer_module

--- a/contrib/opencensus-ext-flask/opencensus/ext/flask/flask_middleware.py
+++ b/contrib/opencensus-ext-flask/opencensus/ext/flask/flask_middleware.py
@@ -31,6 +31,7 @@ from opencensus.trace import span as span_module
 from opencensus.trace import stack_trace, status
 from opencensus.trace import tracer as tracer_module
 from opencensus.trace import utils
+from opencensus.trace.integrations import _Integrations
 from opencensus.trace.propagation import trace_context_http_header_format
 
 HTTP_HOST = attributes_helper.COMMON_ATTRIBUTES['HTTP_HOST']
@@ -118,6 +119,8 @@ class FlaskMiddleware(object):
         self.excludelist_hostnames = settings.get(EXCLUDELIST_HOSTNAMES, None)
 
         self.setup_trace()
+
+        execution_context.add_integration(_Integrations.FLASK)
 
     def setup_trace(self):
         self.app.before_request(self._before_request)

--- a/contrib/opencensus-ext-google-cloud-clientlibs/opencensus/ext/google_cloud_clientlibs/trace.py
+++ b/contrib/opencensus-ext-google-cloud-clientlibs/opencensus/ext/google_cloud_clientlibs/trace.py
@@ -20,8 +20,7 @@ from google.cloud import _helpers
 
 from opencensus.ext.grpc.client_interceptor import OpenCensusClientInterceptor
 from opencensus.ext.requests.trace import trace_integration as trace_requests
-from opencensus.trace import execution_context
-from opencensus.trace.integrations import _Integrations
+from opencensus.trace import integrations
 
 log = logging.getLogger(__name__)
 
@@ -44,7 +43,8 @@ def trace_integration(tracer=None):
     # Integrate with HTTP
     trace_http(tracer)
 
-    execution_context.add_integration(_Integrations.GOOGLE_CLOUD)
+    # pylint: disable=protected-access
+    integrations.add_integration(integrations._Integrations.GOOGLE_CLOUD)
 
 
 def trace_grpc(tracer=None):

--- a/contrib/opencensus-ext-google-cloud-clientlibs/opencensus/ext/google_cloud_clientlibs/trace.py
+++ b/contrib/opencensus-ext-google-cloud-clientlibs/opencensus/ext/google_cloud_clientlibs/trace.py
@@ -20,6 +20,8 @@ from google.cloud import _helpers
 
 from opencensus.ext.grpc.client_interceptor import OpenCensusClientInterceptor
 from opencensus.ext.requests.trace import trace_integration as trace_requests
+from opencensus.trace import execution_context
+from opencensus.trace.integrations import _Integrations
 
 log = logging.getLogger(__name__)
 
@@ -41,6 +43,8 @@ def trace_integration(tracer=None):
 
     # Integrate with HTTP
     trace_http(tracer)
+
+    execution_context.add_integration(_Integrations.GOOGLE_CLOUD)
 
 
 def trace_grpc(tracer=None):

--- a/contrib/opencensus-ext-httplib/opencensus/ext/httplib/trace.py
+++ b/contrib/opencensus-ext-httplib/opencensus/ext/httplib/trace.py
@@ -16,9 +16,9 @@ import logging
 import sys
 
 from opencensus.trace import attributes_helper, execution_context
+from opencensus.trace import integrations
 from opencensus.trace import span as span_module
 from opencensus.trace import utils
-from opencensus.trace.integrations import _Integrations
 
 PYTHON2 = sys.version_info.major == 2
 
@@ -54,7 +54,8 @@ def trace_integration(tracer=None):
     wrapped_response = wrap_httplib_response(response_func)
     setattr(httplib.HTTPConnection, response_func.__name__, wrapped_response)
 
-    execution_context.add_integration(_Integrations.HTTP_LIB)
+    # pylint: disable=protected-access
+    integrations.add_integration(integrations._Integrations.HTTP_LIB)
 
 
 def wrap_httplib_request(request_func):

--- a/contrib/opencensus-ext-httplib/opencensus/ext/httplib/trace.py
+++ b/contrib/opencensus-ext-httplib/opencensus/ext/httplib/trace.py
@@ -53,8 +53,9 @@ def trace_integration(tracer=None):
         httplib.HTTPConnection, HTTPLIB_RESPONSE_FUNC)
     wrapped_response = wrap_httplib_response(response_func)
     setattr(httplib.HTTPConnection, response_func.__name__, wrapped_response)
-    
+
     execution_context.add_integration(_Integrations.HTTP_LIB)
+
 
 def wrap_httplib_request(request_func):
     """Wrap the httplib request function to trace. Create a new span and update

--- a/contrib/opencensus-ext-httplib/opencensus/ext/httplib/trace.py
+++ b/contrib/opencensus-ext-httplib/opencensus/ext/httplib/trace.py
@@ -18,6 +18,7 @@ import sys
 from opencensus.trace import attributes_helper, execution_context
 from opencensus.trace import span as span_module
 from opencensus.trace import utils
+from opencensus.trace.integrations import _Integrations
 
 PYTHON2 = sys.version_info.major == 2
 
@@ -52,7 +53,8 @@ def trace_integration(tracer=None):
         httplib.HTTPConnection, HTTPLIB_RESPONSE_FUNC)
     wrapped_response = wrap_httplib_response(response_func)
     setattr(httplib.HTTPConnection, response_func.__name__, wrapped_response)
-
+    
+    execution_context.add_integration(_Integrations.HTTP_LIB)
 
 def wrap_httplib_request(request_func):
     """Wrap the httplib request function to trace. Create a new span and update

--- a/contrib/opencensus-ext-httplib/opencensus/ext/httplib/trace.py
+++ b/contrib/opencensus-ext-httplib/opencensus/ext/httplib/trace.py
@@ -15,8 +15,7 @@
 import logging
 import sys
 
-from opencensus.trace import attributes_helper, execution_context
-from opencensus.trace import integrations
+from opencensus.trace import attributes_helper, execution_context, integrations
 from opencensus.trace import span as span_module
 from opencensus.trace import utils
 

--- a/contrib/opencensus-ext-logging/opencensus/ext/logging/trace.py
+++ b/contrib/opencensus-ext-logging/opencensus/ext/logging/trace.py
@@ -15,8 +15,7 @@
 import logging
 
 from opencensus.log import TraceLogger
-from opencensus.trace import execution_context
-from opencensus.trace.integrations import _Integrations
+from opencensus.trace import integrations
 
 
 def trace_integration(tracer=None):
@@ -27,4 +26,5 @@ def trace_integration(tracer=None):
     context.
     """
     logging.setLoggerClass(TraceLogger)
-    execution_context.add_integration(_Integrations.LOGGING)
+    # pylint: disable=protected-access
+    integrations.add_integration(integrations._Integrations.LOGGING)

--- a/contrib/opencensus-ext-mysql/opencensus/ext/mysql/trace.py
+++ b/contrib/opencensus-ext-mysql/opencensus/ext/mysql/trace.py
@@ -18,6 +18,8 @@ import logging
 import mysql.connector
 
 from opencensus.ext.dbapi import trace
+from opencensus.trace import execution_context
+from opencensus.trace.integrations import _Integrations
 
 MODULE_NAME = 'mysql'
 
@@ -31,3 +33,4 @@ def trace_integration(tracer=None):
     conn_module = inspect.getmodule(conn_func)
     wrapped = trace.wrap_conn(conn_func)
     setattr(conn_module, CONN_WRAP_METHOD, wrapped)
+    execution_context.add_integration(_Integrations.MYSQL)

--- a/contrib/opencensus-ext-mysql/opencensus/ext/mysql/trace.py
+++ b/contrib/opencensus-ext-mysql/opencensus/ext/mysql/trace.py
@@ -18,8 +18,7 @@ import logging
 import mysql.connector
 
 from opencensus.ext.dbapi import trace
-from opencensus.trace import execution_context
-from opencensus.trace.integrations import _Integrations
+from opencensus.trace import integrations
 
 MODULE_NAME = 'mysql'
 
@@ -33,4 +32,5 @@ def trace_integration(tracer=None):
     conn_module = inspect.getmodule(conn_func)
     wrapped = trace.wrap_conn(conn_func)
     setattr(conn_module, CONN_WRAP_METHOD, wrapped)
-    execution_context.add_integration(_Integrations.MYSQL)
+    # pylint: disable=protected-access
+    integrations.add_integration(integrations._Integrations.MYSQL)

--- a/contrib/opencensus-ext-postgresql/opencensus/ext/postgresql/trace.py
+++ b/contrib/opencensus-ext-postgresql/opencensus/ext/postgresql/trace.py
@@ -20,8 +20,8 @@ from psycopg2 import connect as pg_connect
 from psycopg2.extensions import cursor as pgcursor
 
 from opencensus.trace import execution_context
+from opencensus.trace import integrations
 from opencensus.trace import span as span_module
-from opencensus.trace.integrations import _Integrations
 
 log = logging.getLogger(__name__)
 
@@ -38,7 +38,8 @@ def trace_integration(tracer=None):
     conn_func = getattr(psycopg2, CONN_WRAP_METHOD)
     conn_module = inspect.getmodule(conn_func)
     setattr(conn_module, conn_func.__name__, connect)
-    execution_context.add_integration(_Integrations.POSTGRESQL)
+    # pylint: disable=protected-access
+    integrations.add_integration(integrations._Integrations.POSTGRESQL)
 
 
 def connect(*args, **kwargs):

--- a/contrib/opencensus-ext-postgresql/opencensus/ext/postgresql/trace.py
+++ b/contrib/opencensus-ext-postgresql/opencensus/ext/postgresql/trace.py
@@ -19,8 +19,7 @@ import psycopg2
 from psycopg2 import connect as pg_connect
 from psycopg2.extensions import cursor as pgcursor
 
-from opencensus.trace import execution_context
-from opencensus.trace import integrations
+from opencensus.trace import execution_context, integrations
 from opencensus.trace import span as span_module
 
 log = logging.getLogger(__name__)

--- a/contrib/opencensus-ext-postgresql/opencensus/ext/postgresql/trace.py
+++ b/contrib/opencensus-ext-postgresql/opencensus/ext/postgresql/trace.py
@@ -21,6 +21,7 @@ from psycopg2.extensions import cursor as pgcursor
 
 from opencensus.trace import execution_context
 from opencensus.trace import span as span_module
+from opencensus.trace.integrations import _Integrations
 
 log = logging.getLogger(__name__)
 
@@ -37,6 +38,7 @@ def trace_integration(tracer=None):
     conn_func = getattr(psycopg2, CONN_WRAP_METHOD)
     conn_module = inspect.getmodule(conn_func)
     setattr(conn_module, conn_func.__name__, connect)
+    execution_context.add_integration(_Integrations.POSTGRESQL)
 
 
 def connect(*args, **kwargs):

--- a/contrib/opencensus-ext-pymongo/opencensus/ext/pymongo/trace.py
+++ b/contrib/opencensus-ext-pymongo/opencensus/ext/pymongo/trace.py
@@ -17,8 +17,7 @@ import logging
 from google.rpc import code_pb2
 from pymongo import monitoring
 
-from opencensus.trace import execution_context
-from opencensus.trace import integrations
+from opencensus.trace import execution_context, integrations
 from opencensus.trace import span as span_module
 from opencensus.trace import status as status_module
 

--- a/contrib/opencensus-ext-pymongo/opencensus/ext/pymongo/trace.py
+++ b/contrib/opencensus-ext-pymongo/opencensus/ext/pymongo/trace.py
@@ -20,6 +20,7 @@ from pymongo import monitoring
 from opencensus.trace import execution_context
 from opencensus.trace import span as span_module
 from opencensus.trace import status as status_module
+from opencensus.trace.integrations import _Integrations
 
 log = logging.getLogger(__name__)
 
@@ -32,6 +33,7 @@ def trace_integration(tracer=None):
     """Integrate with pymongo to trace it using event listener."""
     log.info('Integrated module: {}'.format(MODULE_NAME))
     monitoring.register(MongoCommandListener(tracer=tracer))
+    execution_context.add_integration(_Integrations.PYMONGO)
 
 
 class MongoCommandListener(monitoring.CommandListener):

--- a/contrib/opencensus-ext-pymongo/opencensus/ext/pymongo/trace.py
+++ b/contrib/opencensus-ext-pymongo/opencensus/ext/pymongo/trace.py
@@ -18,9 +18,9 @@ from google.rpc import code_pb2
 from pymongo import monitoring
 
 from opencensus.trace import execution_context
+from opencensus.trace import integrations
 from opencensus.trace import span as span_module
 from opencensus.trace import status as status_module
-from opencensus.trace.integrations import _Integrations
 
 log = logging.getLogger(__name__)
 
@@ -33,7 +33,8 @@ def trace_integration(tracer=None):
     """Integrate with pymongo to trace it using event listener."""
     log.info('Integrated module: {}'.format(MODULE_NAME))
     monitoring.register(MongoCommandListener(tracer=tracer))
-    execution_context.add_integration(_Integrations.PYMONGO)
+    # pylint: disable=protected-access
+    integrations.add_integration(integrations._Integrations.PYMONGO)
 
 
 class MongoCommandListener(monitoring.CommandListener):

--- a/contrib/opencensus-ext-pymysql/opencensus/ext/pymysql/trace.py
+++ b/contrib/opencensus-ext-pymysql/opencensus/ext/pymysql/trace.py
@@ -18,8 +18,7 @@ import logging
 import pymysql
 
 from opencensus.ext.dbapi import trace
-from opencensus.trace import execution_context
-from opencensus.trace.integrations import _Integrations
+from opencensus.trace import integrations
 
 MODULE_NAME = 'pymysql'
 
@@ -33,4 +32,5 @@ def trace_integration(tracer=None):
     conn_module = inspect.getmodule(conn_func)
     wrapped = trace.wrap_conn(conn_func)
     setattr(conn_module, CONN_WRAP_METHOD, wrapped)
-    execution_context.add_integration(_Integrations.PYMYSQL)
+    # pylint: disable=protected-access
+    integrations.add_integration(integrations._Integrations.PYMYSQL)

--- a/contrib/opencensus-ext-pymysql/opencensus/ext/pymysql/trace.py
+++ b/contrib/opencensus-ext-pymysql/opencensus/ext/pymysql/trace.py
@@ -18,6 +18,8 @@ import logging
 import pymysql
 
 from opencensus.ext.dbapi import trace
+from opencensus.trace import execution_context
+from opencensus.trace.integrations import _Integrations
 
 MODULE_NAME = 'pymysql'
 
@@ -31,3 +33,4 @@ def trace_integration(tracer=None):
     conn_module = inspect.getmodule(conn_func)
     wrapped = trace.wrap_conn(conn_func)
     setattr(conn_module, CONN_WRAP_METHOD, wrapped)
+    execution_context.add_integration(_Integrations.PYMYSQL)

--- a/contrib/opencensus-ext-pyramid/opencensus/ext/pyramid/pyramid_middleware.py
+++ b/contrib/opencensus-ext-pyramid/opencensus/ext/pyramid/pyramid_middleware.py
@@ -15,8 +15,7 @@
 import logging
 
 from opencensus.ext.pyramid.config import PyramidTraceSettings
-from opencensus.trace import attributes_helper, execution_context
-from opencensus.trace import integrations
+from opencensus.trace import attributes_helper, execution_context, integrations
 from opencensus.trace import span as span_module
 from opencensus.trace import tracer as tracer_module
 from opencensus.trace import utils

--- a/contrib/opencensus-ext-pyramid/opencensus/ext/pyramid/pyramid_middleware.py
+++ b/contrib/opencensus-ext-pyramid/opencensus/ext/pyramid/pyramid_middleware.py
@@ -19,6 +19,7 @@ from opencensus.trace import attributes_helper, execution_context
 from opencensus.trace import span as span_module
 from opencensus.trace import tracer as tracer_module
 from opencensus.trace import utils
+from opencensus.trace.integrations import _Integrations
 
 HTTP_HOST = attributes_helper.COMMON_ATTRIBUTES['HTTP_HOST']
 HTTP_METHOD = attributes_helper.COMMON_ATTRIBUTES['HTTP_METHOD']
@@ -63,6 +64,8 @@ class OpenCensusTweenFactory(object):
         self.propagator = settings.PROPAGATOR
 
         self._excludelist_paths = settings.EXCLUDELIST_PATHS
+
+        execution_context.add_integration(_Integrations.PYRAMID)
 
     def __call__(self, request):
         self._before_request(request)

--- a/contrib/opencensus-ext-pyramid/opencensus/ext/pyramid/pyramid_middleware.py
+++ b/contrib/opencensus-ext-pyramid/opencensus/ext/pyramid/pyramid_middleware.py
@@ -16,10 +16,10 @@ import logging
 
 from opencensus.ext.pyramid.config import PyramidTraceSettings
 from opencensus.trace import attributes_helper, execution_context
+from opencensus.trace import integrations
 from opencensus.trace import span as span_module
 from opencensus.trace import tracer as tracer_module
 from opencensus.trace import utils
-from opencensus.trace.integrations import _Integrations
 
 HTTP_HOST = attributes_helper.COMMON_ATTRIBUTES['HTTP_HOST']
 HTTP_METHOD = attributes_helper.COMMON_ATTRIBUTES['HTTP_METHOD']
@@ -65,7 +65,8 @@ class OpenCensusTweenFactory(object):
 
         self._excludelist_paths = settings.EXCLUDELIST_PATHS
 
-        execution_context.add_integration(_Integrations.PYRAMID)
+        # pylint: disable=protected-access
+        integrations.add_integration(integrations._Integrations.PYRAMID)
 
     def __call__(self, request):
         self._before_request(request)

--- a/contrib/opencensus-ext-requests/opencensus/ext/requests/trace.py
+++ b/contrib/opencensus-ext-requests/opencensus/ext/requests/trace.py
@@ -22,9 +22,9 @@ from opencensus.trace import (
     exceptions_status,
     execution_context,
 )
+from opencensus.trace import integrations
 from opencensus.trace import span as span_module
 from opencensus.trace import utils
-from opencensus.trace.integrations import _Integrations
 
 try:
     from urllib.parse import urlparse
@@ -63,7 +63,8 @@ def trace_integration(tracer=None):
     # https://github.com/psf/requests/commit/4e5c4a6ab7bb0195dececdd19bb8505b872fe120)
     wrapt.wrap_function_wrapper(
         MODULE_NAME, 'Session.request', wrap_session_request)
-    execution_context.add_integration(_Integrations.REQUESTS)
+    # pylint: disable=protected-access
+    integrations.add_integration(integrations._Integrations.REQUESTS)
 
 
 def wrap_session_request(wrapped, instance, args, kwargs):

--- a/contrib/opencensus-ext-requests/opencensus/ext/requests/trace.py
+++ b/contrib/opencensus-ext-requests/opencensus/ext/requests/trace.py
@@ -24,6 +24,7 @@ from opencensus.trace import (
 )
 from opencensus.trace import span as span_module
 from opencensus.trace import utils
+from opencensus.trace.integrations import _Integrations
 
 try:
     from urllib.parse import urlparse
@@ -62,6 +63,7 @@ def trace_integration(tracer=None):
     # https://github.com/psf/requests/commit/4e5c4a6ab7bb0195dececdd19bb8505b872fe120)
     wrapt.wrap_function_wrapper(
         MODULE_NAME, 'Session.request', wrap_session_request)
+    execution_context.add_integration(_Integrations.REQUESTS)
 
 
 def wrap_session_request(wrapped, instance, args, kwargs):

--- a/contrib/opencensus-ext-requests/opencensus/ext/requests/trace.py
+++ b/contrib/opencensus-ext-requests/opencensus/ext/requests/trace.py
@@ -21,8 +21,8 @@ from opencensus.trace import (
     attributes_helper,
     exceptions_status,
     execution_context,
+    integrations,
 )
-from opencensus.trace import integrations
 from opencensus.trace import span as span_module
 from opencensus.trace import utils
 

--- a/contrib/opencensus-ext-sqlalchemy/opencensus/ext/sqlalchemy/trace.py
+++ b/contrib/opencensus-ext-sqlalchemy/opencensus/ext/sqlalchemy/trace.py
@@ -34,6 +34,7 @@ def trace_integration(tracer=None):
     trace_engine(engine.Engine)
     execution_context.add_integration(_Integrations.SQLALCHEMY)
 
+
 def trace_engine(engine):
     """Register the event before cursor execute and after cursor execute
     to the event listner of the engine.

--- a/contrib/opencensus-ext-sqlalchemy/opencensus/ext/sqlalchemy/trace.py
+++ b/contrib/opencensus-ext-sqlalchemy/opencensus/ext/sqlalchemy/trace.py
@@ -18,6 +18,7 @@ from sqlalchemy import engine, event
 
 from opencensus.trace import execution_context
 from opencensus.trace import span as span_module
+from opencensus.trace.integrations import _Integrations
 
 log = logging.getLogger(__name__)
 
@@ -31,7 +32,7 @@ def trace_integration(tracer=None):
     """
     log.info('Integrated module: {}'.format(MODULE_NAME))
     trace_engine(engine.Engine)
-
+    execution_context.add_integration(_Integrations.SQLALCHEMY)
 
 def trace_engine(engine):
     """Register the event before cursor execute and after cursor execute

--- a/contrib/opencensus-ext-sqlalchemy/opencensus/ext/sqlalchemy/trace.py
+++ b/contrib/opencensus-ext-sqlalchemy/opencensus/ext/sqlalchemy/trace.py
@@ -17,8 +17,8 @@ import logging
 from sqlalchemy import engine, event
 
 from opencensus.trace import execution_context
+from opencensus.trace import integrations
 from opencensus.trace import span as span_module
-from opencensus.trace.integrations import _Integrations
 
 log = logging.getLogger(__name__)
 
@@ -32,7 +32,8 @@ def trace_integration(tracer=None):
     """
     log.info('Integrated module: {}'.format(MODULE_NAME))
     trace_engine(engine.Engine)
-    execution_context.add_integration(_Integrations.SQLALCHEMY)
+    # pylint: disable=protected-access
+    integrations.add_integration(integrations._Integrations.SQLALCHEMY)
 
 
 def trace_engine(engine):

--- a/contrib/opencensus-ext-sqlalchemy/opencensus/ext/sqlalchemy/trace.py
+++ b/contrib/opencensus-ext-sqlalchemy/opencensus/ext/sqlalchemy/trace.py
@@ -16,8 +16,7 @@ import logging
 
 from sqlalchemy import engine, event
 
-from opencensus.trace import execution_context
-from opencensus.trace import integrations
+from opencensus.trace import execution_context, integrations
 from opencensus.trace import span as span_module
 
 log = logging.getLogger(__name__)

--- a/opencensus/trace/execution_context.py
+++ b/opencensus/trace/execution_context.py
@@ -13,12 +13,26 @@
 # limitations under the License.
 
 from opencensus.common.runtime_context import RuntimeContext
+from opencensus.trace import integrations
+from opencensus.trace.integrations import _Integrations
 from opencensus.trace.tracers import noop_tracer
 
 _attrs_slot = RuntimeContext.register_slot('attrs', lambda: {})
 _current_span_slot = RuntimeContext.register_slot('current_span', None)
 _exporter_slot = RuntimeContext.register_slot('is_exporter', False)
 _tracer_slot = RuntimeContext.register_slot('tracer', noop_tracer.NoopTracer())
+_integrations_slot = RuntimeContext.register_slot('integrations', 0)
+
+def get_integrations():
+    return RuntimeContext.integrations
+
+
+def add_integration(integration):
+    RuntimeContext.integrations |= integration
+
+
+def remove_intregration(integration):
+    RuntimeContext.integrations &= integration
 
 
 def is_exporter():

--- a/opencensus/trace/execution_context.py
+++ b/opencensus/trace/execution_context.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 from opencensus.common.runtime_context import RuntimeContext
-from opencensus.trace import integrations
-from opencensus.trace.integrations import _Integrations
 from opencensus.trace.tracers import noop_tracer
 
 _attrs_slot = RuntimeContext.register_slot('attrs', lambda: {})
@@ -22,6 +20,7 @@ _current_span_slot = RuntimeContext.register_slot('current_span', None)
 _exporter_slot = RuntimeContext.register_slot('is_exporter', False)
 _tracer_slot = RuntimeContext.register_slot('tracer', noop_tracer.NoopTracer())
 _integrations_slot = RuntimeContext.register_slot('integrations', 0)
+
 
 def get_integrations():
     return RuntimeContext.integrations

--- a/opencensus/trace/execution_context.py
+++ b/opencensus/trace/execution_context.py
@@ -19,19 +19,6 @@ _attrs_slot = RuntimeContext.register_slot('attrs', lambda: {})
 _current_span_slot = RuntimeContext.register_slot('current_span', None)
 _exporter_slot = RuntimeContext.register_slot('is_exporter', False)
 _tracer_slot = RuntimeContext.register_slot('tracer', noop_tracer.NoopTracer())
-_integrations_slot = RuntimeContext.register_slot('integrations', 0)
-
-
-def get_integrations():
-    return RuntimeContext.integrations
-
-
-def add_integration(integration):
-    RuntimeContext.integrations |= integration
-
-
-def remove_intregration(integration):
-    RuntimeContext.integrations &= integration
 
 
 def is_exporter():

--- a/opencensus/trace/integrations.py
+++ b/opencensus/trace/integrations.py
@@ -12,19 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-
-from opencensus.log import TraceLogger
-from opencensus.trace import execution_context
-from opencensus.trace.integrations import _Integrations
-
-
-def trace_integration(tracer=None):
-    """Replace the global default logging class with `TraceLogger`.
-
-    Loggers created after the integration will produce `LogRecord`s
-    with extra traceId, spanId, and traceSampled attributes from the opencensus
-    context.
-    """
-    logging.setLoggerClass(TraceLogger)
-    execution_context.add_integration(_Integrations.LOGGING)
+class _Integrations:
+    NONE = 0
+    DJANGO = 1
+    FLASK = 2
+    GOOGLE_CLOUD = 4
+    HTTP_LIB = 8
+    LOGGING = 16
+    MYSQL = 32
+    POSTGRESQL = 64
+    PYMONGO = 128
+    PYMYSQL = 256
+    PYRAMID = 512
+    REQUESTS = 1024
+    SQLALCHEMY = 2056

--- a/opencensus/trace/integrations.py
+++ b/opencensus/trace/integrations.py
@@ -17,6 +17,7 @@ import threading
 _INTEGRATIONS_BIT_MASK = 0
 _INTEGRATIONS_LOCK = threading.Lock()
 
+
 class _Integrations:
     NONE = 0
     DJANGO = 1

--- a/opencensus/trace/integrations.py
+++ b/opencensus/trace/integrations.py
@@ -14,7 +14,6 @@
 
 import threading
 
-
 _INTEGRATIONS_BIT_MASK = 0
 _INTEGRATIONS_LOCK = threading.Lock()
 

--- a/opencensus/trace/integrations.py
+++ b/opencensus/trace/integrations.py
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import threading
+
+
+_INTEGRATIONS_BIT_MASK = 0
+_INTEGRATIONS_LOCK = threading.Lock()
+
 class _Integrations:
     NONE = 0
     DJANGO = 1
@@ -26,3 +32,19 @@ class _Integrations:
     PYRAMID = 512
     REQUESTS = 1024
     SQLALCHEMY = 2056
+
+
+def get_integrations():
+    return _INTEGRATIONS_BIT_MASK
+
+
+def add_integration(integration):
+    with _INTEGRATIONS_LOCK:
+        global _INTEGRATIONS_BIT_MASK  # pylint: disable=global-statement
+        _INTEGRATIONS_BIT_MASK |= integration
+
+
+def remove_intregration(integration):
+    with _INTEGRATIONS_LOCK:
+        global _INTEGRATIONS_BIT_MASK  # pylint: disable=global-statement
+        _INTEGRATIONS_BIT_MASK &= ~integration


### PR DESCRIPTION
Tracks integrations being used by the current application. Uses a bit to represent each integration, and the number of integrations will probably not increase by that much any time soon. Thread specific.