### PR TITLE
Add TraceLoggingFilter

### DIFF
--- a/opencensus/log/__init__.py
+++ b/opencensus/log/__init__.py
@@ -80,6 +80,19 @@ def _set_extra_attrs(extra):
 
 
 # See
+# https://docs.python.org/3.7/library/logging.html#filter-objects
+# https://docs.python.org/3.7/howto/logging-cookbook.html#using-filters-to-impart-contextual-information
+class TraceLoggingFilter(logging.Filter):
+    """Filter to add opencensus context attrs to records."""
+    def filter(self, record):
+        attrs = {}
+        _set_extra_attrs(attrs)
+        for attr_name, attr_value in attrs.items():
+            if not hasattr(record, attr_name):
+                setattr(record, attr_name, attr_value)
+        return True
+
+# See
 # https://docs.python.org/3.7/library/logging.html#loggeradapter-objects,
 # https://docs.python.org/3.7/howto/logging-cookbook.html#context-info
 class TraceLoggingAdapter(logging.LoggerAdapter):


### PR DESCRIPTION
Filters are another, flexible way to add contextual information to the logs.

A filter can be attached to both a Logger and a Handler, allowing for more granular control on how to add contextual information to a log record. 

E.g., a filter can be attached only to a opencensus export handler. And this will affect all log records emitted to handler, even if you use plain `logging.info(...)` instead of `logging.getLogger(__name__).info(...)`. 

Example:
```python
def configure_logging():
    handler = AzureLogHandler(
        connection_string=app_insights_conn_str,
        sampler=AlwaysOnSampler(),
        credential=credential,
    )
    root = logging.getLogger()
    root.addHandler(handler)
    handler.addFilter(TraceLoggingFilter())
```