### PR TITLE
replace use of utcnow() with now(UTC)

### DIFF
--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/common/storage.py
@@ -14,7 +14,7 @@ def _fmt(timestamp):
 
 
 def _now():
-    return datetime.datetime.utcnow()
+    return datetime.datetime.now(datetime.UTC)
 
 
 def _seconds(seconds):

--- a/contrib/opencensus-ext-azure/opencensus/ext/azure/statsbeat/statsbeat_metrics.py
+++ b/contrib/opencensus-ext-azure/opencensus/ext/azure/statsbeat/statsbeat_metrics.py
@@ -378,7 +378,7 @@ class _StatsbeatMetrics:
                     metric.create_time_series(properties, fn, exc_type=exc_type)  # noqa: E501
                     properties.pop()
 
-            stats_metric = metric.get_metric(datetime.datetime.utcnow())
+            stats_metric = metric.get_metric(datetime.datetime.now(datetime.UTC))
             # metric will be None if status_code or exc_type is invalid
             # for success count, this will never be None
             if stats_metric is not None:
@@ -394,7 +394,7 @@ class _StatsbeatMetrics:
         properties.insert(4, LabelValue(self._feature))  # feature long
         properties.insert(4, LabelValue(_FEATURE_TYPES.FEATURE))  # type
         self._feature_metric.get_or_create_time_series(properties)
-        return self._feature_metric.get_metric(datetime.datetime.utcnow())
+        return self._feature_metric.get_metric(datetime.datetime.now(datetime.UTC))
 
     def _get_instrumentation_metric(self):
         integrations = get_integrations()
@@ -405,7 +405,7 @@ class _StatsbeatMetrics:
         properties.insert(4, LabelValue(get_integrations()))  # instr long
         properties.insert(4, LabelValue(_FEATURE_TYPES.INSTRUMENTATION))  # type  # noqa: E501
         self._instrumentation_metric.get_or_create_time_series(properties)
-        return self._instrumentation_metric.get_metric(datetime.datetime.utcnow())  # noqa: E501
+        return self._instrumentation_metric.get_metric(datetime.datetime.now(datetime.UTC))  # noqa: E501
 
     def _get_attach_metric(self):
         properties = []
@@ -439,7 +439,7 @@ class _StatsbeatMetrics:
         properties.extend(self._get_common_properties())
         properties.insert(1, LabelValue(rpId))  # rpid
         self._attach_metric.get_or_create_time_series(properties)
-        return self._attach_metric.get_metric(datetime.datetime.utcnow())
+        return self._attach_metric.get_metric(datetime.datetime.now(datetime.UTC))
 
     def _get_common_properties(self):
         properties = []

--- a/contrib/opencensus-ext-grpc/opencensus/ext/grpc/utils.py
+++ b/contrib/opencensus-ext-grpc/opencensus/ext/grpc/utils.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from grpc.framework.foundation import future
 from grpc.framework.interfaces.face import face
