### PR TITLE
[Bug fix] Allow redirects for proxy

### DIFF
--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/transport.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/transport.py
@@ -116,7 +116,7 @@ class TransportMixin(object):
 
             response = requests.post(
                 url=endpoint,
-                data=json.dumps(envelopes),
+                data=json.dumps(envelopes, default=str),
                 headers=headers,
                 timeout=self.options.timeout,
                 proxies=proxies,

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/transport.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/transport.py
@@ -111,13 +111,16 @@ class TransportMixin(object):
                 token = self.options.credential.get_token(_MONITOR_OAUTH_SCOPE)
                 headers["Authorization"] = "Bearer {}".format(token.token)
             endpoint += '/v2.1/track'
+            proxies=json.loads(self.options.proxies)
+            allow_redirects=len(proxies) != 0
+
             response = requests.post(
                 url=endpoint,
-                data=json.dumps(envelopes, default=str),
+                data=json.dumps(envelopes),
                 headers=headers,
                 timeout=self.options.timeout,
-                proxies=json.loads(self.options.proxies),
-                allow_redirects=False,
+                proxies=proxies,
+                allow_redirects=allow_redirects,
             )
         except requests.Timeout as ex:
             if not self._is_stats_exporter():

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/transport.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/transport.py
@@ -111,8 +111,8 @@ class TransportMixin(object):
                 token = self.options.credential.get_token(_MONITOR_OAUTH_SCOPE)
                 headers["Authorization"] = "Bearer {}".format(token.token)
             endpoint += '/v2.1/track'
-            proxies=json.loads(self.options.proxies)
-            allow_redirects=len(proxies) != 0
+            proxies = json.loads(self.options.proxies)
+            allow_redirects = len(proxies) != 0
 
             response = requests.post(
                 url=endpoint,


### PR DESCRIPTION
In the current implementation, proxies are offered but not usable. 
In case requests library has proxy options set, allow_redirect needs to be set to true.