### PR TITLE
Add `requests` as a hard dependency to integration

### DIFF
--- a/contrib/opencensus-ext-requests/CHANGELOG.md
+++ b/contrib/opencensus-ext-requests/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Add `requests` library as a hard dependency
-([#1014](https://github.com/census-instrumentation/opencensus-python/pull/1014))
+([#1146](https://github.com/census-instrumentation/opencensus-python/pull/1146))
 
 ## 0.7.5
 Released 2021-05-13

--- a/contrib/opencensus-ext-requests/CHANGELOG.md
+++ b/contrib/opencensus-ext-requests/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add `requests` library as a hard dependency
+([#1014](https://github.com/census-instrumentation/opencensus-python/pull/1014))
+
 ## 0.7.5
 Released 2021-05-13
 

--- a/contrib/opencensus-ext-requests/setup.py
+++ b/contrib/opencensus-ext-requests/setup.py
@@ -42,6 +42,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'opencensus >= 0.9.dev0, < 1.0.0',
+        'requests >= 2.19.0, 3.0.0',
         'wrapt >= 1.0.0, < 2.0.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-requests/setup.py
+++ b/contrib/opencensus-ext-requests/setup.py
@@ -42,7 +42,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'opencensus >= 0.9.dev0, < 1.0.0',
-        'requests >= 2.19.0, 3.0.0',
+        'requests >= 2.19.0, < 3.0.0',
         'wrapt >= 1.0.0, < 2.0.0',
     ],
     extras_require={},


### PR DESCRIPTION
Following the design of all other integrations.