@@ -23,7 +23,7 @@ def add_message_event(proto_message, span, message_event_type, message_id=1):
     """
     span.add_message_event(
         time_event.MessageEvent(
-            datetime.utcnow(),
+            datetime.datetime.now(UTC),
             message_id,
             type=message_event_type,
             uncompressed_size_bytes=extract_byte_size(proto_message),

--- a/contrib/opencensus-ext-ocagent/opencensus/ext/ocagent/utils/__init__.py
+++ b/contrib/opencensus-ext-ocagent/opencensus/ext/ocagent/utils/__init__.py
@@ -23,7 +23,7 @@ def get_node(service_name, host_name):
             else host_name,
             pid=os.getpid(),
             start_timestamp=proto_ts_from_datetime(
-                datetime.datetime.utcnow())),
+                datetime.datetime.now(datetime.UTC))),
         library_info=common_pb2.LibraryInfo(
             language=common_pb2.LibraryInfo.Language.Value('PYTHON'),
             exporter_version=EXPORTER_VERSION,

--- a/contrib/opencensus-ext-ocagent/tests/test_ocagent_utils.py
+++ b/contrib/opencensus-ext-ocagent/tests/test_ocagent_utils.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import unittest
-from datetime import datetime
+from datetime import UTC, datetime
 
 from opencensus.common import utils as common_utils
 from opencensus.ext.ocagent import utils
@@ -21,7 +21,7 @@ from opencensus.ext.ocagent import utils
 
 class TestUtils(unittest.TestCase):
     def test_datetime_str_to_proto_ts_conversion(self):
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         delta = now - datetime(1970, 1, 1)
         expected_seconds = int(delta.total_seconds())
         expected_nanos = delta.microseconds * 1000
@@ -52,7 +52,7 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(proto_ts.nanos, 0)
 
     def test_datetime_to_proto_ts_conversion(self):
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         delta = now - datetime(1970, 1, 1)
         expected_seconds = int(delta.total_seconds())
         expected_nanos = delta.microseconds * 1000

--- a/contrib/opencensus-ext-ocagent/tests/test_trace_exporter_utils.py
+++ b/contrib/opencensus-ext-ocagent/tests/test_trace_exporter_utils.py
@@ -14,7 +14,7 @@
 
 import codecs
 import unittest
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from opencensus.ext.ocagent.trace_exporter import utils
 from opencensus.proto.trace.v1 import trace_pb2
@@ -263,11 +263,11 @@ class TestTraceExporterUtils(unittest.TestCase):
 
     def test_translate_time_events(self):
 
-        annotation0_ts = datetime.utcnow() + timedelta(seconds=-10)
-        annotation1_ts = datetime.utcnow() + timedelta(seconds=-9)
-        message0_ts = datetime.utcnow() + timedelta(seconds=-8)
-        message1_ts = datetime.utcnow() + timedelta(seconds=-7)
-        message2_ts = datetime.utcnow() + timedelta(seconds=-6)
+        annotation0_ts = datetime.now(UTC) + timedelta(seconds=-10)
+        annotation1_ts = datetime.now(UTC) + timedelta(seconds=-9)
+        message0_ts = datetime.now(UTC) + timedelta(seconds=-8)
+        message1_ts = datetime.now(UTC) + timedelta(seconds=-7)
+        message2_ts = datetime.now(UTC) + timedelta(seconds=-6)
 
         span_data = span_data_module.SpanData(
             context=span_context_module.SpanContext(
@@ -374,7 +374,7 @@ class TestTraceExporterUtils(unittest.TestCase):
 
     def test_translate_annotation(self):
 
-        ts = datetime.utcnow() + timedelta(seconds=-10)
+        ts = datetime.now(UTC) + timedelta(seconds=-10)
 
         annotation = time_event_module.Annotation(
             timestamp=ts,
@@ -403,7 +403,7 @@ class TestTraceExporterUtils(unittest.TestCase):
 
     def test_translate_message_event(self):
 
-        ts = datetime.utcnow() + timedelta(seconds=-10)
+        ts = datetime.now(UTC) + timedelta(seconds=-10)
 
         message_event = time_event_module.MessageEvent(
             timestamp=ts,
@@ -501,7 +501,7 @@ class TestTraceExporterUtils(unittest.TestCase):
         pb_event = pb_span.time_events.time_event.add()
 
         message_event = time_event_module.MessageEvent(
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(UTC),
             id=0,
             type=time_event_module.Type.SENT,
             uncompressed_size_bytes=10,
@@ -519,7 +519,7 @@ class TestTraceExporterUtils(unittest.TestCase):
         pb_event = pb_span.time_events.time_event.add()
 
         annotation = time_event_module.Annotation(
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(UTC),
             description="hi there",
             attributes=attributes_module.Attributes(
                 attributes={
@@ -554,10 +554,10 @@ class TestTraceExporterUtils(unittest.TestCase):
         pb_event1 = pb_span.time_events.time_event.add()
 
         annotation0 = time_event_module.Annotation(
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(UTC),
             description="hi there0")
         annotation1 = time_event_module.Annotation(
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(UTC),
             description="hi there1",
             attributes=attributes_module.Attributes())
 

--- a/contrib/opencensus-ext-prometheus/tests/test_prometheus_stats.py
+++ b/contrib/opencensus-ext-prometheus/tests/test_prometheus_stats.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import unittest
-from datetime import datetime
+from datetime import UTC, datetime
 
 import mock
 from prometheus_client.core import Sample
@@ -115,8 +115,8 @@ class TestCollectorPrometheus(unittest.TestCase):
 
     def test_collector_add_view_data(self):
         registry = mock.Mock()
-        start_time = datetime.utcnow()
-        end_time = datetime.utcnow()
+        start_time = datetime.now(UTC)
+        end_time = datetime.now(UTC)
         view_data = view_data_module.ViewData(
             view=VIDEO_SIZE_VIEW, start_time=start_time, end_time=end_time)
         options = prometheus.Options("test1", 8001, "localhost", registry)

--- a/opencensus/common/utils/__init__.py
+++ b/opencensus/common/utils/__init__.py
@@ -72,7 +72,7 @@ def check_str_length(str_to_check, limit=MAX_LENGTH):
 def to_iso_str(ts=None):
     """Get an ISO 8601 string for a UTC datetime."""
     if ts is None:
-        ts = datetime.datetime.utcnow()
+        ts = datetime.datetime.now(datetime.UTC)
     return ts.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
 

--- a/opencensus/metrics/export/gauge.py
+++ b/opencensus/metrics/export/gauge.py
@@ -16,7 +16,7 @@ import six
 
 import threading
 from collections import OrderedDict
-from datetime import datetime
+from datetime import UTC, datetime
 
 from opencensus.common import utils
 from opencensus.metrics.export import (
@@ -506,7 +506,7 @@ class Registry(metric_producer.MetricProducer):
         :rtype: set(:class:`opencensus.metrics.export.metric.Metric`)
         :return: A set of `Metric`s, one for each registered gauge.
         """
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         metrics = set()
         for gauge in self.gauges.values():
             metrics.add(gauge.get_metric(now))

