### PR TITLE
Removed vulnerable versions of flask and requests

### DIFF
--- a/contrib/opencensus-ext-flask/setup.py
+++ b/contrib/opencensus-ext-flask/setup.py
@@ -49,7 +49,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'flask >= 0.12.3, < 3.0.0, != 1.1.3',
+        'flask >= 0.12.3, < 3.0.0, != 1.1.3, != 2.2.3, != 2.2.4',
         'opencensus >= 0.12.dev0, < 1.0.0',
     ],
     extras_require={},

--- a/contrib/opencensus-ext-requests/setup.py
+++ b/contrib/opencensus-ext-requests/setup.py
@@ -49,7 +49,7 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     install_requires=[
-        'opencensus >= 0.12.dev0, < 1.0.0',
+        'opencensus >= 0.12.dev0, < 1.0.0, != 2.28.2, != 2.29.0, != 2.30.0',
         'requests >= 2.19.0, < 3.0.0',
         'wrapt >= 1.0.0, < 2.0.0',
     ],


### PR DESCRIPTION
Flask 2.2.3-2.24:
Due to a caching vulnerability, data intended for one client can accidentally be sent to other clients

Requests 2.28.2-2.30.0:
Under certain circumstances, Proxy-Authorization header can be sent to an unintended destination during a redirect.