### PR TITLE
Fix statsbeat bugs

### DIFF
--- a/contrib/opencensus-ext-azure/CHANGELOG.md
+++ b/contrib/opencensus-ext-azure/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Statsbeat bug fixes
+([#1108](https://github.com/census-instrumentation/opencensus-python/pull/1108))
+
 ## 1.1.3
 Released 2022-03-03
 

--- a/contrib/opencensus-ext-azure/CHANGELOG.md
+++ b/contrib/opencensus-ext-azure/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Statsbeat bug fixes
-([#1108](https://github.com/census-instrumentation/opencensus-python/pull/1108))
+([#1113](https://github.com/census-instrumentation/opencensus-python/pull/1113))
 
 ## 1.1.3
 Released 2022-03-03

--- a/contrib/opencensus-ext-azure/examples/logs/simple.py
+++ b/contrib/opencensus-ext-azure/examples/logs/simple.py
@@ -21,3 +21,5 @@ logger = logging.getLogger(__name__)
 # and place it in the APPLICATIONINSIGHTS_CONNECTION_STRING
 # environment variable.
 logger.addHandler(AzureLogHandler())
+
+logger.warning("Hello World!")

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/statsbeat_metrics/statsbeat.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/statsbeat_metrics/statsbeat.py
@@ -150,27 +150,24 @@ def _get_feature_properties():
 
 def _get_success_count_value():
     with _requests_lock:
-        interval_count = _requests_map.get('success', 0) \
-                    - _requests_map.get('last_success', 0)
-        _requests_map['last_success'] = _requests_map.get('success', 0)
+        interval_count = _requests_map.get('success', 0)
+        _requests_map['success'] = 0
         return interval_count
 
 
 def _get_failure_count_value():
     with _requests_lock:
-        interval_count = _requests_map.get('failure', 0) \
-                    - _requests_map.get('last_failure', 0)
-        _requests_map['last_failure'] = _requests_map.get('failure', 0)
+        interval_count = _requests_map.get('failure', 0)
+        _requests_map['failure'] = 0
         return interval_count
 
 
 def _get_average_duration_value():
     with _requests_lock:
-        interval_duration = _requests_map.get('duration', 0) \
-            - _requests_map.get('last_duration', 0)
-        interval_count = _requests_map.get('count', 0) \
-            - _requests_map.get('last_count', 0)
-        _requests_map['last_duration'] = _requests_map.get('duration', 0)
+        interval_duration = _requests_map.get('duration', 0)
+        interval_count = _requests_map.get('count', 0)
+        _requests_map['duration'] = 0
+        _requests_map['count'] = 0
         if interval_duration > 0 and interval_count > 0:
             result = interval_duration / interval_count
             # Convert to milliseconds
@@ -180,25 +177,22 @@ def _get_average_duration_value():
 
 def _get_retry_count_value():
     with _requests_lock:
-        interval_count = _requests_map.get('retry', 0) \
-                    - _requests_map.get('last_retry', 0)
-        _requests_map['last_retry'] = _requests_map.get('retry', 0)
+        interval_count = _requests_map.get('retry', 0)
+        _requests_map['retry'] = 0
         return interval_count
 
 
 def _get_throttle_count_value():
     with _requests_lock:
-        interval_count = _requests_map.get('throttle', 0) \
-                    - _requests_map.get('last_throttle', 0)
-        _requests_map['last_throttle'] = _requests_map.get('throttle', 0)
+        interval_count = _requests_map.get('throttle', 0)
+        _requests_map['throttle'] = 0
         return interval_count
 
 
 def _get_exception_count_value():
     with _requests_lock:
-        interval_count = _requests_map.get('exception', 0) \
-                    - _requests_map.get('last_exception', 0)
-        _requests_map['last_exception'] = _requests_map.get('exception', 0)
+        interval_count = _requests_map.get('exception', 0)
+        _requests_map['exception'] = 0
         return interval_count
 
 

--- a/contrib/opencensus-ext-azure/tests/test_azure_statsbeat_metrics.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_statsbeat_metrics.py
@@ -337,10 +337,46 @@ class TestStatsbeatMetrics(unittest.TestCase):
 
     def test_get_success_count_value(self):
         _requests_map.clear()
-        _requests_map['last_success'] = 5
         _requests_map['success'] = 10
-        self.assertEqual(_get_success_count_value(), 5)
-        self.assertEqual(_requests_map['last_success'], 10)
+        self.assertEqual(_get_success_count_value(), 10)
+        self.assertEqual(_requests_map['success'], 0)
+        _requests_map.clear()
+
+    def test_get_failure_count_value(self):
+        _requests_map.clear()
+        _requests_map['failure'] = 10
+        self.assertEqual(_get_failure_count_value(), 10)
+        self.assertEqual(_requests_map['failure'], 0)
+        _requests_map.clear()
+
+    def test_get_average_duration_value(self):
+        _requests_map.clear()
+        _requests_map['duration'] = 10
+        _requests_map['count'] = 2
+        self.assertEqual(_get_average_duration_value(), 5000.0)
+        self.assertEqual(_requests_map['duration'], 0)
+        self.assertEqual(_requests_map['count'], 0)
+        _requests_map.clear()
+
+    def test_get_retry_count_value(self):
+        _requests_map.clear()
+        _requests_map['retry'] = 10
+        self.assertEqual(_get_retry_count_value(), 10)
+        self.assertEqual(_requests_map['retry'], 0)
+        _requests_map.clear()
+
+    def test_get_throttle_count_value(self):
+        _requests_map.clear()
+        _requests_map['throttle'] = 10
+        self.assertEqual(_get_throttle_count_value(), 10)
+        self.assertEqual(_requests_map['throttle'], 0)
+        _requests_map.clear()
+
+    def test_get_exception_count_value(self):
+        _requests_map.clear()
+        _requests_map['exception'] = 10
+        self.assertEqual(_get_exception_count_value(), 10)
+        self.assertEqual(_requests_map['exception'], 0)
         _requests_map.clear()
 
     def test_statsbeat_metric_get_initial_metrics(self):

--- a/contrib/opencensus-ext-azure/tests/test_transport_mixin.py
+++ b/contrib/opencensus-ext-azure/tests/test_transport_mixin.py
@@ -25,6 +25,7 @@ from azure.identity._exceptions import CredentialUnavailableError
 from opencensus.ext.azure.common import Options
 from opencensus.ext.azure.common.storage import LocalFileStorage
 from opencensus.ext.azure.common.transport import (
+    _requests_map,
     _MAX_CONSECUTIVE_REDIRECTS,
     _MONITOR_OAUTH_SCOPE,
     TransportMixin,
@@ -87,6 +88,19 @@ class TestTransportMixin(unittest.TestCase):
             self.assertIsNone(mixin.storage.get())
             self.assertEqual(len(os.listdir(mixin.storage.path)), 1)
 
+    def test_statsbeat_timeout(self):
+        _requests_map.clear()
+        mixin = TransportMixin()
+        mixin.options = Options()
+        with mock.patch('requests.post', throw(requests.Timeout)):
+            result = mixin._transmit([1,2,3])
+            self.assertEqual(len(_requests_map), 3)
+            self.assertIsNotNone(_requests_map['duration'])
+            self.assertEqual(_requests_map['count'], 1)
+            self.assertEqual(_requests_map['retry'], 1)
+            self.assertEqual(result, mixin.options.minimum_retry_interval)
+        _requests_map.clear()
+
     def test_transmission_pre_req_exception(self):
         mixin = TransportMixin()
         mixin.options = Options()
@@ -97,6 +111,19 @@ class TestTransportMixin(unittest.TestCase):
                 mixin._transmit_from_storage()
             self.assertIsNone(mixin.storage.get())
             self.assertEqual(len(os.listdir(mixin.storage.path)), 1)
+    
+    def test_statsbeat_req_exception(self):
+        _requests_map.clear()
+        mixin = TransportMixin()
+        mixin.options = Options()
+        with mock.patch('requests.post', throw(requests.RequestException)):
+            result = mixin._transmit([1,2,3])
+            self.assertEqual(len(_requests_map), 3)
+            self.assertIsNotNone(_requests_map['duration'])
+            self.assertEqual(_requests_map['count'], 1)
+            self.assertEqual(_requests_map['retry'], 1)
+            self.assertEqual(result, mixin.options.minimum_retry_interval)
+        _requests_map.clear()
 
     def test_transmission_cred_exception(self):
         mixin = TransportMixin()
@@ -109,6 +136,19 @@ class TestTransportMixin(unittest.TestCase):
             self.assertIsNone(mixin.storage.get())
             self.assertEqual(len(os.listdir(mixin.storage.path)), 0)
 
+    def test_statsbeat_cred_exception(self):
+        _requests_map.clear()
+        mixin = TransportMixin()
+        mixin.options = Options()
+        with mock.patch('requests.post', throw(CredentialUnavailableError)):
+            result = mixin._transmit([1,2,3])
+            self.assertEqual(len(_requests_map), 3)
+            self.assertIsNotNone(_requests_map['duration'])
+            self.assertEqual(_requests_map['exception'], 1)
+            self.assertEqual(_requests_map['count'], 1)
+            self.assertEqual(result, -1)
+        _requests_map.clear()
+
     def test_transmission_client_exception(self):
         mixin = TransportMixin()
         mixin.options = Options()
@@ -120,6 +160,19 @@ class TestTransportMixin(unittest.TestCase):
             self.assertIsNone(mixin.storage.get())
             self.assertEqual(len(os.listdir(mixin.storage.path)), 1)
 
+    def test_statsbeat_client_exception(self):
+        _requests_map.clear()
+        mixin = TransportMixin()
+        mixin.options = Options()
+        with mock.patch('requests.post', throw(ClientAuthenticationError)):
+            result = mixin._transmit([1,2,3])
+            self.assertEqual(len(_requests_map), 3)
+            self.assertIsNotNone(_requests_map['duration'])
+            self.assertEqual(_requests_map['retry'], 1)
+            self.assertEqual(_requests_map['count'], 1)
+            self.assertEqual(result, mixin.options.minimum_retry_interval)
+        _requests_map.clear()
+
     def test_transmission_pre_exception(self):
         mixin = TransportMixin()
         mixin.options = Options()
@@ -130,6 +183,19 @@ class TestTransportMixin(unittest.TestCase):
                 mixin._transmit_from_storage()
             self.assertIsNone(mixin.storage.get())
             self.assertEqual(len(os.listdir(mixin.storage.path)), 0)
+
+    def test_statsbeat_exception(self):
+        _requests_map.clear()
+        mixin = TransportMixin()
+        mixin.options = Options()
+        with mock.patch('requests.post', throw(Exception)):
+            result = mixin._transmit([1,2,3])
+            self.assertEqual(len(_requests_map), 3)
+            self.assertIsNotNone(_requests_map['duration'])
+            self.assertEqual(_requests_map['exception'], 1)
+            self.assertEqual(_requests_map['count'], 1)
+            self.assertEqual(result, -1)
+        _requests_map.clear()
 
     @mock.patch('requests.post', return_value=mock.Mock())
     def test_transmission_lease_failure(self, requests_mock):
@@ -146,7 +212,7 @@ class TestTransportMixin(unittest.TestCase):
                 mixin._transmit_from_storage()
             self.assertTrue(mixin.storage.get())
 
-    def test_transmission_exception(self):
+    def test_transmission_text_exception(self):
         mixin = TransportMixin()
         mixin.options = Options()
         with LocalFileStorage(os.path.join(TEST_FOLDER, self.id())) as stor:
@@ -171,6 +237,20 @@ class TestTransportMixin(unittest.TestCase):
                 mixin._transmit_from_storage()
             self.assertIsNone(mixin.storage.get())
             self.assertEqual(len(os.listdir(mixin.storage.path)), 0)
+
+    def test_statsbeat_success(self):
+        _requests_map.clear()
+        mixin = TransportMixin()
+        mixin.options = Options()
+        with mock.patch('requests.post') as post:
+            post.return_value = MockResponse(200, 'unknown')
+            result = mixin._transmit([1,2,3])
+            self.assertEqual(len(_requests_map), 3)
+            self.assertIsNotNone(_requests_map['duration'])
+            self.assertEqual(_requests_map['success'], 1)
+            self.assertEqual(_requests_map['count'], 1)
+            self.assertEqual(result, 0)
+        _requests_map.clear()
 
     def test_transmission_auth(self):
         mixin = TransportMixin()
@@ -219,7 +299,22 @@ class TestTransportMixin(unittest.TestCase):
             self.assertIsNone(mixin.storage.get())
             self.assertEqual(len(os.listdir(mixin.storage.path)), 1)
 
-    def test_transmission_206_500(self):
+    def test_statsbeat_206(self):
+        _requests_map.clear()
+        mixin = TransportMixin()
+        mixin.options = Options()
+        with mock.patch('requests.post') as post:
+            post.return_value = MockResponse(206, 'unknown')
+            result = mixin._transmit([1,2,3])
+            self.assertEqual(len(_requests_map), 4)
+            self.assertIsNotNone(_requests_map['duration'])
+            self.assertEqual(_requests_map['retry'], 1)
+            self.assertEqual(_requests_map['count'], 1)
+            self.assertEqual(_requests_map['failure'], 1)
+            self.assertEqual(result, mixin.options.minimum_retry_interval)
+        _requests_map.clear()
+
+    def test_transmission_206_partial_retry(self):
         mixin = TransportMixin()
         mixin.options = Options()
         with LocalFileStorage(os.path.join(TEST_FOLDER, self.id())) as stor:
@@ -246,6 +341,36 @@ class TestTransportMixin(unittest.TestCase):
             self.assertEqual(len(os.listdir(mixin.storage.path)), 1)
             self.assertEqual(mixin.storage.get().get(), (3,))
 
+    def test_statsbeat_206_partial_retry(self):
+        _requests_map.clear()
+        mixin = TransportMixin()
+        mixin.options = Options()
+        with mock.patch('requests.post') as post:
+            post.return_value = MockResponse(206, json.dumps({
+                    'itemsReceived': 5,
+                    'itemsAccepted': 3,
+                    'errors': [
+                        {
+                            'index': 0,
+                            'statusCode': 400,
+                            'message': '',
+                        },
+                        {
+                            'index': 2,
+                            'statusCode': 500,
+                            'message': 'Internal Server Error',
+                        },
+                    ],
+                }))
+            result = mixin._transmit([1,2,3])
+            self.assertEqual(len(_requests_map), 4)
+            self.assertIsNotNone(_requests_map['duration'])
+            self.assertEqual(_requests_map['retry'], 1)
+            self.assertEqual(_requests_map['count'], 1)
+            self.assertEqual(_requests_map['failure'], 1)
+            self.assertEqual(result, -206)
+        _requests_map.clear()
+
     def test_transmission_206_no_retry(self):
         mixin = TransportMixin()
         mixin.options = Options()
@@ -266,6 +391,30 @@ class TestTransportMixin(unittest.TestCase):
                 }))
                 mixin._transmit_from_storage()
             self.assertEqual(len(os.listdir(mixin.storage.path)), 0)
+
+    def test_statsbeat_206_no_retry(self):
+        _requests_map.clear()
+        mixin = TransportMixin()
+        mixin.options = Options()
+        with mock.patch('requests.post') as post:
+            post.return_value = MockResponse(206, json.dumps({
+                    'itemsReceived': 3,
+                    'itemsAccepted': 2,
+                    'errors': [
+                        {
+                            'index': 0,
+                            'statusCode': 400,
+                            'message': '',
+                        },
+                    ],
+                }))
+            result = mixin._transmit([1,2,3])
+            self.assertEqual(len(_requests_map), 3)
+            self.assertIsNotNone(_requests_map['duration'])
+            self.assertEqual(_requests_map['count'], 1)
+            self.assertEqual(_requests_map['failure'], 1)
+            self.assertEqual(result, -206)
+        _requests_map.clear()
 
     def test_transmission_206_bogus(self):
         mixin = TransportMixin()
@@ -288,6 +437,87 @@ class TestTransportMixin(unittest.TestCase):
             self.assertIsNone(mixin.storage.get())
             self.assertEqual(len(os.listdir(mixin.storage.path)), 0)
 
+    def test_transmission_429(self):
+        mixin = TransportMixin()
+        mixin.options = Options()
+        with LocalFileStorage(os.path.join(TEST_FOLDER, self.id())) as stor:
+            mixin.storage = stor
+            mixin.storage.put([1, 2, 3])
+            with mock.patch('requests.post') as post:
+                post.return_value = MockResponse(429, 'unknown')
+                mixin._transmit_from_storage()
+            self.assertIsNone(mixin.storage.get())
+            self.assertEqual(len(os.listdir(mixin.storage.path)), 1)
+
+    def test_statsbeat_429(self):
+        _requests_map.clear()
+        mixin = TransportMixin()
+        mixin.options = Options()
+        with mock.patch('requests.post') as post:
+            post.return_value = MockResponse(429, 'unknown')
+            result = mixin._transmit([1,2,3])
+            self.assertEqual(len(_requests_map), 4)
+            self.assertIsNotNone(_requests_map['duration'])
+            self.assertEqual(_requests_map['retry'], 1)
+            self.assertEqual(_requests_map['count'], 1)
+            self.assertEqual(_requests_map['failure'], 1)
+            self.assertEqual(result, mixin.options.minimum_retry_interval)
+        _requests_map.clear()
+
+    def test_transmission_500(self):
+        mixin = TransportMixin()
+        mixin.options = Options()
+        with LocalFileStorage(os.path.join(TEST_FOLDER, self.id())) as stor:
+            mixin.storage = stor
+            mixin.storage.put([1, 2, 3])
+            with mock.patch('requests.post') as post:
+                post.return_value = MockResponse(500, 'unknown')
+                mixin._transmit_from_storage()
+            self.assertIsNone(mixin.storage.get())
+            self.assertEqual(len(os.listdir(mixin.storage.path)), 1)
+
+    def test_statsbeat_500(self):
+        _requests_map.clear()
+        mixin = TransportMixin()
+        mixin.options = Options()
+        with mock.patch('requests.post') as post:
+            post.return_value = MockResponse(500, 'unknown')
+            result = mixin._transmit([1,2,3])
+            self.assertEqual(len(_requests_map), 4)
+            self.assertIsNotNone(_requests_map['duration'])
+            self.assertEqual(_requests_map['retry'], 1)
+            self.assertEqual(_requests_map['count'], 1)
+            self.assertEqual(_requests_map['failure'], 1)
+            self.assertEqual(result, mixin.options.minimum_retry_interval)
+        _requests_map.clear()
+
+    def test_transmission_503(self):
+        mixin = TransportMixin()
+        mixin.options = Options()
+        with LocalFileStorage(os.path.join(TEST_FOLDER, self.id())) as stor:
+            mixin.storage = stor
+            mixin.storage.put([1, 2, 3])
+            with mock.patch('requests.post') as post:
+                post.return_value = MockResponse(503, 'unknown')
+                mixin._transmit_from_storage()
+            self.assertIsNone(mixin.storage.get())
+            self.assertEqual(len(os.listdir(mixin.storage.path)), 1)
+
+    def test_statsbeat_503(self):
+        _requests_map.clear()
+        mixin = TransportMixin()
+        mixin.options = Options()
+        with mock.patch('requests.post') as post:
+            post.return_value = MockResponse(503, 'unknown')
+            result = mixin._transmit([1,2,3])
+            self.assertEqual(len(_requests_map), 4)
+            self.assertIsNotNone(_requests_map['duration'])
+            self.assertEqual(_requests_map['retry'], 1)
+            self.assertEqual(_requests_map['count'], 1)
+            self.assertEqual(_requests_map['failure'], 1)
+            self.assertEqual(result, mixin.options.minimum_retry_interval)
+        _requests_map.clear()
+
     def test_transmission_401(self):
         mixin = TransportMixin()
         mixin.options = Options()
@@ -299,28 +529,46 @@ class TestTransportMixin(unittest.TestCase):
                 mixin._transmit_from_storage()
             self.assertEqual(len(os.listdir(mixin.storage.path)), 1)
 
-    def test_transmission_500(self):
+    def test_statsbeat_401(self):
+        _requests_map.clear()
+        mixin = TransportMixin()
+        mixin.options = Options()
+        with mock.patch('requests.post') as post:
+            post.return_value = MockResponse(401, 'unknown')
+            result = mixin._transmit([1,2,3])
+            self.assertEqual(len(_requests_map), 4)
+            self.assertIsNotNone(_requests_map['duration'])
+            self.assertEqual(_requests_map['retry'], 1)
+            self.assertEqual(_requests_map['count'], 1)
+            self.assertEqual(_requests_map['failure'], 1)
+            self.assertEqual(result, mixin.options.minimum_retry_interval)
+        _requests_map.clear()
+
+    def test_transmission_403(self):
         mixin = TransportMixin()
         mixin.options = Options()
         with LocalFileStorage(os.path.join(TEST_FOLDER, self.id())) as stor:
             mixin.storage = stor
             mixin.storage.put([1, 2, 3])
             with mock.patch('requests.post') as post:
-                post.return_value = MockResponse(500, '{}')
+                post.return_value = MockResponse(403, '{}')
                 mixin._transmit_from_storage()
-            self.assertIsNone(mixin.storage.get())
             self.assertEqual(len(os.listdir(mixin.storage.path)), 1)
 
-    def test_transmission_400(self):
+    def test_statsbeat_403(self):
+        _requests_map.clear()
         mixin = TransportMixin()
         mixin.options = Options()
-        with LocalFileStorage(os.path.join(TEST_FOLDER, self.id())) as stor:
-            mixin.storage = stor
-            mixin.storage.put([1, 2, 3])
-            with mock.patch('requests.post') as post:
-                post.return_value = MockResponse(400, '{}')
-                mixin._transmit_from_storage()
-            self.assertEqual(len(os.listdir(mixin.storage.path)), 0)
+        with mock.patch('requests.post') as post:
+            post.return_value = MockResponse(403, 'unknown')
+            result = mixin._transmit([1,2,3])
+            self.assertEqual(len(_requests_map), 4)
+            self.assertIsNotNone(_requests_map['duration'])
+            self.assertEqual(_requests_map['retry'], 1)
+            self.assertEqual(_requests_map['count'], 1)
+            self.assertEqual(_requests_map['failure'], 1)
+            self.assertEqual(result, mixin.options.minimum_retry_interval)
+        _requests_map.clear()
 
     def test_transmission_307(self):
         mixin = TransportMixin()
@@ -348,3 +596,45 @@ class TestTransportMixin(unittest.TestCase):
             self.assertEqual(result, -307)
         self.assertEqual(post.call_count, _MAX_CONSECUTIVE_REDIRECTS)
         self.assertEqual(mixin.options.endpoint, "https://example.com")
+
+    def test_statsbeat_307(self):
+        _requests_map.clear()
+        mixin = TransportMixin()
+        mixin.options = Options()
+        mixin._consecutive_redirects = 0
+        mixin.options.endpoint = "test.endpoint"
+        with mock.patch('requests.post') as post:
+            post.return_value = MockResponse(307, '{}', {"location": "https://example.com"})  # noqa: E501
+            result = mixin._transmit([1,2,3])
+            self.assertEqual(len(_requests_map), 4)
+            self.assertIsNotNone(_requests_map['duration'])
+            self.assertEqual(_requests_map['exception'], 1)
+            self.assertEqual(_requests_map['count'], 10)
+            self.assertEqual(_requests_map['failure'], 10)
+            self.assertEqual(result, -307)
+        _requests_map.clear()
+
+    def test_transmission_439(self):
+        mixin = TransportMixin()
+        mixin.options = Options()
+        with LocalFileStorage(os.path.join(TEST_FOLDER, self.id())) as stor:
+            mixin.storage = stor
+            mixin.storage.put([1, 2, 3])
+            with mock.patch('requests.post') as post:
+                post.return_value = MockResponse(439, '{}')
+                mixin._transmit_from_storage()
+            self.assertEqual(len(os.listdir(mixin.storage.path)), 0)
+
+    def test_statsbeat_439(self):
+        _requests_map.clear()
+        mixin = TransportMixin()
+        mixin.options = Options()
+        with mock.patch('requests.post') as post:
+            post.return_value = MockResponse(439, 'unknown')
+            result = mixin._transmit([1,2,3])
+            self.assertEqual(len(_requests_map), 3)
+            self.assertIsNotNone(_requests_map['duration'])
+            self.assertEqual(_requests_map['throttle'], 1)
+            self.assertEqual(_requests_map['count'], 1)
+            self.assertEqual(result, -439)
+        _requests_map.clear()

--- a/contrib/opencensus-ext-azure/tests/test_transport_mixin.py
+++ b/contrib/opencensus-ext-azure/tests/test_transport_mixin.py
@@ -25,10 +25,10 @@ from azure.identity._exceptions import CredentialUnavailableError
 from opencensus.ext.azure.common import Options
 from opencensus.ext.azure.common.storage import LocalFileStorage
 from opencensus.ext.azure.common.transport import (
-    _requests_map,
     _MAX_CONSECUTIVE_REDIRECTS,
     _MONITOR_OAUTH_SCOPE,
     TransportMixin,
+    _requests_map,
 )
 
 TEST_FOLDER = os.path.abspath('.test.transport')

--- a/contrib/opencensus-ext-azure/tests/test_transport_mixin.py
+++ b/contrib/opencensus-ext-azure/tests/test_transport_mixin.py
@@ -93,7 +93,7 @@ class TestTransportMixin(unittest.TestCase):
         mixin = TransportMixin()
         mixin.options = Options()
         with mock.patch('requests.post', throw(requests.Timeout)):
-            result = mixin._transmit([1,2,3])
+            result = mixin._transmit([1, 2, 3])
             self.assertEqual(len(_requests_map), 3)
             self.assertIsNotNone(_requests_map['duration'])
             self.assertEqual(_requests_map['count'], 1)
@@ -111,13 +111,13 @@ class TestTransportMixin(unittest.TestCase):
                 mixin._transmit_from_storage()
             self.assertIsNone(mixin.storage.get())
             self.assertEqual(len(os.listdir(mixin.storage.path)), 1)
-    
+
     def test_statsbeat_req_exception(self):
         _requests_map.clear()
         mixin = TransportMixin()
         mixin.options = Options()
         with mock.patch('requests.post', throw(requests.RequestException)):
-            result = mixin._transmit([1,2,3])
+            result = mixin._transmit([1, 2, 3])
             self.assertEqual(len(_requests_map), 3)
             self.assertIsNotNone(_requests_map['duration'])
             self.assertEqual(_requests_map['count'], 1)
@@ -141,7 +141,7 @@ class TestTransportMixin(unittest.TestCase):
         mixin = TransportMixin()
         mixin.options = Options()
         with mock.patch('requests.post', throw(CredentialUnavailableError)):
-            result = mixin._transmit([1,2,3])
+            result = mixin._transmit([1, 2, 3])
             self.assertEqual(len(_requests_map), 3)
             self.assertIsNotNone(_requests_map['duration'])
             self.assertEqual(_requests_map['exception'], 1)
@@ -165,7 +165,7 @@ class TestTransportMixin(unittest.TestCase):
         mixin = TransportMixin()
         mixin.options = Options()
         with mock.patch('requests.post', throw(ClientAuthenticationError)):
-            result = mixin._transmit([1,2,3])
+            result = mixin._transmit([1, 2, 3])
             self.assertEqual(len(_requests_map), 3)
             self.assertIsNotNone(_requests_map['duration'])
             self.assertEqual(_requests_map['retry'], 1)
@@ -189,7 +189,7 @@ class TestTransportMixin(unittest.TestCase):
         mixin = TransportMixin()
         mixin.options = Options()
         with mock.patch('requests.post', throw(Exception)):
-            result = mixin._transmit([1,2,3])
+            result = mixin._transmit([1, 2, 3])
             self.assertEqual(len(_requests_map), 3)
             self.assertIsNotNone(_requests_map['duration'])
             self.assertEqual(_requests_map['exception'], 1)
@@ -244,7 +244,7 @@ class TestTransportMixin(unittest.TestCase):
         mixin.options = Options()
         with mock.patch('requests.post') as post:
             post.return_value = MockResponse(200, 'unknown')
-            result = mixin._transmit([1,2,3])
+            result = mixin._transmit([1, 2, 3])
             self.assertEqual(len(_requests_map), 3)
             self.assertIsNotNone(_requests_map['duration'])
             self.assertEqual(_requests_map['success'], 1)
@@ -305,7 +305,7 @@ class TestTransportMixin(unittest.TestCase):
         mixin.options = Options()
         with mock.patch('requests.post') as post:
             post.return_value = MockResponse(206, 'unknown')
-            result = mixin._transmit([1,2,3])
+            result = mixin._transmit([1, 2, 3])
             self.assertEqual(len(_requests_map), 4)
             self.assertIsNotNone(_requests_map['duration'])
             self.assertEqual(_requests_map['retry'], 1)
@@ -362,7 +362,7 @@ class TestTransportMixin(unittest.TestCase):
                         },
                     ],
                 }))
