### PR TITLE
Make sure handler.flush() doesn't deadlock.

### DIFF
--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/log_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/log_exporter/__init__.py
@@ -110,14 +110,14 @@ class BaseLogHandler(logging.Handler):
             return
 
         # We must check the worker thread is alive, because otherwise flush
-        # is useless. Also, it would deadlock if not timeout is given, and the
+        # is useless. Also, it would deadlock if no timeout is given, and the
         # queue isn't empty.
         # This is a very possible scenario during process termination, when
         # atexit first calls handler.close() and then logging.shutdown(),
         # that in turn calls handler.flush() without arguments.
         if not self._worker.is_alive():
             logger.warning("Can't flush %s, worker thread is dead. "
-                           "Pending messages will be lost.", self)
+                           "Any pending messages will be lost.", self)
             return
 
         self._queue.flush(timeout=timeout)

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/log_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/log_exporter/__init__.py
@@ -106,6 +106,20 @@ class BaseLogHandler(logging.Handler):
         raise NotImplementedError  # pragma: NO COVER
 
     def flush(self, timeout=None):
+        if self._queue.is_empty():
+            return
+
+        # We must check the worker thread is alive, because otherwise flush
+        # is useless. Also, it would deadlock if not timeout is given, and the
+        # queue isn't empty.
+        # This is a very possible scenario during process termination, when
+        # atexit first calls handler.close() and then logging.shutdown(),
+        # that in turn calls handler.flush() without arguments.
+        if not self._worker.is_alive():
+            logger.warning("Can't flush %s, worker thread is dead. "
+                           "Pending messages will be lost.", self)
+            return
+
         self._queue.flush(timeout=timeout)
 
 

--- a/opencensus/common/schedule/__init__.py
+++ b/opencensus/common/schedule/__init__.py
@@ -112,6 +112,9 @@ class Queue(object):
     def gets(self, count, timeout):
         return tuple(self._gets(count, timeout))
 
+    def is_empty(self):
+        return not self._queue.qsize()
+
     def flush(self, timeout=None):
         if self._queue.qsize() == 0:
             return 0
@@ -124,7 +127,7 @@ class Queue(object):
             return
         elapsed_time = time.time() - start_time
         wait_time = timeout and max(timeout - elapsed_time, 0)
-        if event.wait(timeout):
+        if event.wait(wait_time):
             return time.time() - start_time  # time taken to flush
 
     def put(self, item, block=True, timeout=None):


### PR DESCRIPTION
Currently `flush()` deadlocks during process termination if there's any unsent messages in the queue.

This is because `atexit` first calls `handler.close()` and then `logging.shutdown()`, that in turn calls `handler.flush()` without arguments. I.e. `handler.close()` kills the worker, and then `handler.flush()` forever waits for the dead worker to send the messages from the queue.

Stacktrace dump by `py-spy` of the application in a deadlock:
```
Thread 8900 (idle): "MainThread"
    wait (threading.py:296)
    wait (threading.py:552)
    wait (opencensus\common\schedule\__init__.py:75)
    flush (opencensus\common\schedule\__init__.py:127)
    flush (opencensus\ext\azure\log_exporter\__init__.py:109)
    shutdown (logging\__init__.py:2036)
``` 

After this change, the deadlock is still possible if another thread concurrently closes the handler during the flush. However, this scenario is much less likely.