### PR TITLE
Adds str fallback to envelope serialization

### DIFF
--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/transport.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/transport.py
@@ -113,7 +113,7 @@ class TransportMixin(object):
             endpoint += '/v2.1/track'
             response = requests.post(
                 url=endpoint,
-                data=json.dumps(envelopes),
+                data=json.dumps(envelopes, default=str),
                 headers=headers,
                 timeout=self.options.timeout,
                 proxies=json.loads(self.options.proxies),


### PR DESCRIPTION
When serialization fails (e.g. when a non-JSON-serializable value is added to the properties) the entire batch that envelope belongs to does not get sent. Falling back to to str as a means of serialization when JSON serialization fails seems like a sane default that greatly reduces the risk of missed telemetry.