### PR TITLE
Fixed support for Django 4.1

### DIFF
--- a/contrib/opencensus-ext-django/CHANGELOG.md
+++ b/contrib/opencensus-ext-django/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Fixed support for Django 4.1
+- ([#1159](https://github.com/census-instrumentation/opencensus-python/pull/1158))
+
 ## 0.7.5
 Released 2021-05-13
 

--- a/contrib/opencensus-ext-django/CHANGELOG.md
+++ b/contrib/opencensus-ext-django/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Fixed support for Django 4.1
-- ([#1159](https://github.com/census-instrumentation/opencensus-python/pull/1158))
+- ([#1159](https://github.com/census-instrumentation/opencensus-python/pull/1159))
 
 ## 0.7.5
 Released 2021-05-13

--- a/contrib/opencensus-ext-django/opencensus/ext/django/middleware.py
+++ b/contrib/opencensus-ext-django/opencensus/ext/django/middleware.py
@@ -147,7 +147,7 @@ class OpencensusMiddleware(MiddlewareMixin):
     """Saves the request in thread local"""
 
     def __init__(self, get_response=None):
-        self.get_response = get_response
+        super().__init__(get_response)
         settings = getattr(django.conf.settings, 'OPENCENSUS', {})
         settings = settings.get('TRACE', {})
 

--- a/contrib/opencensus-ext-django/opencensus/ext/django/middleware.py
+++ b/contrib/opencensus-ext-django/opencensus/ext/django/middleware.py
@@ -146,8 +146,8 @@ def _trace_db_call(execute, sql, params, many, context):
 class OpencensusMiddleware(MiddlewareMixin):
     """Saves the request in thread local"""
 
-    def __init__(self, get_response=None):
-        super().__init__(get_response)
+    def __init__(self, get_response):
+        super(OpencensusMiddleware, self).__init__(get_response)
         settings = getattr(django.conf.settings, 'OPENCENSUS', {})
         settings = settings.get('TRACE', {})
 

--- a/contrib/opencensus-ext-django/tests/test_django_db_middleware.py
+++ b/contrib/opencensus-ext-django/tests/test_django_db_middleware.py
@@ -18,9 +18,14 @@ from collections import namedtuple
 import django
 import mock
 import pytest
+from django.http import HttpResponse
 from django.test.utils import teardown_test_environment
 
 from opencensus.trace import execution_context
+
+
+def get_response(request):
+    return HttpResponse()
 
 
 class TestOpencensusDatabaseMiddleware(unittest.TestCase):
@@ -50,7 +55,7 @@ class TestOpencensusDatabaseMiddleware(unittest.TestCase):
         mock_execute = mock.Mock()
         mock_execute.return_value = "Mock result"
 
-        middleware.OpencensusMiddleware()
+        middleware.OpencensusMiddleware(get_response)
 
         patch_no_tracer = mock.patch(
             'opencensus.ext.django.middleware._get_current_tracer',

--- a/contrib/opencensus-ext-django/tests/test_django_middleware.py
+++ b/contrib/opencensus-ext-django/tests/test_django_middleware.py
@@ -17,6 +17,7 @@ import traceback
 import unittest
 
 import mock
+from django.http import HttpResponse
 from django.test import RequestFactory
 from django.test.utils import teardown_test_environment
 
@@ -25,6 +26,10 @@ from opencensus.trace import span as span_module
 from opencensus.trace import utils
 from opencensus.trace.blank_span import BlankSpan
 from opencensus.trace.propagation import trace_context_http_header_format
+
+
+def get_response(request):
+    return HttpResponse()
 
 
 class TestOpencensusMiddleware(unittest.TestCase):
@@ -44,7 +49,7 @@ class TestOpencensusMiddleware(unittest.TestCase):
     def test_constructor_default(self):
         from opencensus.ext.django import middleware
 
-        middleware = middleware.OpencensusMiddleware()
+        middleware = middleware.OpencensusMiddleware(get_response)
 
         assert isinstance(middleware.sampler, samplers.ProbabilitySampler)
         assert isinstance(middleware.exporter, print_exporter.PrintExporter)
@@ -69,7 +74,7 @@ class TestOpencensusMiddleware(unittest.TestCase):
             settings)
 
         with patch_settings:
-            middleware = middleware.OpencensusMiddleware()
+            middleware = middleware.OpencensusMiddleware(get_response)
 
         assert isinstance(middleware.sampler, samplers.AlwaysOnSampler)
         assert isinstance(middleware.exporter, print_exporter.PrintExporter)
@@ -100,7 +105,7 @@ class TestOpencensusMiddleware(unittest.TestCase):
             settings)
 
         with patch_settings:
-            middleware_obj = middleware.OpencensusMiddleware()
+            middleware_obj = middleware.OpencensusMiddleware(get_response)
 
         # test process_request
         middleware_obj.process_request(django_request)
@@ -148,7 +153,7 @@ class TestOpencensusMiddleware(unittest.TestCase):
             settings)
 
         with patch_settings:
-            middleware_obj = middleware.OpencensusMiddleware()
+            middleware_obj = middleware.OpencensusMiddleware(get_response)
 
         django_request = RequestFactory().get('/test_excludelist_path')
         disabled = utils.disable_tracing_url(django_request.path,
@@ -204,7 +209,7 @@ class TestOpencensusMiddleware(unittest.TestCase):
             settings)
 
         with patch_settings:
-            middleware_obj = middleware.OpencensusMiddleware()
+            middleware_obj = middleware.OpencensusMiddleware(get_response)
 
         middleware_obj.process_request(django_request)
         tracer = middleware._get_current_tracer()
@@ -259,7 +264,7 @@ class TestOpencensusMiddleware(unittest.TestCase):
             settings)
 
         with patch_settings:
-            middleware_obj = middleware.OpencensusMiddleware()
+            middleware_obj = middleware.OpencensusMiddleware(get_response)
 
         middleware_obj.process_request(django_request)
         tracer = middleware._get_current_tracer()
@@ -316,7 +321,7 @@ class TestOpencensusMiddleware(unittest.TestCase):
             settings)
 
         with patch_settings:
-            middleware_obj = middleware.OpencensusMiddleware()
+            middleware_obj = middleware.OpencensusMiddleware(get_response)
 
         tb = None
         try:


### PR DESCRIPTION
This PR fixes the support for Django 4.1 according to this bug report: https://github.com/census-instrumentation/opencensus-python/issues/1154

The issue was a missing call to __init__ of the super class, which worked fine before, but broke as of this change in Django: https://github.com/django/django/pull/15216