### PR TITLE
Fixed AzureLogHandler with multiple processes.

### DIFF
--- a/opencensus/common/schedule/__init__.py
+++ b/opencensus/common/schedule/__init__.py
@@ -15,6 +15,7 @@
 from six.moves import queue
 
 import logging
+import multiprocessing
 import threading
 import time
 
@@ -82,7 +83,7 @@ class QueueExitEvent(QueueEvent):
 class Queue(object):
     def __init__(self, capacity):
         self.EXIT_EVENT = QueueExitEvent('EXIT')
-        self._queue = queue.Queue(maxsize=capacity)
+        self._queue = multiprocessing.Queue(maxsize=capacity)
 
     def _gets(self, count, timeout):
         start_time = time.time()


### PR DESCRIPTION
These changes fix both https://github.com/census-instrumentation/opencensus-python/issues/900 and https://github.com/census-instrumentation/opencensus-python/issues/928, but I'm not so sure about the compatibility with Python2.
I changed the normal queue.Queue to a multiprocessing.Queue and converted the LogRecord to an envelope before putting it on the queue as serializing a LogRecord didn't work when it contained a traceback.