### PR TITLE
Use non-deprecated assertion methods

### DIFF
--- a/contrib/opencensus-ext-prometheus/tests/test_prometheus_stats.py
+++ b/contrib/opencensus-ext-prometheus/tests/test_prometheus_stats.py
@@ -229,7 +229,7 @@ class TestCollectorPrometheus(unittest.TestCase):
         collector.register_view(view)
         desc = collector.registered_views[list(REGISTERED_VIEW)[0]]
 
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError,
                 'unsupported aggregation type <class \'mock.mock.Mock\'>'):
             collector.to_metric(desc=desc, tag_values=[None], agg_data=agg)
@@ -278,8 +278,8 @@ class TestCollectorPrometheus(unittest.TestCase):
 
 class TestPrometheusStatsExporter(unittest.TestCase):
     def test_exporter_constructor_no_namespace(self):
-        with self.assertRaisesRegexp(ValueError,
-                                     'Namespace can not be empty string.'):
+        with self.assertRaisesRegex(ValueError,
+                                    'Namespace can not be empty string.'):
             prometheus.new_stats_exporter(prometheus.Options())
 
     def test_emit(self):

--- a/tests/unit/common/monitored_resource_util/test_monitored_resource.py
+++ b/tests/unit/common/monitored_resource_util/test_monitored_resource.py
@@ -102,9 +102,11 @@ class TestMonitoredResource(unittest.TestCase):
             with mock_gce_env():
                 resource = monitored_resource.get_instance()
         self.assertEqual(resource.get_type(), 'mock_resource_type')
-        self.assertDictContainsSubset(
-            {'mock_label_key': 'mock_label_value'}, resource.get_labels())
-        self.assertDictContainsSubset(mocked_labels, resource.get_labels())
+        self.assertGreaterEqual(
+            resource.get_labels().items(),
+            {'mock_label_key': 'mock_label_value'}.items())
+        self.assertGreaterEqual(
+            resource.get_labels().items(), mocked_labels.items())
 
     @mock.patch('opencensus.common.monitored_resource.monitored_resource'
                 '.gcp_metadata_config.GcpMetadataConfig')
@@ -130,16 +132,19 @@ class TestMonitoredResource(unittest.TestCase):
 
         gcp_md_mock.get_attribute.assert_called_once_with(cluster_name_key)
         self.assertEqual(r1.get_type(), 'k8s_container')
-        self.assertDictContainsSubset(mocked_labels, r1.get_labels())
+        self.assertGreaterEqual(
+            r1.get_labels().items(), mocked_labels.items())
 
         with mock_oc_env():
             with mock_k8s_env():
                 r2 = monitored_resource.get_instance()
 
         self.assertEqual(r1.get_type(), 'k8s_container')
-        self.assertDictContainsSubset(mocked_labels, r1.get_labels())
-        self.assertDictContainsSubset(
-            {'mock_label_key': 'mock_label_value'}, r2.get_labels())
+        self.assertGreaterEqual(
+            r1.get_labels().items(), mocked_labels.items())
+        self.assertGreaterEqual(
+            r2.get_labels().items(),
+            {'mock_label_key': 'mock_label_value'}.items())
 
     @mock.patch('opencensus.common.monitored_resource.monitored_resource'
                 '.aws_identity_doc_utils.AwsIdentityDocumentUtils')
@@ -163,9 +168,11 @@ class TestMonitoredResource(unittest.TestCase):
             with mock_aws_env():
                 resource = monitored_resource.get_instance()
         self.assertEqual(resource.get_type(), 'mock_resource_type')