--- a/opencensus/stats/stats.py
+++ b/opencensus/stats/stats.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 from opencensus.metrics.export.metric_producer import MetricProducer
 from opencensus.stats.stats_recorder import StatsRecorder
@@ -37,7 +37,7 @@ class _Stats(MetricProducer):
         :rtype: Iterator[:class: `opencensus.metrics.export.metric.Metric`]
         """
         return self.view_manager.measure_to_view_map.get_metrics(
-            datetime.utcnow())
+            datetime.now(UTC))
 
 
 stats = _Stats()

--- a/opencensus/trace/span.py
+++ b/opencensus/trace/span.py
@@ -21,7 +21,7 @@ except ImportError:
 
 import threading
 from collections import OrderedDict, deque
-from datetime import datetime
+from datetime import UTC, datetime
 from itertools import chain
 
 from opencensus.common import utils
@@ -323,7 +323,7 @@ class Span(base_span.BaseSpan):
         :param attrs: keyworded arguments e.g. failed=True, name='Caching'
         """
         self.annotations.append(time_event.Annotation(
-            datetime.utcnow(),
+            datetime.now(UTC),
             description,
             attributes_module.Attributes(attrs)
         ))

--- a/tests/unit/stats/test_view_data.py
+++ b/tests/unit/stats/test_view_data.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import unittest
-from datetime import datetime
+from datetime import UTC, datetime
 
 import mock
 
@@ -27,8 +27,8 @@ from opencensus.stats import view_data as view_data_module
 class TestViewData(unittest.TestCase):
     def test_constructor(self):
         view = mock.Mock()
-        start_time = datetime.utcnow()
-        end_time = datetime.utcnow()
+        start_time = datetime.now(UTC)
+        end_time = datetime.now(UTC)
         view_data = view_data_module.ViewData(
             view=view, start_time=start_time, end_time=end_time)
 
@@ -40,7 +40,7 @@ class TestViewData(unittest.TestCase):
     def test_start(self):
         view = mock.Mock()
         start_time = mock.Mock()
-        end_time = datetime.utcnow()
+        end_time = datetime.now(UTC)
         view_data = view_data_module.ViewData(
             view=view, start_time=start_time, end_time=end_time)
         view_data.start()
@@ -49,7 +49,7 @@ class TestViewData(unittest.TestCase):
 
     def test_end(self):
         view = mock.Mock()
