### PR TITLE
Release opencensus-ext-azure 1.1.12

### DIFF
--- a/contrib/opencensus-ext-azure/CHANGELOG.md
+++ b/contrib/opencensus-ext-azure/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.1.12
+
 - Fix missing/None fields in `ExceptionDetails`
 ([#1232](https://github.com/census-instrumentation/opencensus-python/pull/1232))
 - Fix missing/None typeName field in `ExceptionDetails`

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/version.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '1.2.dev0'
+__version__ = '1.1.12'

--- a/contrib/opencensus-ext-azure/setup.py
+++ b/contrib/opencensus-ext-azure/setup.py
@@ -43,7 +43,7 @@ setup(
     install_requires=[
         'azure-core >= 1.12.0, < 2.0.0',
         'azure-identity >= 1.5.0, < 2.0.0',
-        'opencensus >= 0.12.dev0, < 1.0.0',
+        'opencensus >= 0.11.3, < 1.0.0',
         'psutil >= 5.6.3',
         'requests >= 2.19.0',
     ],

--- a/opencensus/common/version/__init__.py
+++ b/opencensus/common/version/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.12.dev0'
+__version__ = '0.11.3'


### PR DESCRIPTION
- Fix missing/None fields in `ExceptionDetails`
([#1232](https://github.com/census-instrumentation/opencensus-python/pull/1232))
- Fix missing/None typeName field in `ExceptionDetails`
([#1234](https://github.com/census-instrumentation/opencensus-python/pull/1234))