### PR TITLE
Azure: Allow specifying metrics for custom events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Allow specifying metrics (custom_measurements) for Azure custom events
+([#1117](https://github.com/census-instrumentation/opencensus-python/pull/1117))
 
 # 0.9.0
 Released 2022-04-20

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/log_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/log_exporter/__init__.py
@@ -255,10 +255,16 @@ class AzureEventHandler(TransportMixin, ProcessorMixin, BaseLogHandler):
                 isinstance(record.custom_dimensions, dict)):
             properties.update(record.custom_dimensions)
 
+        measurements = {}
+        if (hasattr(record, 'custom_measurements') and
+                isinstance(record.custom_measurements, dict)):
+            measurements.update(record.custom_measurements)
+
         envelope.name = 'Microsoft.ApplicationInsights.Event'
         data = Event(
             name=self.format(record),
             properties=properties,
+            measurements=measurements,
         )
         envelope.data = Data(baseData=data, baseType='EventData')
 

--- a/contrib/opencensus-ext-azure/tests/test_azure_log_exporter.py
+++ b/contrib/opencensus-ext-azure/tests/test_azure_log_exporter.py
@@ -373,6 +373,11 @@ class TestAzureEventHandler(unittest.TestCase):
                 {
                         'key_1': 'value_1',
                         'key_2': 'value_2'
+                },
+                'custom_measurements':
+                {
+                    'measure_1': 1,
+                    'measure_2': 2
                 }
             }
             logger.exception('Captured an exception.', extra=properties)
@@ -382,6 +387,8 @@ class TestAzureEventHandler(unittest.TestCase):
         self.assertTrue('ZeroDivisionError' in post_body)
         self.assertTrue('key_1' in post_body)
         self.assertTrue('key_2' in post_body)
+        self.assertTrue('measure_1' in post_body)
+        self.assertTrue('measure_2' in post_body)
 
     @mock.patch('requests.post', return_value=mock.Mock())
     def test_export_empty(self, request_mock):
@@ -436,6 +443,11 @@ class TestAzureEventHandler(unittest.TestCase):
                 {
                     'key_1': 'value_1',
                     'key_2': 'value_2'
+                },
+            'custom_measurements':
+                {
+                    'measure_1': 1,
+                    'measure_2': 2
                 }
             })
         handler.close()
@@ -443,6 +455,8 @@ class TestAzureEventHandler(unittest.TestCase):
         self.assertTrue('action' in post_body)
         self.assertTrue('key_1' in post_body)
         self.assertTrue('key_2' in post_body)
+        self.assertTrue('measure_1' in post_body)
+        self.assertTrue('measure_2' in post_body)
 
     @mock.patch('requests.post', return_value=mock.Mock())
     def test_log_with_invalid_custom_properties(self, requests_mock):
@@ -454,7 +468,8 @@ class TestAzureEventHandler(unittest.TestCase):
         logger.addHandler(handler)
         logger.warning('action_1_%s', None)
         logger.warning('action_2_%s', 'arg', extra={
-            'custom_dimensions': 'not_a_dict'
+            'custom_dimensions': 'not_a_dict',
+            'custom_measurements': 'also_not'
         })
         logger.warning('action_3_%s', 'arg', extra={
             'notcustom_dimensions': {'key_1': 'value_1'}
@@ -468,6 +483,7 @@ class TestAzureEventHandler(unittest.TestCase):
         self.assertTrue('action_3_arg' in post_body)
 
         self.assertFalse('not_a_dict' in post_body)
+        self.assertFalse('also_not' in post_body)
         self.assertFalse('key_1' in post_body)
 
     @mock.patch('requests.post', return_value=mock.Mock())


### PR DESCRIPTION
### Description
This PR adds the ability to specify custom measurements as part of Azure events, emulating the way it was done for custom dimensions.

### Testing
I tested this manually using the following python command:
```python
import logging
from opencensus.ext.azure.log_exporter import AzureEventHandler

events = logging.getLogger("myLogger")
events.addHandler(AzureEventHandler())
events.warning("My event", extra={"custom_dimensions":{"type":"Example"},"custom_measurements":{"example_metric":1}})
```
My Application Insights resource successfully received a custom event with both the `customDimensions` and `customMeasurements` properties.

### Additional Context
This was requested in a comment in #809 and this PR might be the final piece needed to close that issue, but I'm not sure because the feature request made there isn't very specific.