### PR TITLE
fix typename data drop

### DIFF
--- a/contrib/opencensus-ext-azure/CHANGELOG.md
+++ b/contrib/opencensus-ext-azure/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fix missing/None fields in `ExceptionDetails`
 ([#1232](https://github.com/census-instrumentation/opencensus-python/pull/1232))
+- Fix missing/None typeName field in `ExceptionDetails`
+([#1234](https://github.com/census-instrumentation/opencensus-python/pull/1234))
 
 ## 1.1.11
 

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/trace_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/trace_exporter/__init__.py
@@ -102,13 +102,14 @@ class AzureExporter(BaseExporter, TransportMixin, ProcessorMixin):
                 stack_trace = sd.attributes.get(STACKTRACE, [])
                 if not hasattr(stack_trace, '__iter__'):
                     stack_trace = []
+                type_name = sd.attributes.get(ERROR_NAME, 'Exception')
                 exc_env = Envelope(**envelope)
                 exc_env.name = 'Microsoft.ApplicationInsights.Exception'
                 data = ExceptionData(
                     exceptions=[{
                         'id': 1,
                         'outerId': 0,
-                        'typeName': sd.attributes.get(ERROR_NAME, ''),
+                        'typeName': type_name,
                         'message': message,
                         'hasFullStack': STACKTRACE in sd.attributes,
                         'parsedStack': stack_trace


### PR DESCRIPTION
When using FastAPI's HTTPException, ERROR_NAME cannot be pulled from the exception by the trace exporter. Defaulting to 'Exception'.