### PR TITLE
Fix statsbeat bugs

### DIFF
--- a/contrib/opencensus-ext-azure/CHANGELOG.md
+++ b/contrib/opencensus-ext-azure/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-- Statsbeat bug fixes
+- Statsbeat bug fixes - status codes
+([#1113](https://github.com/census-instrumentation/opencensus-python/pull/1113))
+- Statsbeat bug fixes - do not log if statsbeat
 ([#1113](https://github.com/census-instrumentation/opencensus-python/pull/1113))
 
 ## 1.1.3

--- a/contrib/opencensus-ext-azure/CHANGELOG.md
+++ b/contrib/opencensus-ext-azure/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Statsbeat bug fixes - status codes
 ([#1113](https://github.com/census-instrumentation/opencensus-python/pull/1113))
 - Statsbeat bug fixes - do not log if statsbeat
-([#1113](https://github.com/census-instrumentation/opencensus-python/pull/1113))
+([#1116](https://github.com/census-instrumentation/opencensus-python/pull/1116))
 
 ## 1.1.3
 Released 2022-03-03

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/transport.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/transport.py
@@ -41,6 +41,9 @@ class TransportMixin(object):
     def _check_stats_collection(self):
         return not os.environ.get("APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL") and (not hasattr(self, '_is_stats') or not self._is_stats)  # noqa: E501
 
+    def _is_stats_exporter(self):
+        return hasattr(self, '_is_stats') and self._is_stats
+
     def _transmit_from_storage(self):
         if self.storage:
             for blob in self.storage.gets():
@@ -88,23 +91,28 @@ class TransportMixin(object):
                 allow_redirects=False,
             )
         except requests.Timeout:
-            logger.warning(
-                'Request time out. Ingestion may be backed up. Retrying.')
+            if not self._is_stats_exporter():
+                logger.warning(
+                    'Request time out. Ingestion may be backed up. Retrying.')
             exception = self.options.minimum_retry_interval
         except requests.RequestException as ex:
-            logger.warning(
-                'Retrying due to transient client side error %s.', ex)
+            if not self._is_stats_exporter():
+                logger.warning(
+                    'Retrying due to transient client side error %s.', ex)
             # client side error (retryable)
             exception = self.options.minimum_retry_interval
         except CredentialUnavailableError as ex:
-            logger.warning('Credential error. %s. Dropping telemetry.', ex)
+            if not self._is_stats_exporter():
+                logger.warning('Credential error. %s. Dropping telemetry.', ex)
             exception = -1
         except ClientAuthenticationError as ex:
-            logger.warning('Authentication error %s', ex)
+            if not self._is_stats_exporter():
+                logger.warning('Authentication error %s', ex)
             exception = self.options.minimum_retry_interval
         except Exception as ex:
-            logger.warning(
-                'Error when sending request %s. Dropping telemetry.', ex)
+            if not self._is_stats_exporter():
+                logger.warning(
+                    'Error when sending request %s. Dropping telemetry.', ex)
             # Extraneous error (non-retryable)
             exception = -1
         finally:
@@ -128,7 +136,8 @@ class TransportMixin(object):
         try:
             text = response.text
         except Exception as ex:
-            logger.warning('Error while reading response body %s.', ex)
+            if not self._is_stats_exporter():
+                logger.warning('Error while reading response body %s.', ex)
         else:
             try:
                 data = json.loads(text)
@@ -169,12 +178,13 @@ class TransportMixin(object):
                                 _requests_map['retry'] = _requests_map.get('retry', 0) + 1  # noqa: E501
                         self.storage.put(resend_envelopes)
                 except Exception as ex:
-                    logger.error(
-                        'Error while processing %s: %s %s.',
-                        response.status_code,
-                        text,
-                        ex,
-                    )
+                    if not self._is_stats_exporter():
+                        logger.error(
+                            'Error while processing %s: %s %s.',
+                            response.status_code,
+                            text,
+                            ex,
+                        )
                 return -response.status_code
             # cannot parse response body, fallback to retry
         if response.status_code in (
@@ -183,11 +193,12 @@ class TransportMixin(object):
                 500,  # Internal Server Error
                 503,  # Service Unavailable
         ):
-            logger.warning(
-                'Transient server side error %s: %s.',
-                response.status_code,
-                text,
-            )
+            if not self._is_stats_exporter():
+                logger.warning(
+                    'Transient server side error %s: %s.',
+                    response.status_code,
+                    text,
+                )
             # server side error (retryable)
             if self._check_stats_collection():
                 with _requests_lock:
@@ -195,11 +206,12 @@ class TransportMixin(object):
             return self.options.minimum_retry_interval
         # Authentication error
         if response.status_code == 401:
-            logger.warning(
-                'Authentication error %s: %s.',
-                response.status_code,
-                text,
-            )
+            if not self._is_stats_exporter():
+                logger.warning(
+                    'Authentication error %s: %s.',
+                    response.status_code,
+                    text,
+                )
             if self._check_stats_collection():
                 with _requests_lock:
                     _requests_map['retry'] = _requests_map.get('retry', 0) + 1  # noqa: E501
@@ -208,11 +220,12 @@ class TransportMixin(object):
         # Can occur when v2 endpoint is used while AI resource is configured
         # with disableLocalAuth
         if response.status_code == 403:
-            logger.warning(
-                'Forbidden error %s: %s.',
-                response.status_code,
-                text,
-            )
+            if not self._is_stats_exporter():
+                logger.warning(
+                    'Forbidden error %s: %s.',
+                    response.status_code,
+                    text,
+                )
             if self._check_stats_collection():
                 with _requests_lock:
                     _requests_map['retry'] = _requests_map.get('retry', 0) + 1  # noqa: E501
@@ -230,24 +243,27 @@ class TransportMixin(object):
                             self.options.endpoint = "{}://{}".format(url.scheme, url.netloc)  # noqa: E501
                             # Attempt to export again
                             return self._transmit(envelopes)
-                logger.error(
-                    "Error parsing redirect information."
-                )
+                if not self._is_stats_exporter():
+                    logger.error(
+                        "Error parsing redirect information."
+                    )
             else:
-                logger.error(
-                    "Error sending telemetry because of circular redirects."
-                    " Please check the integrity of your connection string."
-                )
+                if not self._is_stats_exporter():
+                    logger.error(
+                        "Error sending telemetry because of circular redirects."
+                        " Please check the integrity of your connection string."
+                    )
             # If redirect but did not return, exception occured
             if self._check_stats_collection():
                 with _requests_lock:
                     _requests_map['exception'] = _requests_map.get('exception', 0) + 1  # noqa: E501
         # Other, server side error (non-retryable)
-        logger.error(
-            'Non-retryable server side error %s: %s.',
-            response.status_code,
-            text,
-        )
+        if not self._is_stats_exporter():
+            logger.error(
+                'Non-retryable server side error %s: %s.',
+                response.status_code,
+                text,
+            )
         if self._check_stats_collection():
             if response.status_code == 402 or response.status_code == 439:
                 # 402: Monthly Quota Exceeded (new SDK)

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/transport.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/transport.py
@@ -250,8 +250,8 @@ class TransportMixin(object):
             else:
                 if not self._is_stats_exporter():
                     logger.error(
-                        "Error sending telemetry because of circular redirects."
-                        " Please check the integrity of your connection string."
+                        "Error sending telemetry because of circular redirects."  # noqa: E501
+                        " Please check the integrity of your connection string."  # noqa: E501
                     )
             # If redirect but did not return, exception occured
             if self._check_stats_collection():

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/__init__.py
@@ -33,6 +33,7 @@ from opencensus.stats import stats as stats_module
 
 __all__ = ['MetricsExporter', 'new_metrics_exporter']
 
+
 class MetricsExporter(TransportMixin, ProcessorMixin):
     """Metrics exporter for Microsoft Azure Monitor."""
 

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/__init__.py
@@ -34,9 +34,6 @@ from opencensus.stats import stats as stats_module
 
 __all__ = ['MetricsExporter', 'new_metrics_exporter']
 
-logger = logging.getLogger(__name__)
-
-
 class MetricsExporter(TransportMixin, ProcessorMixin):
     """Metrics exporter for Microsoft Azure Monitor."""
 

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/__init__.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import atexit
-import logging
 import os
 
 from opencensus.common import utils as common_utils

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/statsbeat_metrics/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/statsbeat_metrics/__init__.py
@@ -22,6 +22,7 @@ from opencensus.ext.azure.metrics_exporter.statsbeat_metrics.statsbeat import (
 )
 from opencensus.metrics import transport
 from opencensus.metrics.export.metric_producer import MetricProducer
+from opencensus.trace import execution_context
 
 _STATSBEAT_METRICS = None
 _STATSBEAT_EXPORTER = None
@@ -46,7 +47,9 @@ def collect_statsbeat_metrics(options):
             producer = _AzureStatsbeatMetricsProducer(options)
             _STATSBEAT_METRICS = producer
             # Export some initial stats on program start
+            execution_context.set_is_exporter(True)
             exporter.export_metrics(_STATSBEAT_METRICS.get_initial_metrics())
+            execution_context.set_is_exporter(False)
             exporter.exporter_thread = \
                 transport.get_exporter_thread([_STATSBEAT_METRICS],
                                               exporter,

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/statsbeat_metrics/statsbeat.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/statsbeat_metrics/statsbeat.py
@@ -31,6 +31,7 @@ from opencensus.metrics.export.gauge import (
 )
 from opencensus.metrics.label_key import LabelKey
 from opencensus.metrics.label_value import LabelValue
+from opencensus.trace import execution_context
 from opencensus.trace.integrations import _Integrations, get_integrations
 
 _AIMS_URI = "http://169.254.169.254/metadata/instance/compute"
@@ -67,8 +68,6 @@ _ENDPOINT_TYPES = ["breeze"]
 _RP_NAMES = ["appsvc", "functions", "vm", "unknown"]
 
 _HOST_PATTERN = re.compile('^https?://(?:www\\.)?([^/.]+)')
-
-_logger = logging.getLogger(__name__)
 
 
 class _FEATURE_TYPES:
@@ -316,7 +315,7 @@ class _StatsbeatMetrics:
             network_metrics = self._get_network_metrics()
             metrics.extend(network_metrics)
         except Exception as ex:
-            _logger.warning('Error while exporting stats metrics %s.', ex)
+            pass
 
         return metrics
 
@@ -374,7 +373,7 @@ class _StatsbeatMetrics:
             # Function apps
             rp = _RP_NAMES[1]
             rpId = os.environ.get("WEBSITE_HOSTNAME")
-        elif self._vm_retry and self._get_azure_compute_metadata():
+        elif self._get_azure_compute_metadata():
             # VM
             rp = _RP_NAMES[2]
             rpId = '{}/{}'.format(

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/statsbeat_metrics/statsbeat.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/statsbeat_metrics/statsbeat.py
@@ -312,7 +312,7 @@ class _StatsbeatMetrics:
                     self._long_threshold_count = 0
             network_metrics = self._get_network_metrics()
             metrics.extend(network_metrics)
-        except Exception as ex:
+        except Exception:
             pass
 
         return metrics

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/statsbeat_metrics/statsbeat.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/metrics_exporter/statsbeat_metrics/statsbeat.py
@@ -14,7 +14,6 @@
 
 import datetime
 import json
-import logging
 import os
 import platform
 import re
@@ -31,7 +30,6 @@ from opencensus.metrics.export.gauge import (
 )
 from opencensus.metrics.label_key import LabelKey
 from opencensus.metrics.label_value import LabelValue
-from opencensus.trace import execution_context
 from opencensus.trace.integrations import _Integrations, get_integrations
 
 _AIMS_URI = "http://169.254.169.254/metadata/instance/compute"
@@ -373,7 +371,7 @@ class _StatsbeatMetrics:
             # Function apps
             rp = _RP_NAMES[1]
             rpId = os.environ.get("WEBSITE_HOSTNAME")
-        elif self._get_azure_compute_metadata():
+        elif self._vm_retry and self._get_azure_compute_metadata():
             # VM
             rp = _RP_NAMES[2]
             rpId = '{}/{}'.format(

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ deps =
   unit,lint,bandit: -e contrib/opencensus-ext-mysql
   unit,lint,bandit: -e contrib/opencensus-ext-ocagent
   unit,lint,bandit: -e contrib/opencensus-ext-postgresql
-  py{36,37,38,39}-unit,lint,bandit prometheus-client==0.13.1
+  py{36,37,38,39}-unit,lint,bandit: prometheus-client==0.13.1
   unit,lint,bandit: -e contrib/opencensus-ext-prometheus
   unit,lint,bandit: -e contrib/opencensus-ext-pymongo
   unit,lint,bandit: -e contrib/opencensus-ext-pymysql

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,7 @@ deps =
   unit,lint,bandit: -e contrib/opencensus-ext-mysql
   unit,lint,bandit: -e contrib/opencensus-ext-ocagent
   unit,lint,bandit: -e contrib/opencensus-ext-postgresql
+  unit,lint,bandit: prometheus-client==0.13.1
   unit,lint,bandit: -e contrib/opencensus-ext-prometheus
   unit,lint,bandit: -e contrib/opencensus-ext-pymongo
   unit,lint,bandit: -e contrib/opencensus-ext-pymysql

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ deps =
   unit,lint,bandit: -e contrib/opencensus-ext-mysql
   unit,lint,bandit: -e contrib/opencensus-ext-ocagent
   unit,lint,bandit: -e contrib/opencensus-ext-postgresql
-  unit,lint,bandit: prometheus-client==0.13.1
+  py{36,37,38,39}-unit,lint,bandit prometheus-client==0.13.1
   unit,lint,bandit: -e contrib/opencensus-ext-prometheus
   unit,lint,bandit: -e contrib/opencensus-ext-pymongo
   unit,lint,bandit: -e contrib/opencensus-ext-pymysql


### PR DESCRIPTION
1. Do not log when sending statsbeat data
2. Set `is_exporter` to `True` when calling `azure_meta_data_service` so `requests` instrumentation will not track `requests` call as regular telemetry