-        start_time = datetime.utcnow()
+        start_time = datetime.now(UTC)
         end_time = mock.Mock()
         view_data = view_data_module.ViewData(
             view=view, start_time=start_time, end_time=end_time)
@@ -59,8 +59,8 @@ class TestViewData(unittest.TestCase):
 
     def test_get_tag_values(self):
         view = mock.Mock()
-        start_time = datetime.utcnow()
-        end_time = datetime.utcnow()
+        start_time = datetime.now(UTC)
+        end_time = datetime.now(UTC)
         view_data = view_data_module.ViewData(
             view=view, start_time=start_time, end_time=end_time)
 
@@ -78,8 +78,8 @@ class TestViewData(unittest.TestCase):
         view = mock.Mock()
         view.columns = ['key1']
         view.aggregation = mock.Mock()
-        start_time = datetime.utcnow()
-        end_time = datetime.utcnow()
+        start_time = datetime.now(UTC)
+        end_time = datetime.now(UTC)
         view_data = view_data_module.ViewData(
             view=view, start_time=start_time, end_time=end_time)
 
@@ -138,9 +138,9 @@ class TestViewData(unittest.TestCase):
             measure=measure,
             aggregation=distribution_aggregation)
 
-        start_time = datetime.utcnow()
+        start_time = datetime.now(UTC)
         attachments = {"One": "one", "Two": "two"}
-        end_time = datetime.utcnow()
+        end_time = datetime.now(UTC)
         view_data = view_data_module.ViewData(
             view=view, start_time=start_time, end_time=end_time)
         context = mock.Mock
@@ -187,9 +187,9 @@ class TestViewData(unittest.TestCase):
             measure=measure,
             aggregation=distribution_aggregation)
 
-        start_time = datetime.utcnow()
+        start_time = datetime.now(UTC)
         attachments = {"One": "one", "Two": "two"}
-        end_time = datetime.utcnow()
+        end_time = datetime.now(UTC)
         view_data = view_data_module.ViewData(
             view=view, start_time=start_time, end_time=end_time)
         context = mock.Mock
@@ -218,8 +218,8 @@ class TestViewData(unittest.TestCase):
         sum_aggregation = aggregation_module.SumAggregation()
         view = view_module.View("test_view", "description", ['key1', 'key2'],
                                 measure, sum_aggregation)
-        start_time = datetime.utcnow()
-        end_time = datetime.utcnow()
+        start_time = datetime.now(UTC)
+        end_time = datetime.now(UTC)
         view_data = view_data_module.ViewData(
             view=view, start_time=start_time, end_time=end_time)
         context = mock.Mock()
@@ -274,8 +274,8 @@ class TestViewData(unittest.TestCase):
         sum_aggregation = aggregation_module.SumAggregation()
         view = view_module.View("test_view", "description", ['key1', 'key2'],
                                 measure, sum_aggregation)
-        start_time = datetime.utcnow()
-        end_time = datetime.utcnow()
+        start_time = datetime.now(UTC)
+        end_time = datetime.now(UTC)
         view_data = view_data_module.ViewData(
             view=view, start_time=start_time, end_time=end_time)
         context = mock.Mock()
@@ -300,8 +300,8 @@ class TestViewData(unittest.TestCase):
         sum_aggregation = aggregation_module.SumAggregation()
         view = view_module.View("test_view", "description", ['key1', 'key2'],
                                 measure, sum_aggregation)
-        start_time = datetime.utcnow()
-        end_time = datetime.utcnow()
+        start_time = datetime.now(UTC)
+        end_time = datetime.now(UTC)
         view_data = view_data_module.ViewData(
             view=view, start_time=start_time, end_time=end_time)
         time = utils.to_iso_str()

--- a/tests/unit/trace/test_blank_span.py
+++ b/tests/unit/trace/test_blank_span.py
@@ -65,7 +65,7 @@ class TestBlankSpan(unittest.TestCase):
         span.set_status(status)
 
         message_event = mock.Mock()
-        message_event = MessageEvent(datetime.datetime.utcnow(), mock.Mock())
+        message_event = MessageEvent(datetime.datetime.now(datetime.UTC), mock.Mock())
         span.add_message_event(message_event)
 
         span_iter_list = list(iter(span))

