### PR TITLE
Remove custom createLock method in BaseLogHandler

### DIFF
--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/log_exporter/__init__.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/log_exporter/__init__.py
@@ -102,9 +102,6 @@ class BaseLogHandler(logging.Handler):
             self._worker.stop(timeout)
         super(BaseLogHandler, self).close()
 
-    def createLock(self):
-        self.lock = None
-
     def emit(self, record):
         self._queue.put(record, block=False)
 


### PR DESCRIPTION
This patch removes the override of createLock method so this class will use the default logging.Handler method.

The tests are failing for python 3.13 because in this version there's a direct usage of self.lock instead of calling self.acquire(): https://github.com/python/cpython/blob/3.13/Lib/logging/__init__.py#L1025-L1026