-        self.assertDictContainsSubset(
-            {'mock_label_key': 'mock_label_value'}, resource.get_labels())
-        self.assertDictContainsSubset(mocked_labels, resource.get_labels())
+        self.assertGreaterEqual(
+            resource.get_labels().items(),
+            {'mock_label_key': 'mock_label_value'}.items())
+        self.assertGreaterEqual(
+            resource.get_labels().items(), mocked_labels.items())
 
     def test_k8s_environment(self):
         patch = mock.patch.dict(os.environ,

--- a/tests/unit/stats/test_aggregation_data.py
+++ b/tests/unit/stats/test_aggregation_data.py
@@ -295,15 +295,15 @@ class TestDistributionAggregationData(unittest.TestCase):
     def test_exemplar_null_attachments(self):
         timestamp = time.time()
 
-        with self.assertRaisesRegexp(TypeError,
-                                     'attachments should not be empty'):
+        with self.assertRaisesRegex(TypeError,
+                                    'attachments should not be empty'):
             aggregation_data_module.Exemplar(6, timestamp, None)
 
     def test_exemplar_null_attachment_key(self):
         timestamp = time.time()
         attachment = {None: "one", "Two": "two"}
 
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 TypeError,
                 'attachment key should not be empty and should be a string'):
             aggregation_data_module.Exemplar(6, timestamp, attachment)
@@ -312,7 +312,7 @@ class TestDistributionAggregationData(unittest.TestCase):
         timestamp = time.time()
         attachment = {"One": "one", "Two": None}
 
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 TypeError,
                 'attachment value should not be empty and should be a string'):
             aggregation_data_module.Exemplar(6, timestamp, attachment)
@@ -321,7 +321,7 @@ class TestDistributionAggregationData(unittest.TestCase):
         timestamp = time.time()
         attachment = {1: "one", "Two": "two"}
 
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 TypeError,
                 'attachment key should not be empty and should be a string'):
             aggregation_data_module.Exemplar(6, timestamp, attachment)
@@ -330,7 +330,7 @@ class TestDistributionAggregationData(unittest.TestCase):
         timestamp = time.time()
         attachment = {"One": "one", "Two": 2}
 
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 TypeError,
                 'attachment value should not be empty and should be a string'):
             aggregation_data_module.Exemplar(6, timestamp, attachment)

--- a/tests/unit/stats/test_measurement_map.py
+++ b/tests/unit/stats/test_measurement_map.py
@@ -58,7 +58,7 @@ class TestMeasurementMap(unittest.TestCase):
         test_value = 'testValue'
         measurement_map = measurement_map_module.MeasurementMap(
             measure_to_view_map=measure_to_view_map, attachments={})
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 TypeError,
                 'attachment key should not be empty and should be a string'):
             measurement_map.measure_put_attachment(test_key, test_value)
@@ -69,7 +69,7 @@ class TestMeasurementMap(unittest.TestCase):
         test_value = None
         measurement_map = measurement_map_module.MeasurementMap(
             measure_to_view_map=measure_to_view_map, attachments={})
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 TypeError,
                 'attachment value should not be empty and should be a string'):
             measurement_map.measure_put_attachment(test_key, test_value)
@@ -80,7 +80,7 @@ class TestMeasurementMap(unittest.TestCase):
         test_value = 'testValue'
         measurement_map = measurement_map_module.MeasurementMap(
             measure_to_view_map=measure_to_view_map, attachments={})
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 TypeError,
                 'attachment key should not be empty and should be a string'):
             measurement_map.measure_put_attachment(test_key, test_value)
@@ -91,7 +91,7 @@ class TestMeasurementMap(unittest.TestCase):
         test_value = 42
         measurement_map = measurement_map_module.MeasurementMap(
             measure_to_view_map=measure_to_view_map, attachments={})
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 TypeError,
                 'attachment value should not be empty and should be a string'):
             measurement_map.measure_put_attachment(test_key, test_value)


### PR DESCRIPTION
Both assertDictContainsSubset and assertRaisesRegexp have been deprecated, and removed in Python 3.12. Use assertGreaterEqual on the dictionary items to compare dictionaries instead of assertDictContainsSubset.

Fixes #1242