### PR TITLE
Enhance httpx tracing

### DIFF
--- a/contrib/opencensus-ext-httpx/opencensus/ext/httpx/trace.py
+++ b/contrib/opencensus-ext-httpx/opencensus/ext/httpx/trace.py
@@ -41,7 +41,7 @@ def trace_integration(tracer=None):
         execution_context.set_opencensus_tracer(tracer)
 
     wrapt.wrap_function_wrapper(
-        MODULE_NAME, "Client.request", wrap_client_request
+        MODULE_NAME, "Client.send", wrap_client_request
     )
     # pylint: disable=protected-access
     integrations.add_integration(integrations._Integrations.HTTPX)

--- a/contrib/opencensus-ext-httpx/tests/test_httpx_trace.py
+++ b/contrib/opencensus-ext-httpx/tests/test_httpx_trace.py
@@ -37,7 +37,7 @@ class Test_httpx_trace(unittest.TestCase):
                 noop_tracer.NoopTracer,
             )
             mock_wrap.assert_called_once_with(
-                trace.MODULE_NAME, "Client.request", trace.wrap_client_request
+                trace.MODULE_NAME, "Client.send", trace.wrap_client_request
             )
 
     def test_trace_integration_set_tracer(self):
@@ -54,7 +54,7 @@ class Test_httpx_trace(unittest.TestCase):
                 execution_context.get_opencensus_tracer(), TmpTracer
             )
             mock_wrap.assert_called_once_with(
-                trace.MODULE_NAME, "Client.request", trace.wrap_client_request
+                trace.MODULE_NAME, "Client.send", trace.wrap_client_request
             )
 
     def test_wrap_client_request(self):
@@ -81,7 +81,7 @@ class Test_httpx_trace(unittest.TestCase):
 
         with patch, patch_thread:
             trace.wrap_client_request(
-                wrapped, "Client.request", (request_method, url), kwargs
+                wrapped, "Client.send", (request_method, url), kwargs
             )
 
         expected_attributes = {
@@ -137,7 +137,7 @@ class Test_httpx_trace(unittest.TestCase):
 
         with patch_tracer, patch_attr, patch_thread:
             trace.wrap_client_request(
-                wrapped, "Client.request", (request_method, url), {}
+                wrapped, "Client.send", (request_method, url), {}
             )
 
         expected_name = "/"
@@ -170,7 +170,7 @@ class Test_httpx_trace(unittest.TestCase):
 
         with patch_tracer, patch_attr, patch_thread:
             trace.wrap_client_request(
-                wrapped, "Client.request", (request_method, url), {}
+                wrapped, "Client.send", (request_method, url), {}
             )
 
         self.assertEqual(None, mock_tracer.current_span)
@@ -202,7 +202,7 @@ class Test_httpx_trace(unittest.TestCase):
 
         with patch_tracer, patch_attr, patch_thread:
             trace.wrap_client_request(
-                wrapped, "Client.request", (request_method, url), {}
+                wrapped, "Client.send", (request_method, url), {}
             )
 
         self.assertEqual(None, mock_tracer.current_span)
@@ -230,7 +230,7 @@ class Test_httpx_trace(unittest.TestCase):
 
         with patch, patch_thread:
             trace.wrap_client_request(
-                wrapped, "Client.request", (request_method, url), kwargs
+                wrapped, "Client.send", (request_method, url), kwargs
             )
 
         self.assertEqual(kwargs["headers"]["x-trace"], "some-value")
@@ -258,7 +258,7 @@ class Test_httpx_trace(unittest.TestCase):
 
         with patch, patch_thread:
             trace.wrap_client_request(
-                wrapped, "Client.request", (request_method, url), kwargs
+                wrapped, "Client.send", (request_method, url), kwargs
             )
 
         self.assertEqual(kwargs["headers"]["key"], "value")
@@ -288,7 +288,7 @@ class Test_httpx_trace(unittest.TestCase):
 
         with patch, patch_thread:
             trace.wrap_client_request(
-                wrapped, "Client.request", (request_method, url), kwargs
+                wrapped, "Client.send", (request_method, url), kwargs
             )
 
         self.assertEqual(kwargs["headers"]["x-trace"], "some-value")
@@ -320,7 +320,7 @@ class Test_httpx_trace(unittest.TestCase):
             with self.assertRaises(httpx.TimeoutException):
                 # breakpoint()
                 trace.wrap_client_request(
-                    wrapped, "Client.request", (request_method, url), kwargs
+                    wrapped, "Client.send", (request_method, url), kwargs
                 )
 
         expected_attributes = {
@@ -371,7 +371,7 @@ class Test_httpx_trace(unittest.TestCase):
         with patch, patch_thread:
             with self.assertRaises(httpx.InvalidURL):
                 trace.wrap_client_request(
-                    wrapped, "Client.request", (request_method, url), kwargs
+                    wrapped, "Client.send", (request_method, url), kwargs
                 )
 
         expected_attributes = {
@@ -422,7 +422,7 @@ class Test_httpx_trace(unittest.TestCase):
         with patch, patch_thread:
             with self.assertRaises(httpx.TooManyRedirects):
                 trace.wrap_client_request(
-                    wrapped, "Client.request", (request_method, url), kwargs
+                    wrapped, "Client.send", (request_method, url), kwargs
                 )
 
         expected_attributes = {


### PR DESCRIPTION
In httpx `Advanced Usage` docs there is a [chapter `Request Instances`](https://www.python-httpx.org/advanced/#request-instances) where they show alternative way of sending requests, where you can use once initialized client to send various of different requests to the same host. 

Current implementation of tracing doesn't cover that use case, because calling structure is different while function `Client.send` is actually what is common and it returns `Response` object. 

In a nutshell:
```python 
class Client:
    ...
    def request(...) -> Response:
        ...
        request = self.build_request(...)
        return self.send(request)
```
so when I have something like this:
```python
req_1 = httpx.Request(...)
req_2 = httpx.Request(...)

with httpx.Client() as client:
    client.send(req_1)
    client.send(req_2)
```
It's not traced.

This is a use case that I have in my project and I would love to have that requests traced.
