### PR TITLE
change the way for logging integration

### DIFF
--- a/contrib/opencensus-ext-logging/opencensus/ext/logging/trace.py
+++ b/contrib/opencensus-ext-logging/opencensus/ext/logging/trace.py
@@ -14,17 +14,20 @@
 
 import logging
 
-from opencensus.log import TraceLogger
+from opencensus.log import decorate_log_record_factory
 from opencensus.trace import integrations
 
 
 def trace_integration(tracer=None):
-    """Replace the global default logging class with `TraceLogger`.
+    """Customize LogRecord with opencensus trace data.
+    https://docs.python.org/3/howto/logging-cookbook.html#customizing-logrecord
 
-    Loggers created after the integration will produce `LogRecord`s
+    LogRecordFactory created after the integration will produce `LogRecord`s
     with extra traceId, spanId, and traceSampled attributes from the opencensus
     context.
     """
-    logging.setLoggerClass(TraceLogger)
+    logging.setLogRecordFactory(
+        decorate_log_record_factory(logging.getLogRecordFactory()),
+    )
     # pylint: disable=protected-access
     integrations.add_integration(integrations._Integrations.LOGGING)

--- a/contrib/opencensus-ext-logging/version.py
+++ b/contrib/opencensus-ext-logging/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.1'
+__version__ = '0.2.0'

--- a/opencensus/log/__init__.py
+++ b/opencensus/log/__init__.py
@@ -113,3 +113,20 @@ class TraceLogger(logging.getLoggerClass()):
                 kwargs['extra'] = extra
         _set_extra_attrs(extra)
         return super(TraceLogger, self).makeRecord(*args, **kwargs)
+
+
+def set_default_attr(obj, attr, def_value):
+    if not hasattr(obj, attr):
+        setattr(obj, attr, def_value)
+
+
+def decorate_log_record_factory(old_factory):
+    def _new_factory(*args, **kwargs):
+        record = old_factory(*args, **kwargs)
+        trace_id, span_id, sampling_decision = get_log_attrs()
+        set_default_attr(record, TRACE_ID_KEY, trace_id)
+        set_default_attr(record, SPAN_ID_KEY, span_id)
+        set_default_attr(record, SAMPLING_DECISION_KEY, sampling_decision)
+        return record
+
+    return _new_factory


### PR DESCRIPTION
Fix problem related to Note "Note that this only takes effect for loggers created after the integration."
Face with such issue when was trying to integrate opencensus-logging into uvicorn+FastAPI. 
uvicorn starts application in new thread/process and creates uvicorn logger object in new thread/process before opencensus-logging-integration execution. 
`TraceLogger` just overrides `makeRecord`, `logging.setLogRecordFactory` is a better approach because it has not drawback with time of logger object initialization.   