### PR TITLE
Remove SQLAlchemy 1.3.24 limitation in opencensus-ext-sqlalchemy

### DIFF
--- a/contrib/opencensus-ext-sqlalchemy/setup.py
+++ b/contrib/opencensus-ext-sqlalchemy/setup.py
@@ -42,7 +42,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'opencensus >= 0.7.13, < 1.0.0',
-        'SQLAlchemy >= 1.1.14, < 1.3.24',  # https://github.com/sqlalchemy/sqlalchemy/issues/6168 # noqa: E501
+        'SQLAlchemy >= 1.1.14',
     ],
     extras_require={},
     license='Apache-2.0',


### PR DESCRIPTION
We can remove the limitation for SQLAlchemy 1.3.24 because https://github.com/sqlalchemy/sqlalchemy/issues/6168 referenced in the code has been fixed for a long time.