-            result = mixin._transmit([1,2,3])
+            result = mixin._transmit([1, 2, 3])
             self.assertEqual(len(_requests_map), 4)
             self.assertIsNotNone(_requests_map['duration'])
             self.assertEqual(_requests_map['retry'], 1)
@@ -408,7 +408,7 @@ class TestTransportMixin(unittest.TestCase):
                         },
                     ],
                 }))
-            result = mixin._transmit([1,2,3])
+            result = mixin._transmit([1, 2, 3])
             self.assertEqual(len(_requests_map), 3)
             self.assertIsNotNone(_requests_map['duration'])
             self.assertEqual(_requests_map['count'], 1)
@@ -455,7 +455,7 @@ class TestTransportMixin(unittest.TestCase):
         mixin.options = Options()
         with mock.patch('requests.post') as post:
             post.return_value = MockResponse(429, 'unknown')
-            result = mixin._transmit([1,2,3])
+            result = mixin._transmit([1, 2, 3])
             self.assertEqual(len(_requests_map), 4)
             self.assertIsNotNone(_requests_map['duration'])
             self.assertEqual(_requests_map['retry'], 1)
@@ -482,7 +482,7 @@ class TestTransportMixin(unittest.TestCase):
         mixin.options = Options()
         with mock.patch('requests.post') as post:
             post.return_value = MockResponse(500, 'unknown')
