### PR TITLE
Updated translate_to_datadog function to include a null check for attributes

### DIFF
--- a/contrib/opencensus-ext-datadog/opencensus/ext/datadog/traces.py
+++ b/contrib/opencensus-ext-datadog/opencensus/ext/datadog/traces.py
@@ -201,9 +201,10 @@ class DatadogTraceExporter(base_exporter.Exporter):
             if span.get("status").get("message") is not None:
                 meta["opencensus.status_description"] = span.get("status").get(
                     "message")
-
-            atts = span.get("attributes").get("attributeMap")
-            atts_to_metadata(atts, meta=meta)
+            
+            if span.get("attributes") is not None:
+                atts = span.get("attributes").get("attributeMap")
+                atts_to_metadata(atts, meta=meta)
 
             dd_span["meta"] = meta
             dd_trace.append(dd_span)


### PR DESCRIPTION
Was using this library to instrument our code and noticed that if you pass no attributes to the span (attributes is an optional arg) it will try to get them and throw an error.

Added a null check to remove this behaviour. 