### PR TITLE
Don't create temp folder if local storage disabled

### DIFF
--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/__init__.py
@@ -66,7 +66,7 @@ def process_options(options):
         )
 
     # storage path
-    if options.storage_path is None:
+    if options.enable_local_storage and options.storage_path is None:
         TEMPDIR_SUFFIX = options.instrumentation_key or ""
         options.storage_path = os.path.join(
                 tempfile.gettempdir(),

--- a/contrib/opencensus-ext-azure/tests/test_options.py
+++ b/contrib/opencensus-ext-azure/tests/test_options.py
@@ -14,6 +14,7 @@
 
 import os
 import unittest
+from unittest.mock import patch
 
 from opencensus.ext.azure import common
 
@@ -107,6 +108,22 @@ class TestOptions(unittest.TestCase):
             options.proxies,
             '{"https": "https://test-proxy.com"}'
         )
+
+    @patch("opencensus.ext.azure.common.tempfile")
+    def test_process_options_enable_local_storage(self, mock_tempfile):
+        options = common.Options()
+
+        self.assertTrue(options.enable_local_storage)
+        self.assertIsNotNone(options.storage_path)
+        mock_tempfile.gettempdir.assert_called_once()
+
+    @patch("opencensus.ext.azure.common.tempfile")
+    def test_process_options_disable_local_storage(self, mock_tempfile):
+        options = common.Options(enable_local_storage = False)
+
+        self.assertFalse(options.enable_local_storage, False)
+        self.assertIsNone(options.storage_path)
+        mock_tempfile.gettempdir.assert_not_called()
 
     def test_parse_connection_string_none(self):
         cs = None


### PR DESCRIPTION
Fixes #1208

If local storage is disabled, Don't create temp storage directory.