-            result = mixin._transmit([1,2,3])
+            result = mixin._transmit([1, 2, 3])
             self.assertEqual(len(_requests_map), 4)
             self.assertIsNotNone(_requests_map['duration'])
             self.assertEqual(_requests_map['retry'], 1)
@@ -509,7 +509,7 @@ class TestTransportMixin(unittest.TestCase):
         mixin.options = Options()
         with mock.patch('requests.post') as post:
             post.return_value = MockResponse(503, 'unknown')
-            result = mixin._transmit([1,2,3])
+            result = mixin._transmit([1, 2, 3])
             self.assertEqual(len(_requests_map), 4)
             self.assertIsNotNone(_requests_map['duration'])
             self.assertEqual(_requests_map['retry'], 1)
@@ -535,7 +535,7 @@ class TestTransportMixin(unittest.TestCase):
         mixin.options = Options()
         with mock.patch('requests.post') as post:
             post.return_value = MockResponse(401, 'unknown')
-            result = mixin._transmit([1,2,3])
+            result = mixin._transmit([1, 2, 3])
             self.assertEqual(len(_requests_map), 4)
             self.assertIsNotNone(_requests_map['duration'])
             self.assertEqual(_requests_map['retry'], 1)
@@ -561,7 +561,7 @@ class TestTransportMixin(unittest.TestCase):
         mixin.options = Options()
         with mock.patch('requests.post') as post:
             post.return_value = MockResponse(403, 'unknown')
