### PR TITLE
Fix formatting of error message

### DIFF
--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
@@ -199,7 +199,7 @@ class LocalFileStorage(object):
                             "reached. Currently at %fKB. Telemetry will be "
                             "lost. Please consider increasing the value of "
                             "'storage_max_size' in exporter config.",
-                            format(size/1024)
+                            size/1024
                         )
                         return False
         return True


### PR DESCRIPTION
The log string expects a real number and not a string
but format returns a string so remove the redundant format call here.


Without this fix I would see 

```
In [9]: logger.warning(
   ...:     "Persistent storage max capacity has been "
   ...:     "reached. Currently at %fKB. Telemetry will be "
   ...:     "lost. Please consider increasing the value of "
   ...:     "'storage_max_size' in exporter config.",
   ...:     format(size / 1024),
   ...: )
--- Logging error ---
Traceback (most recent call last):
  File "C:\Users\jenielse\Miniconda3\envs\qcodespip310\lib\logging\__init__.py", line 1098, in emit
    msg = self.format(record)
  File "C:\Users\jenielse\Miniconda3\envs\qcodespip310\lib\logging\__init__.py", line 942, in format
    return fmt.format(record)
  File "C:\Users\jenielse\Miniconda3\envs\qcodespip310\lib\logging\__init__.py", line 678, in format
    record.message = record.getMessage()
  File "C:\Users\jenielse\Miniconda3\envs\qcodespip310\lib\logging\__init__.py", line 368, in getMessage
    msg = msg % self.args
TypeError: must be real number, not str
Call stack:
  File "C:\Users\jenielse\Miniconda3\envs\qcodespip310\lib\runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Users\jenielse\Miniconda3\envs\qcodespip310\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "C:\Users\jenielse\Miniconda3\envs\qcodespip310\Scripts\ipython.exe\__main__.py", line 7, in <module>
    sys.exit(start_ipython())
  File "C:\Users\jenielse\Miniconda3\envs\qcodespip310\lib\site-packages\IPython\__init__.py", line 123, in start_ipython
    return launch_new_instance(argv=argv, **kwargs)
  File "C:\Users\jenielse\Miniconda3\envs\qcodespip310\lib\site-packages\traitlets\config\application.py", line 846, in launch_instance
    app.start()
  File "C:\Users\jenielse\Miniconda3\envs\qcodespip310\lib\site-packages\IPython\terminal\ipapp.py", line 316, in start
    self.shell.mainloop()
  File "C:\Users\jenielse\Miniconda3\envs\qcodespip310\lib\site-packages\IPython\terminal\interactiveshell.py", line 611, in mainloop
    self.interact()
  File "C:\Users\jenielse\Miniconda3\envs\qcodespip310\lib\site-packages\IPython\terminal\interactiveshell.py", line 604, in interact
    self.run_cell(code, store_history=True)
  File "C:\Users\jenielse\Miniconda3\envs\qcodespip310\lib\site-packages\IPython\core\interactiveshell.py", line 2768, in run_cell
    result = self._run_cell(
  File "C:\Users\jenielse\Miniconda3\envs\qcodespip310\lib\site-packages\IPython\core\interactiveshell.py", line 2814, in _run_cell
    return runner(coro)
  File "C:\Users\jenielse\Miniconda3\envs\qcodespip310\lib\site-packages\IPython\core\async_helpers.py", line 129, in _pseudo_sync_runner
    coro.send(None)
  File "C:\Users\jenielse\Miniconda3\envs\qcodespip310\lib\site-packages\IPython\core\interactiveshell.py", line 3012, in run_cell_async
    has_raised = await self.run_ast_nodes(code_ast.body, cell_name,
  File "C:\Users\jenielse\Miniconda3\envs\qcodespip310\lib\site-packages\IPython\core\interactiveshell.py", line 3191, in run_ast_nodes
    if await self.run_code(code, result, async_=asy):
  File "C:\Users\jenielse\Miniconda3\envs\qcodespip310\lib\site-packages\IPython\core\interactiveshell.py", line 3251, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-9-57cf4391c151>", line 1, in <module>
    logger.warning(
Message: "Persistent storage max capacity has been reached. Currently at %fKB. Telemetry will be lost. Please consider increasing the value of 'storage_max_size' in exporter config."
Arguments: ('0.0009765625',)
```

With this fix I get a correctly formatted error message

```
In [4]: logger.warning(
   ...:     "Persistent storage max capacity has been "
   ...:     "reached. Currently at %fKB. Telemetry will be "
   ...:     "lost. Please consider increasing the value of "
   ...:     "'storage_max_size' in exporter config.",
   ...:     10000000 / 1024,
   ...: )
Persistent storage max capacity has been reached. Currently at 9765.625000KB. Telemetry will be lost. Please consider increasing the value of 'storage_max_size' in exporter config
```


