### PR TITLE
Add 502 and 504 as retriable

### DIFF
--- a/contrib/opencensus-ext-azure/CHANGELOG.md
+++ b/contrib/opencensus-ext-azure/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Add storage existence checks to storing and transmitting in exporter
 ([#1150](https://github.com/census-instrumentation/opencensus-python/pull/1150))
+- Add 502 and 504 status codes as retriable
+([#1150](https://github.com/census-instrumentation/opencensus-python/pull/1150))
 
 ## 1.1.6
 Released 2022-08-03

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/transport.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/transport.py
@@ -43,7 +43,9 @@ RETRYABLE_STATUS_CODES = (
     408,  # Request Timeout
     429,  # Too many requests
     500,  # Internal server error
+    502,  # Bad Gateway
     503,  # Service unavailable
+    504,  # Gateway timeout
 )
 THROTTLE_STATUS_CODES = (402, 439)
 

--- a/contrib/opencensus-ext-azure/tests/test_transport_mixin.py
+++ b/contrib/opencensus-ext-azure/tests/test_transport_mixin.py
@@ -599,6 +599,30 @@ class TestTransportMixin(unittest.TestCase):
             self.assertEqual(_requests_map['count'], 1)
             self.assertEqual(result, TransportStatusCode.RETRY)
 
+    def test_transmission_502(self):
+        mixin = TransportMixin()
+        mixin.options = Options()
+        with LocalFileStorage(os.path.join(TEST_FOLDER, self.id())) as stor:
+            mixin.storage = stor
+            mixin.storage.put([1, 2, 3])
+            with mock.patch('requests.post') as post:
+                post.return_value = MockResponse(502, 'unknown')
+                mixin._transmit_from_storage()
+            self.assertIsNone(mixin.storage.get())
+            self.assertEqual(len(os.listdir(mixin.storage.path)), 1)
+
+    def test_statsbeat_502(self):
+        mixin = TransportMixin()
+        mixin.options = Options()
+        with mock.patch('requests.post') as post:
+            post.return_value = MockResponse(502, 'unknown')
+            result = mixin._transmit([1, 2, 3])
+            self.assertEqual(len(_requests_map), 3)
+            self.assertIsNotNone(_requests_map['duration'])
+            self.assertEqual(_requests_map['retry'][502], 1)
+            self.assertEqual(_requests_map['count'], 1)
+            self.assertEqual(result, TransportStatusCode.RETRY)
+
     def test_transmission_503(self):
         mixin = TransportMixin()
         mixin.options = Options()
@@ -620,6 +644,30 @@ class TestTransportMixin(unittest.TestCase):
             self.assertEqual(len(_requests_map), 3)
             self.assertIsNotNone(_requests_map['duration'])
             self.assertEqual(_requests_map['retry'][503], 1)
+            self.assertEqual(_requests_map['count'], 1)
+            self.assertEqual(result, TransportStatusCode.RETRY)
+
+    def test_transmission_504(self):
+        mixin = TransportMixin()
+        mixin.options = Options()
+        with LocalFileStorage(os.path.join(TEST_FOLDER, self.id())) as stor:
+            mixin.storage = stor
+            mixin.storage.put([1, 2, 3])
+            with mock.patch('requests.post') as post:
+                post.return_value = MockResponse(504, 'unknown')
+                mixin._transmit_from_storage()
+            self.assertIsNone(mixin.storage.get())
+            self.assertEqual(len(os.listdir(mixin.storage.path)), 1)
+
+    def test_statsbeat_504(self):
+        mixin = TransportMixin()
+        mixin.options = Options()
+        with mock.patch('requests.post') as post:
+            post.return_value = MockResponse(504, 'unknown')
+            result = mixin._transmit([1, 2, 3])
+            self.assertEqual(len(_requests_map), 3)
+            self.assertIsNotNone(_requests_map['duration'])
+            self.assertEqual(_requests_map['retry'][504], 1)
             self.assertEqual(_requests_map['count'], 1)
             self.assertEqual(result, TransportStatusCode.RETRY)
 


### PR DESCRIPTION
From spec: https://github.com/microsoft/Telemetry-Collection-Spec/blob/main/ApplicationInsights/sdk_behavior_breeze.md#502---bad-gateway