### PR TITLE
Added support for Flask 2. Setup.py-dependency bumped to < 3.0.0.  Closes #1022

### DIFF
--- a/contrib/opencensus-ext-flask/setup.py
+++ b/contrib/opencensus-ext-flask/setup.py
@@ -41,7 +41,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'flask >= 0.12.3, < 2.0.0, != 1.1.3',
+        'flask >= 0.12.3, < 3.0.0, != 1.1.3',
         'opencensus >= 0.8.dev0, < 1.0.0',
     ],
     extras_require={},


### PR DESCRIPTION
FlaskMiddleware is compatible with Flask 2. The dependency is thus bumped in setup.py to < 3.0.0.

