### PR TITLE
Fix TypeError when local file storage is above max limit in opencensus-ext-azure

### DIFF
--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
@@ -199,7 +199,7 @@ class LocalFileStorage(object):
                             "reached. Currently at %fKB. Telemetry will be "
                             "lost. Please consider increasing the value of "
                             "'storage_max_size' in exporter config.",
-                            format(size/1024)
+                            size/1024
                         )
                         return False
         return True

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
@@ -196,10 +196,10 @@ class LocalFileStorage(object):
                     if size >= self.max_size:
                         logger.warning(
                             "Persistent storage max capacity has been "
-                            "reached. Currently at %fKB. Telemetry will be "
+                            "reached. Currently at %sKB. Telemetry will be "
                             "lost. Please consider increasing the value of "
                             "'storage_max_size' in exporter config.",
-                            size/1024
+                            format(size/1024)
                         )
                         return False
         return True

--- a/contrib/opencensus-ext-azure/tests/test_storage.py
+++ b/contrib/opencensus-ext-azure/tests/test_storage.py
@@ -151,6 +151,16 @@ class TestLocalFileStorage(unittest.TestCase):
                     os_mock.return_value = True
                 self.assertTrue(stor._check_storage_size())
 
+    def test_check_storage_size_above_max_limit(self):
+        input = (1, 2, 3)
+        with LocalFileStorage(os.path.join(TEST_FOLDER, 'asd5'), 1) as stor:
+            with mock.patch('os.path.getsize') as os_mock:
+                os_mock.return_value = 52000000
+                stor.put(input)
+                with mock.patch('os.path.islink') as os_mock:
+                    os_mock.return_value = True
+                self.assertFalse(stor._check_storage_size())
+
     def test_maintenance_routine(self):
         with mock.patch('os.makedirs') as m:
             LocalFileStorage(os.path.join(TEST_FOLDER, 'baz'))


### PR DESCRIPTION
This is a pretty ugly issue if we go over the limit of 50 MB local storage. (default limit)
The logging is broken and each time the max limit will be reached opencensus will go into some kind of infinite cycle because an exception will be thrown each time it tries to log the warning and so on. (we saw even 2 million TypeErrors in application insights in ~30 minutes)

Please take into consideration this issue because it's quite critical to azure-exporter usage.

Added test that reproduces it. Fix is to remove `format`
Full error stack
```
Unhandled exception from exporter.
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/opencensus/ext/azure/log_exporter/__init__.py", line 138, in run
    dst._export(batch)
  File "/usr/local/lib/python3.8/site-packages/opencensus/ext/azure/log_exporter/__init__.py", line 75, in _export
    envelopes = [self.log_record_to_envelope(x) for x in batch]
  File "/usr/local/lib/python3.8/site-packages/opencensus/ext/azure/log_exporter/__init__.py", line 75, in <listcomp>
    envelopes = [self.log_record_to_envelope(x) for x in batch]
  File "/usr/local/lib/python3.8/site-packages/opencensus/ext/azure/log_exporter/__init__.py", line 223, in log_record_to_envelope
    message=self.format(record),
  File "/usr/lib64/python3.8/logging/__init__.py", line 925, in format
    return fmt.format(record)
  File "/usr/lib64/python3.8/logging/__init__.py", line 664, in format
    record.message = record.getMessage()
  File "/usr/lib64/python3.8/logging/__init__.py", line 369, in getMessage
    msg = msg % self.args
TypeError: must be real number, not str 
```