--- a/tests/unit/trace/test_span.py
+++ b/tests/unit/trace/test_span.py
@@ -148,7 +148,7 @@ class TestSpan(unittest.TestCase):
         span = self._make_one(span_name)
         message_event = mock.Mock()
 
-        message_event = MessageEvent(datetime.datetime.utcnow(), mock.Mock())
+        message_event = MessageEvent(datetime.datetime.now(datetime.UTC), mock.Mock())
         span.add_message_event(message_event)
 
         self.assertEqual(len(span.message_events), 1)
@@ -382,10 +382,10 @@ class Test_format_span_json(unittest.TestCase):
         span.end_time = end_time
         span._child_spans = []
         mock_time = mock.Mock()
-        annotation = Annotation(datetime.datetime.utcnow(), mock.Mock())
+        annotation = Annotation(datetime.datetime.now(datetime.UTC), mock.Mock())
         annotation.timestamp = mock_time
         span.annotations = [annotation]
-        message_event = MessageEvent(datetime.datetime.utcnow(), mock.Mock())
+        message_event = MessageEvent(datetime.datetime.now(datetime.UTC), mock.Mock())
         message_event.timestamp = mock_time
         span.message_events = [message_event]
         span.stack_trace = StackTrace()

--- a/tests/unit/trace/test_time_event.py
+++ b/tests/unit/trace/test_time_event.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import unittest
-from datetime import datetime
+from datetime import UTC, datetime
 
 import mock
 
@@ -25,7 +25,7 @@ class TestAnnotation(unittest.TestCase):
         description = 'test description'
         attributes = mock.Mock()
 
-        ts = datetime.utcnow()
+        ts = datetime.now(UTC)
         annotation = time_event_module.Annotation(ts, description, attributes)
 
         self.assertEqual(annotation.description, description)
@@ -37,7 +37,7 @@ class TestAnnotation(unittest.TestCase):
         attributes = mock.Mock()
         attributes.format_attributes_json.return_value = attrs_json
 
-        ts = datetime.utcnow()
+        ts = datetime.now(UTC)
         annotation = time_event_module.Annotation(ts, description, attributes)
 
         annotation_json = annotation.format_annotation_json()
@@ -55,7 +55,7 @@ class TestAnnotation(unittest.TestCase):
     def test_format_annotation_json_without_attributes(self):
         description = 'test description'
 
-        ts = datetime.utcnow()
+        ts = datetime.now(UTC)
         annotation = time_event_module.Annotation(ts, description)
 
         annotation_json = annotation.format_annotation_json()
@@ -74,7 +74,7 @@ class TestMessageEvent(unittest.TestCase):
     def test_constructor_default(self):
         id = '1234'
 
-        ts = datetime.utcnow()
+        ts = datetime.now(UTC)
         message_event = time_event_module.MessageEvent(ts, id)
 
         self.assertEqual(message_event.id, id)
@@ -88,7 +88,7 @@ class TestMessageEvent(unittest.TestCase):
         type = time_event_module.Type.SENT
         uncompressed_size_bytes = '100'
 
-        ts = datetime.utcnow()
+        ts = datetime.now(UTC)
         message_event = time_event_module.MessageEvent(
             ts, id, type, uncompressed_size_bytes)
 
@@ -104,7 +104,7 @@ class TestMessageEvent(unittest.TestCase):
         type = time_event_module.Type.SENT
         uncompressed_size_bytes = '100'
 
-        ts = datetime.utcnow()
+        ts = datetime.now(UTC)
         message_event = time_event_module.MessageEvent(
             ts, id, type, uncompressed_size_bytes)
 
@@ -123,7 +123,7 @@ class TestMessageEvent(unittest.TestCase):
         id = '1234'
         type = time_event_module.Type.SENT
 
-        ts = datetime.utcnow()
+        ts = datetime.now(UTC)
         message_event = time_event_module.MessageEvent(ts, id, type)
 
         expected_message_event_json = {


### PR DESCRIPTION
using utcnow generates the following warning:

```
DeprecationWarning: datetime.datetime.utcnow() is deprecated and
scheduled for removal in a future version. Use timezone-aware objects to
represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    ts = datetime.datetime.utcnow()
```
