### PR TITLE
Allow google-api-core < 3 for python >= 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'opencensus-context == 0.2.dev0',
-        'google-api-core >= 1.0.0, < 2.0.0',
+        'google-api-core >= 1.0.0, < 2.0.0; python_version<"3.6"',
+        'google-api-core >= 1.0.0, < 3.0.0; python_version>="3.6"',
     ],
     extras_require={},
     license='Apache-2.0',


### PR DESCRIPTION
google-api-core dropped support for python < 3.6 in the [2.0.0 release](https://github.com/googleapis/python-api-core/blob/master/CHANGELOG.md#200-2021-08-18). I see this library still supports 2.7, so I created two separate pins for python < 3.6 and python >= 3.6.