-            result = mixin._transmit([1,2,3])
+            result = mixin._transmit([1, 2, 3])
             self.assertEqual(len(_requests_map), 4)
             self.assertIsNotNone(_requests_map['duration'])
             self.assertEqual(_requests_map['retry'], 1)
@@ -605,7 +605,7 @@ class TestTransportMixin(unittest.TestCase):
         mixin.options.endpoint = "test.endpoint"
         with mock.patch('requests.post') as post:
             post.return_value = MockResponse(307, '{}', {"location": "https://example.com"})  # noqa: E501
-            result = mixin._transmit([1,2,3])
+            result = mixin._transmit([1, 2, 3])
             self.assertEqual(len(_requests_map), 4)
             self.assertIsNotNone(_requests_map['duration'])
             self.assertEqual(_requests_map['exception'], 1)
@@ -631,7 +631,7 @@ class TestTransportMixin(unittest.TestCase):
         mixin.options = Options()
         with mock.patch('requests.post') as post:
             post.return_value = MockResponse(439, 'unknown')
-            result = mixin._transmit([1,2,3])
+            result = mixin._transmit([1, 2, 3])
             self.assertEqual(len(_requests_map), 3)
             self.assertIsNotNone(_requests_map['duration'])
             self.assertEqual(_requests_map['throttle'], 1)

--- a/opencensus/trace/stack_trace.py
+++ b/opencensus/trace/stack_trace.py
@@ -181,7 +181,7 @@ def generate_hash_id():
 
 
 def generate_hash_id_from_traceback(tb):
-    m = hashlib.md5()
+    m = hashlib.md5()  # nosec
     for tb_line in traceback.format_tb(tb):
         m.update(tb_line.encode('utf-8'))
     # truncate the hash for easier compatibility with StackDriver,


### PR DESCRIPTION
1. Miscounted failures (must not include 439 and 402)
2. For 206, only count as retry if errored envelopes are retriable
3. Fix 429 to be retry instead of throttle
4. Count exception for 307 redirect if circular redirect
5. Count 402 and 439 as throttle